### PR TITLE
Measure from the spec size and lay out with the real coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ everything around them is new.
 
 ### Fixed
 
+- `AbstractAdapterView.onMeasure` reports the size from the measure spec
+  instead of the raw spec (which leaked the spec mode into
+  `getMeasuredState()`), and `onLayout` no longer runs `MeasureSpec.getSize`
+  on its layout coordinates, which laid out nothing when the view sat at a
+  negative offset inside its parent.
 - Snapping (after a drag or fling, on tap, on `setSelection`, and after a
   data set change) now measures against the size inside the view's padding,
   the same size the layout pass uses. With padding set, `center` and `end`

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
@@ -168,7 +168,9 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
 
     @Override
     protected void onMeasure(final int widthMeasureSpec, final int heightMeasureSpec) {
-        setMeasuredDimension(widthMeasureSpec, heightMeasureSpec);
+        final int width = MeasureSpec.getSize(widthMeasureSpec);
+        final int height = MeasureSpec.getSize(heightMeasureSpec);
+        setMeasuredDimension(width, height);
 
         final LayoutManager<Cell> layoutManager = mAdapterViewInitializer.getLayoutManager();
         if (layoutManager != null) {
@@ -197,13 +199,8 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
         childTouchListener.computeScrollOffset();
         final Animation animation = childTouchListener.getAnimation();
 
-        final int leftSize = MeasureSpec.getSize(left);
-        final int rightSize = MeasureSpec.getSize(right);
-        final int topSize = MeasureSpec.getSize(top);
-        final int bottomSize = MeasureSpec.getSize(bottom);
-
         if (layoutManager != null) {
-            layoutManager.layout(this, animation, leftSize, topSize, rightSize, bottomSize);
+            layoutManager.layout(this, animation, left, top, right, bottom);
         }
         final AdapterAnimator.State state = childTouchListener.getState();
         switch (state) {

--- a/library/src/test/java/mobi/parchment/HorizontalListViewTest.java
+++ b/library/src/test/java/mobi/parchment/HorizontalListViewTest.java
@@ -74,6 +74,62 @@ public class HorizontalListViewTest {
         assertThat(horizontalListView.getChildAt(0).getLeft()).isEqualTo(0);
     }
 
+    @Test
+    public void onMeasure_withAnExactSpec_reportsTheSizeWithoutStateBits() {
+        final ListView<?> horizontalListView = inflateBasicListView();
+
+        final int widthSpec =
+                View.MeasureSpec.makeMeasureSpec(
+                        HORIZONTAL_LIST_VIEW_WIDTH, View.MeasureSpec.EXACTLY);
+        final int heightSpec = View.MeasureSpec.makeMeasureSpec(300, View.MeasureSpec.EXACTLY);
+        horizontalListView.measure(widthSpec, heightSpec);
+
+        assertThat(horizontalListView.getMeasuredWidth()).isEqualTo(HORIZONTAL_LIST_VIEW_WIDTH);
+        assertThat(horizontalListView.getMeasuredHeight()).isEqualTo(300);
+        assertThat(horizontalListView.getMeasuredState()).isEqualTo(0);
+    }
+
+    @Test
+    public void onMeasure_withAnAtMostSpec_takesTheAvailableSizeWithoutStateBits() {
+        final ListView<?> horizontalListView = inflateBasicListView();
+
+        final int widthSpec =
+                View.MeasureSpec.makeMeasureSpec(
+                        HORIZONTAL_LIST_VIEW_WIDTH, View.MeasureSpec.AT_MOST);
+        final int heightSpec = View.MeasureSpec.makeMeasureSpec(300, View.MeasureSpec.AT_MOST);
+        horizontalListView.measure(widthSpec, heightSpec);
+
+        assertThat(horizontalListView.getMeasuredWidth()).isEqualTo(HORIZONTAL_LIST_VIEW_WIDTH);
+        assertThat(horizontalListView.getMeasuredHeight()).isEqualTo(300);
+        assertThat(horizontalListView.getMeasuredState()).isEqualTo(0);
+    }
+
+    @Test
+    public void onLayout_atANegativeOffsetInsideItsParent_laysOutTheChildren() {
+        final ListView<?> horizontalListView = inflateBasicListView();
+        final int measureSpec =
+                View.MeasureSpec.makeMeasureSpec(
+                        HORIZONTAL_LIST_VIEW_WIDTH, View.MeasureSpec.EXACTLY);
+        horizontalListView.measure(measureSpec, measureSpec);
+
+        horizontalListView.layout(
+                -50, -50, HORIZONTAL_LIST_VIEW_WIDTH - 50, HORIZONTAL_LIST_VIEW_WIDTH - 50);
+
+        assertThat(horizontalListView.getChildCount()).isGreaterThan(0);
+        assertThat(horizontalListView.getChildAt(0).getLeft()).isEqualTo(0);
+        assertThat(horizontalListView.getChildAt(0).getRight())
+                .isEqualTo(HORIZONTAL_LIST_VIEW_WIDTH);
+    }
+
+    private static ListView<?> inflateBasicListView() {
+        final ActivityController<TestActivity> controller =
+                Robolectric.buildActivity(TestActivity.class);
+        final TestActivity testActivity = controller.get();
+        testActivity.setLayoutId(R.layout.basic);
+        controller.create();
+        return testActivity.findViewById(R.id.horizontal_list_view);
+    }
+
     public static class TestActivity extends Activity {
 
         private int layoutId;


### PR DESCRIPTION
## Description
Stacked on #30 (base branch `fix/snap-size-inside-padding`); only the last commit belongs to this PR.

`AbstractAdapterView.onMeasure` passed the raw `MeasureSpec`s to `setMeasuredDimension`, so the spec mode bits ended up in `getMeasuredState()` and were reported to the parent as measured state. `onLayout` ran `MeasureSpec.getSize` on its `left/top/right/bottom` arguments; that masks a negative coordinate into a 16-million-pixel value, so a view laid out at a negative offset inside its parent computed a negative size and laid out nothing.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## How Has This Been Tested?
Three new cases in `HorizontalListViewTest`, written first (all three failed on the old code): measured size with a zero measured state for `EXACTLY` and `AT_MOST` specs, and children laid out across the view's own width when the view is laid out at (-50, -50).

- [x] Unit tests (`./gradlew :library:test`: 79 pass, `spotlessCheck` and `:library:lintDebug` clean)
- [ ] Instrumented tests
- [ ] Manual testing on device/emulator

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
