### PR TITLE
Snap against the size inside the padding, as the layout pass does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ everything around them is new.
 
 ### Fixed
 
+- Snapping (after a drag or fling, on tap, on `setSelection`, and after a
+  data set change) now measures against the size inside the view's padding,
+  the same size the layout pass uses. With padding set, `center` and `end`
+  snaps used to target a point shifted by the padding, so the snap target
+  could disagree with where the content is allowed to stop.
 - Drag distance is accumulated between layout passes and consumed by the pass
   that applies it. Two move events before one layout used to lose the first
   delta, and an extra layout pass during a drag (an image loading into a

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
@@ -758,7 +758,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         final boolean isSnapToPosition = mLayoutManagerAttributes.isSnapToPosition();
         if (!isSnapToPosition) return 0;
 
-        final int size = mScrollDirectionManager.getViewGroupSize(viewGroup);
+        final int size = getSizeInsidePadding(viewGroup);
 
         final View nearestView = getSnapDistanceToNearestView(size);
         if (nearestView == null) return 0;
@@ -786,7 +786,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         final int adapterCount = mAdapterViewManager.getAdapterCount();
         final int lastItemIndex = adapterCount - 1;
 
-        final int size = mScrollDirectionManager.getViewGroupSize(mViewGroup);
+        final int size = getSizeInsidePadding(mViewGroup);
         final View nearestViewToSnapPosition = getNearestViewToSnapPosition(size);
         final int positionOfNearestView = getPosition(nearestViewToSnapPosition);
 
@@ -857,7 +857,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
     }
 
     private void jumpToPosition(final AdapterViewHandler adapterViewHandler, final int position) {
-        final int size = mScrollDirectionManager.getViewGroupSize(mViewGroup);
+        final int size = getSizeInsidePadding(mViewGroup);
 
         final View nearestViewToSnapPosition = getNearestViewToSnapPosition(size);
         final int positionOfNearestView = getPosition(nearestViewToSnapPosition);
@@ -919,6 +919,11 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
 
     public int getViewGroupSize(final ViewGroup viewGroup) {
         return mScrollDirectionManager.getViewGroupSize(viewGroup);
+    }
+
+    public int getSizeInsidePadding(final ViewGroup viewGroup) {
+        final int size = mScrollDirectionManager.getViewGroupSize(viewGroup);
+        return size - getStartSizePadding() - getEndSizePadding();
     }
 
     public boolean isVerticalScroll() {

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerBridge.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerBridge.java
@@ -22,7 +22,7 @@ public class LayoutManagerBridge {
 
         if (!mLayoutManager.isSnapToPosition()) return 0;
 
-        final int size = mLayoutManager.getViewGroupSize(viewGroup);
+        final int size = mLayoutManager.getSizeInsidePadding(viewGroup);
         final int distance = mLayoutManager.getSnapToPixelDistance(size, view);
         return distance;
     }

--- a/library/src/test/java/mobi/parchment/widget/adapterview/ListLayoutManagerSnapPaddingTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/ListLayoutManagerSnapPaddingTest.java
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import androidx.test.core.app.ApplicationProvider;
+import java.util.ArrayList;
+import java.util.List;
+import mobi.parchment.widget.adapterview.listview.ListLayoutManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class ListLayoutManagerSnapPaddingTest {
+
+    private static final int VIEW_GROUP_SIZE = 300;
+    private static final int START_PADDING = 10;
+    private static final int END_PADDING = 30;
+    private static final int VIEW_SIZE = 100;
+    private static final int CELL_SPACING = 0;
+    private static final int ADAPTER_SIZE = 10;
+    private static final boolean NOT_CIRCULAR = false;
+    private static final boolean SNAP_TO_POSITION = true;
+    private static final boolean NOT_VIEW_PAGER = false;
+    private static final boolean NO_SELECT_ON_SNAP = false;
+    private static final boolean NO_SELECT_WHILE_SCROLLING = false;
+    private static final boolean HORIZONTAL = false;
+
+    private final MyViewGroup mViewGroup =
+            new MyViewGroup(ApplicationProvider.getApplicationContext());
+    private final AdapterViewManager mAdapterViewManager = new AdapterViewManager();
+    private final TestAdapter mTestAdapter = new TestAdapter();
+    private final Animation mAnimation = new Animation();
+    private ListLayoutManager mListLayoutManager;
+
+    private void setup(final SnapPosition snapPosition) {
+        final LayoutManagerAttributes attributes =
+                new LayoutManagerAttributes(
+                        NOT_CIRCULAR,
+                        SNAP_TO_POSITION,
+                        NOT_VIEW_PAGER,
+                        0,
+                        snapPosition,
+                        CELL_SPACING,
+                        NO_SELECT_ON_SNAP,
+                        NO_SELECT_WHILE_SCROLLING,
+                        HORIZONTAL);
+        mViewGroup.setPadding(START_PADDING, 0, END_PADDING, 0);
+        mListLayoutManager =
+                new ListLayoutManager(mViewGroup, null, mAdapterViewManager, attributes);
+        mAdapterViewManager.setAdapter(mTestAdapter);
+        mTestAdapter.setAdapterSize(ADAPTER_SIZE);
+
+        final int measureSpec =
+                View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
+        mViewGroup.measure(measureSpec, measureSpec);
+        mViewGroup.layout(0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+
+        mAnimation.newAnimation();
+        layout();
+    }
+
+    private void layout() {
+        mListLayoutManager.layout(mViewGroup, mAnimation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+    }
+
+    private void scrollBy(final int displacement) {
+        mAnimation.setDisplacement(displacement);
+        layout();
+    }
+
+    private View view(final int position) {
+        return mListLayoutManager.getViewForPosition(position);
+    }
+
+    @Test
+    public void firstLayout_centerSnapWithPadding_centersTheFirstCellInsideThePadding() {
+        setup(SnapPosition.center);
+
+        assertThat(view(0).getLeft()).isEqualTo(90);
+    }
+
+    @Test
+    public void snapTo_centerSnapWithPadding_targetsTheCellNearestThePaddedCenter() {
+        setup(SnapPosition.center);
+        scrollBy(-45);
+        assertThat(view(0).getLeft()).isEqualTo(45);
+        assertThat(view(1).getLeft()).isEqualTo(145);
+
+        assertThat(mListLayoutManager.snapTo(mViewGroup)).isEqualTo(45);
+    }
+
+    @Test
+    public void snapTo_endSnapWithPadding_targetsThePaddedEnd() {
+        setup(SnapPosition.end);
+        assertThat(view(0).getRight()).isEqualTo(270);
+        scrollBy(-30);
+
+        assertThat(mListLayoutManager.snapTo(mViewGroup)).isEqualTo(30);
+    }
+
+    @Test
+    public void onSingleTapUp_withPadding_snapsTheTappedViewToThePaddedCenter() {
+        setup(SnapPosition.center);
+        scrollBy(-45);
+        final LayoutManagerBridge bridge = new LayoutManagerBridge(mListLayoutManager);
+
+        assertThat(bridge.onSingleTapUp(mViewGroup, view(1))).isEqualTo(-55);
+    }
+
+    @Test
+    public void setSelected_withPadding_replacesTheCellNearestThePaddedSnapPosition() {
+        setup(SnapPosition.center);
+        scrollBy(-45);
+
+        mListLayoutManager.setSelected(5, mViewGroup);
+        scrollBy(0);
+
+        assertThat(view(5).getLeft()).isEqualTo(45);
+    }
+
+    @Test
+    public void dataSetChange_withPadding_keepsTheCellNearestThePaddedSnapPositionInPlace() {
+        setup(SnapPosition.center);
+        scrollBy(-45);
+
+        mTestAdapter.setAdapterSize(ADAPTER_SIZE);
+        scrollBy(0);
+
+        assertThat(view(0).getLeft()).isEqualTo(45);
+        assertThat(view(1).getLeft()).isEqualTo(145);
+    }
+
+    public static final class MyViewGroup extends LinearLayout implements AdapterViewHandler {
+        public final List<View> mViews = new ArrayList<View>();
+
+        public MyViewGroup(final Context context) {
+            super(context);
+        }
+
+        @Override
+        public boolean addViewInAdapterView(
+                final View view, final int index, final ViewGroup.LayoutParams layoutParams) {
+            mViews.add(index, view);
+            return true;
+        }
+
+        @Override
+        public void removeViewInAdapterView(final View view) {
+            mViews.remove(view);
+        }
+    }
+
+    public static final class TestAdapter extends BaseAdapter {
+        private int mAdapterSize;
+
+        public void setAdapterSize(final int adapterSize) {
+            mAdapterSize = adapterSize;
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public int getCount() {
+            return mAdapterSize;
+        }
+
+        @Override
+        public Object getItem(final int position) {
+            return position;
+        }
+
+        @Override
+        public long getItemId(final int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(final int position, final View convertView, final ViewGroup parent) {
+            final FrameLayout view = new FrameLayout(ApplicationProvider.getApplicationContext());
+            view.setTag(position);
+            view.setLayoutParams(
+                    new ViewGroup.LayoutParams(VIEW_SIZE, ViewGroup.LayoutParams.MATCH_PARENT));
+            return view;
+        }
+    }
+}


### PR DESCRIPTION
## Description
Stacked on #29 (base branch `fix/drag-displacement`); only the last commit belongs to this PR.

`LayoutManager.layout` hands the snap positions the view size minus start and end padding, but `snapTo`, `jumpToPosition`, `onDataSetChanged`, and `LayoutManagerBridge.onSingleTapUp` passed the full measured size. With padding set, `center` and `end` snaps targeted a point shifted by the padding and could pick a different nearest cell than the layout pass, so the snap animation aimed past where the draw-limit clamp lets the content stop.

All four paths now use a new `getSizeInsidePadding`. The scrollbar extent keeps the full size on purpose: it describes the visible viewport.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## How Has This Been Tested?
New `ListLayoutManagerSnapPaddingTest` (6 cases, written first; 4 failed on the old code) pins the padded targets for `snapTo` with center and end snap, tap-to-snap through the bridge, `setSelected`, first layout, and a data set change.

- [x] Unit tests (`./gradlew :library:test`: 76 pass, `spotlessCheck` clean)
- [ ] Instrumented tests
- [ ] Manual testing on device/emulator

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
