### PR TITLE
Schedule animation frames through the view instead of requestLayout()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ everything around them is new.
 
 ### Fixed
 
+- Animations no longer call `requestLayout()` from inside the layout pass.
+  `AdapterAnimator` asks an `AnimationFrameScheduler` (implemented by the
+  view) for the next frame, and the view posts a single coalesced request,
+  so starting a snap or fling while laying out no longer triggers the
+  framework's "requestLayout() improperly called during layout" second pass.
 - `AbstractAdapterView.onMeasure` reports the size from the measure spec
   instead of the raw spec (which leaked the spec mode into
   `getMeasuredState()`), and `onLayout` no longer runs `MeasureSpec.getSize`

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
@@ -17,19 +17,18 @@ import android.widget.Adapter;
 
 public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
         extends android.widget.AdapterView<ADAPTER>
-        implements OnLongClickListener, OnClickListener, OnSelectedListener, AdapterViewHandler {
+        implements OnLongClickListener,
+                OnClickListener,
+                OnSelectedListener,
+                AdapterViewHandler,
+                AnimationFrameScheduler {
 
     private OnItemSelectedListener mOnItemSelectedListener;
     private ADAPTER mAdapter;
     private AdapterViewInitializer<Cell> mAdapterViewInitializer;
 
-    private Runnable mRequestLayout =
-            new Runnable() {
-                @Override
-                public void run() {
-                    requestLayout();
-                }
-            };
+    private final AnimationFrameRunnable mAnimationFrameRunnable = new AnimationFrameRunnable(this);
+    private boolean mAnimationFrameRequested;
 
     private final DataSetObserver mDataSetObserver =
             new DataSetObserver() {
@@ -77,6 +76,7 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
         final ViewConfiguration viewConfiguration = ViewConfiguration.get(context);
         final ChildTouchGestureListener childTouchGestureListener =
                 new ChildTouchGestureListener(
+                        this,
                         this,
                         isViewPager,
                         isVerticalScroll,
@@ -152,6 +152,20 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
         final LayoutManager<Cell> layoutManager = mAdapterViewInitializer.getLayoutManager();
         adapterViewManager.unregisterDataSetObserver(mDataSetObserver);
         layoutManager.destroy();
+        removeCallbacks(mAnimationFrameRunnable);
+        mAnimationFrameRequested = false;
+    }
+
+    @Override
+    public void requestAnimationFrame() {
+        if (mAnimationFrameRequested) return;
+        mAnimationFrameRequested = true;
+        post(mAnimationFrameRunnable);
+    }
+
+    protected void onAnimationFrame() {
+        mAnimationFrameRequested = false;
+        requestLayout();
     }
 
     @Override
@@ -208,7 +222,7 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
             case flinging:
             case jumpingTo:
             case snapingTo:
-                post(mRequestLayout);
+                requestAnimationFrame();
                 awakenScrollBars();
                 break;
             case scrolling:
@@ -404,5 +418,18 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
     public boolean isVerticalScrollBarEnabled() {
         final LayoutManager<Cell> layoutManager = mAdapterViewInitializer.getLayoutManager();
         return layoutManager.isVerticalScroll();
+    }
+
+    private static final class AnimationFrameRunnable implements Runnable {
+        private final AbstractAdapterView<?, ?> mView;
+
+        AnimationFrameRunnable(final AbstractAdapterView<?, ?> view) {
+            mView = view;
+        }
+
+        @Override
+        public void run() {
+            mView.onAnimationFrame();
+        }
     }
 }

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
@@ -28,6 +28,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
     private final Animation mAnimation = new Animation();
     private final ScrollAnimator mScrollAnimator;
     private final ViewGroup mViewGroup;
+    private final AnimationFrameScheduler mFrameScheduler;
     private final LayoutManagerBridge mLayoutManagerBridge;
     private final boolean mIsViewPager;
     private boolean mTouchSlopExceeded = false;
@@ -40,13 +41,15 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
 
     public AdapterAnimator(
             final ViewGroup view,
+            final AnimationFrameScheduler frameScheduler,
             final boolean isViewPager,
             final boolean isVerticalScroll,
             final LayoutManagerBridge layoutManagerBridge,
-            ViewConfiguration viewConfiguration) {
+            final ViewConfiguration viewConfiguration) {
         mLayoutManagerBridge = layoutManagerBridge;
         mLayoutManagerBridge.setAnimationStoppedListener(this);
         mViewGroup = view;
+        mFrameScheduler = frameScheduler;
         mIsViewPager = isViewPager;
         mIsVerticalScroll = isVerticalScroll;
         mScrollAnimator = new ScrollAnimator(view.getContext(), isVerticalScroll);
@@ -75,7 +78,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
             mScrollAnimator.flingBy(velocityX, velocityY);
         }
 
-        mViewGroup.requestLayout();
+        mFrameScheduler.requestAnimationFrame();
         return true;
     }
 
@@ -104,7 +107,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
         final int displacement =
                 (int) mLayoutManagerBridge.getScrollDisplacement(distanceX, distanceY);
         mPendingScrollDisplacement += displacement;
-        mViewGroup.requestLayout();
+        mFrameScheduler.requestAnimationFrame();
         return true;
     }
 
@@ -120,7 +123,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
         setState(State.flinging);
 
         mScrollAnimator.startScroll(scrollDistance, ANIMATION_DURATION);
-        mViewGroup.requestLayout();
+        mFrameScheduler.requestAnimationFrame();
 
         return true;
     }
@@ -158,7 +161,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
             if (scrollDistance == 0) return;
             setState(State.snapingTo);
             mScrollAnimator.startScroll(scrollDistance, ANIMATION_DURATION);
-            mViewGroup.requestLayout();
+            mFrameScheduler.requestAnimationFrame();
         }
     }
 
@@ -203,7 +206,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
     public void setAnimateToDistance(final int animate) {
         setState(State.animatingTo);
         mScrollAnimator.startScroll(animate, FINAL_ANIMATE_TO_DURATION_IN_MILLISECONDS);
-        mViewGroup.requestLayout();
+        mFrameScheduler.requestAnimationFrame();
     }
 
     protected ViewGroup getViewGroup() {

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AnimationFrameScheduler.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AnimationFrameScheduler.java
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+public interface AnimationFrameScheduler {
+    void requestAnimationFrame();
+}

--- a/library/src/main/java/mobi/parchment/widget/adapterview/ChildTouchGestureListener.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/ChildTouchGestureListener.java
@@ -21,13 +21,20 @@ public class ChildTouchGestureListener extends AdapterAnimator {
 
     public ChildTouchGestureListener(
             final ViewGroup viewGroup,
+            final AnimationFrameScheduler frameScheduler,
             final boolean isViewPager,
             final boolean isVertical,
             final OnClickListener onClickListener,
             final OnLongClickListener onLongClickListener,
             final LayoutManagerBridge layoutManagerBridge,
             final ViewConfiguration viewConfiguration) {
-        super(viewGroup, isViewPager, isVertical, layoutManagerBridge, viewConfiguration);
+        super(
+                viewGroup,
+                frameScheduler,
+                isViewPager,
+                isVertical,
+                layoutManagerBridge,
+                viewConfiguration);
         mOnClickListener = onClickListener;
         mOnLongClickListener = onLongClickListener;
         mScaledTouchSlop = viewConfiguration.getScaledTouchSlop();

--- a/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
@@ -7,9 +7,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import android.content.Context;
 import android.view.MotionEvent;
+import android.view.View;
 import android.view.ViewConfiguration;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
 import android.widget.FrameLayout;
 import androidx.test.core.app.ApplicationProvider;
+import java.util.ArrayList;
+import java.util.List;
 import mobi.parchment.widget.adapterview.listview.ListLayoutManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,24 +24,54 @@ import org.robolectric.RobolectricTestRunner;
 @RunWith(RobolectricTestRunner.class)
 public class AdapterAnimatorTest {
 
+    private static final int VIEW_GROUP_SIZE = 300;
+    private static final int VIEW_SIZE = 100;
+    private static final int ADAPTER_SIZE = 10;
+
+    private final Context mContext = ApplicationProvider.getApplicationContext();
+    private final RecordingFrameScheduler mFrameScheduler = new RecordingFrameScheduler();
+    private final MyViewGroup mViewGroup = new MyViewGroup(mContext);
+    private final AdapterViewManager mAdapterViewManager = new AdapterViewManager();
+    private ListLayoutManager mLayoutManager;
     private AdapterAnimator mAdapterAnimator;
 
     @Before
     public void setup() {
-        final Context context = ApplicationProvider.getApplicationContext();
-        final FrameLayout viewGroup = new FrameLayout(context);
+        setup(false, SnapPosition.onScreen);
+    }
+
+    private void setup(final boolean snapToPosition, final SnapPosition snapPosition) {
         final LayoutManagerAttributes attributes =
                 new LayoutManagerAttributes(
-                        false, false, false, 0, SnapPosition.onScreen, 0, false, false, false);
-        final ListLayoutManager layoutManager =
-                new ListLayoutManager(viewGroup, null, new AdapterViewManager(), attributes);
+                        false, snapToPosition, false, 0, snapPosition, 0, false, false, false);
+        mLayoutManager = new ListLayoutManager(mViewGroup, null, mAdapterViewManager, attributes);
         mAdapterAnimator =
                 new AdapterAnimator(
-                        viewGroup,
+                        mViewGroup,
+                        mFrameScheduler,
                         false,
                         false,
-                        new LayoutManagerBridge(layoutManager),
-                        ViewConfiguration.get(context));
+                        new LayoutManagerBridge(mLayoutManager),
+                        ViewConfiguration.get(mContext));
+        final int measureSpec =
+                View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
+        mViewGroup.measure(measureSpec, measureSpec);
+        mViewGroup.layout(0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+        assertThat(mViewGroup.isLayoutRequested()).isFalse();
+    }
+
+    private void layOutCenterSnappingList() {
+        setup(true, SnapPosition.center);
+        final TestAdapter adapter = new TestAdapter();
+        mAdapterViewManager.setAdapter(adapter);
+        adapter.setAdapterSize(ADAPTER_SIZE);
+        layout();
+    }
+
+    private void layout() {
+        mAdapterAnimator.computeScrollOffset();
+        final Animation animation = mAdapterAnimator.getAnimation();
+        mLayoutManager.layout(mViewGroup, animation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
     }
 
     @Test
@@ -113,6 +148,68 @@ public class AdapterAnimatorTest {
         assertThat(nextFrameDisplacement()).isEqualTo(5);
     }
 
+    @Test
+    public void onFling_requestsAnAnimationFrameInsteadOfALayout() {
+        mAdapterAnimator.onFling(down(), up(), 1000f, 0f);
+
+        assertThat(mFrameScheduler.mRequests).isEqualTo(1);
+        assertThat(mViewGroup.isLayoutRequested()).isFalse();
+    }
+
+    @Test
+    public void onScroll_requestsAnAnimationFrameInsteadOfALayout() {
+        mAdapterAnimator.onDown(down());
+        mAdapterAnimator.onScroll(down(), moveTo(100f), -100f, 0f);
+
+        assertThat(mFrameScheduler.mRequests).isEqualTo(1);
+        assertThat(mViewGroup.isLayoutRequested()).isFalse();
+    }
+
+    @Test
+    public void onSingleTapUp_onAView_requestsAnAnimationFrameInsteadOfALayout() {
+        mAdapterAnimator.onSingleTapUp(up(), new View(mContext));
+
+        assertThat(mFrameScheduler.mRequests).isEqualTo(1);
+        assertThat(mViewGroup.isLayoutRequested()).isFalse();
+    }
+
+    @Test
+    public void setAnimateToDistance_requestsAnAnimationFrameInsteadOfALayout() {
+        mAdapterAnimator.setAnimateToDistance(50);
+
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.animatingTo);
+        assertThat(mFrameScheduler.mRequests).isEqualTo(1);
+        assertThat(mViewGroup.isLayoutRequested()).isFalse();
+    }
+
+    @Test
+    public void onUp_afterADragThatNeedsASnap_requestsAnAnimationFrameInsteadOfALayout() {
+        layOutCenterSnappingList();
+        mAdapterAnimator.onDown(down());
+        mAdapterAnimator.onScroll(down(), moveTo(45f), 45f, 0f);
+        layout();
+        assertThat(mLayoutManager.getViewForPosition(0).getLeft()).isEqualTo(55);
+        mFrameScheduler.mRequests = 0;
+
+        mAdapterAnimator.onUp();
+
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.snapingTo);
+        assertThat(mFrameScheduler.mRequests).isEqualTo(1);
+        assertThat(mViewGroup.isLayoutRequested()).isFalse();
+    }
+
+    @Test
+    public void onUp_afterADragThatEndsOnTheSnapPosition_doesNotRequestAFrame() {
+        layOutCenterSnappingList();
+        mFrameScheduler.mRequests = 0;
+
+        mAdapterAnimator.onDown(down());
+        mAdapterAnimator.onUp();
+
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.notMoving);
+        assertThat(mFrameScheduler.mRequests).isEqualTo(0);
+    }
+
     private int nextFrameDisplacement() {
         mAdapterAnimator.computeScrollOffset();
         return mAdapterAnimator.getAnimation().getDisplacement();
@@ -128,5 +225,67 @@ public class AdapterAnimatorTest {
 
     private static MotionEvent up() {
         return MotionEvent.obtain(0, 50, MotionEvent.ACTION_UP, 200f, 0f, 0);
+    }
+
+    private static final class RecordingFrameScheduler implements AnimationFrameScheduler {
+        private int mRequests;
+
+        @Override
+        public void requestAnimationFrame() {
+            mRequests++;
+        }
+    }
+
+    public static final class MyViewGroup extends FrameLayout implements AdapterViewHandler {
+        public final List<View> mViews = new ArrayList<View>();
+
+        public MyViewGroup(final Context context) {
+            super(context);
+        }
+
+        @Override
+        public boolean addViewInAdapterView(
+                final View view, final int index, final ViewGroup.LayoutParams layoutParams) {
+            mViews.add(index, view);
+            return true;
+        }
+
+        @Override
+        public void removeViewInAdapterView(final View view) {
+            mViews.remove(view);
+        }
+    }
+
+    public static final class TestAdapter extends BaseAdapter {
+        private int mAdapterSize;
+
+        public void setAdapterSize(final int adapterSize) {
+            mAdapterSize = adapterSize;
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public int getCount() {
+            return mAdapterSize;
+        }
+
+        @Override
+        public Object getItem(final int position) {
+            return position;
+        }
+
+        @Override
+        public long getItemId(final int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(final int position, final View convertView, final ViewGroup parent) {
+            final FrameLayout view = new FrameLayout(ApplicationProvider.getApplicationContext());
+            view.setTag(position);
+            view.setLayoutParams(
+                    new ViewGroup.LayoutParams(VIEW_SIZE, ViewGroup.LayoutParams.MATCH_PARENT));
+            return view;
+        }
     }
 }

--- a/library/src/test/java/mobi/parchment/widget/adapterview/AnimationFrameSchedulingTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/AnimationFrameSchedulingTest.java
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Looper;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.FrameLayout;
+import java.time.Duration;
+import mobi.parchment.test.R;
+import mobi.parchment.widget.adapterview.listview.ListView;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowSystemClock;
+
+@RunWith(RobolectricTestRunner.class)
+public class AnimationFrameSchedulingTest {
+
+    private static final int VIEW_SIZE = 300;
+    private static final int CELL_SIZE = 100;
+    private static final int ADAPTER_SIZE = 10;
+    private static final float FLING_VELOCITY = -1000f;
+
+    private FrameLayout mContent;
+    private CountingListView mListView;
+
+    @Before
+    public void setup() {
+        final Activity activity = Robolectric.buildActivity(Activity.class).setup().get();
+        mContent = new FrameLayout(activity);
+        activity.setContentView(mContent);
+        mListView = (CountingListView) View.inflate(activity, R.layout.counting_list_view, null);
+        mListView.setAdapter(new FixedSizeAdapter(activity));
+        mContent.addView(mListView, new FrameLayout.LayoutParams(VIEW_SIZE, VIEW_SIZE));
+        assertThat(mListView.isAttachedToWindow()).isTrue();
+        measureAndLayout();
+        mListView.reset();
+    }
+
+    private void measureAndLayout() {
+        final int measureSpec =
+                View.MeasureSpec.makeMeasureSpec(VIEW_SIZE, View.MeasureSpec.EXACTLY);
+        mListView.forceLayout();
+        mListView.measure(measureSpec, measureSpec);
+        mListView.layout(0, 0, VIEW_SIZE, VIEW_SIZE);
+    }
+
+    private void idleMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle();
+    }
+
+    private View firstChild() {
+        return mListView.getChildAt(0);
+    }
+
+    @Test
+    public void firstLayout_centersTheFirstCell() {
+        assertThat(mListView.getChildCount()).isGreaterThan(0);
+        assertThat(firstChild().getLeft()).isEqualTo(100);
+    }
+
+    @Test
+    public void requestAnimationFrame_runsTheFrameOnTheNextLooperPassNotSynchronously() {
+        mListView.requestAnimationFrame();
+
+        assertThat(mListView.mFramesRun).isEqualTo(0);
+        assertThat(mListView.mLayoutRequests).isEqualTo(0);
+
+        idleMainLooper();
+
+        assertThat(mListView.mFramesRun).isEqualTo(1);
+        assertThat(mListView.mLayoutRequests).isEqualTo(1);
+    }
+
+    @Test
+    public void requestAnimationFrame_twiceBeforeTheFrame_runsOneFrame() {
+        mListView.requestAnimationFrame();
+        mListView.requestAnimationFrame();
+
+        idleMainLooper();
+
+        assertThat(mListView.mFramesRun).isEqualTo(1);
+    }
+
+    @Test
+    public void requestAnimationFrame_afterTheFrameRan_runsAnotherFrame() {
+        mListView.requestAnimationFrame();
+        idleMainLooper();
+
+        mListView.requestAnimationFrame();
+        idleMainLooper();
+
+        assertThat(mListView.mFramesRun).isEqualTo(2);
+    }
+
+    @Test
+    public void detachingTheView_dropsThePendingFrameAndAcceptsANewOne() {
+        mListView.requestAnimationFrame();
+
+        mContent.removeView(mListView);
+        assertThat(mListView.isAttachedToWindow()).isFalse();
+        mContent.addView(mListView, new FrameLayout.LayoutParams(VIEW_SIZE, VIEW_SIZE));
+        mListView.reset();
+
+        mListView.requestAnimationFrame();
+        idleMainLooper();
+
+        assertThat(mListView.mFramesRun).isEqualTo(1);
+    }
+
+    @Test
+    public void aDrag_movesTheCellsOnTheNextFrameWithoutRequestingLayoutDuringLayout() {
+        mListView.mGestureListener.onDown(down());
+        mListView.mGestureListener.onScroll(down(), moveTo(155f), 45f, 0f);
+
+        assertThat(mListView.mFrameRequests).isEqualTo(1);
+        assertThat(mListView.mLayoutRequests).isEqualTo(0);
+        idleMainLooper();
+        assertThat(mListView.mFramesRun).isEqualTo(1);
+
+        measureAndLayout();
+
+        assertThat(firstChild().getLeft()).isEqualTo(55);
+        assertThat(mListView.mLayoutRequestsDuringLayout).isEqualTo(0);
+    }
+
+    @Test
+    public void onLayout_whileAnimating_requestsTheNextFrameThroughTheScheduler() {
+        fling();
+        mListView.reset();
+
+        measureAndLayout();
+
+        assertThat(mListView.mFrameRequests).isEqualTo(1);
+        assertThat(mListView.mLayoutRequestsDuringLayout).isEqualTo(0);
+    }
+
+    @Test
+    public void aSnapThatStartsInsideOnLayout_isScheduledNotRequestedDuringLayout() {
+        fling();
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(5));
+        measureAndLayout();
+        assertThat(firstChild().getLeft()).isNotEqualTo(100);
+        mListView.reset();
+
+        measureAndLayout();
+
+        assertThat(mListView.mGestureListener.getState())
+                .isEqualTo(AdapterAnimator.State.snapingTo);
+        assertThat(mListView.mFrameRequests).isGreaterThanOrEqualTo(1);
+        assertThat(mListView.mLayoutRequestsDuringLayout).isEqualTo(0);
+        assertThat(mListView.mLayoutRequests).isEqualTo(0);
+
+        idleMainLooper();
+
+        assertThat(mListView.mGestureListener.getState())
+                .isEqualTo(AdapterAnimator.State.notMoving);
+        assertThat(mListView.mFramesRun).isGreaterThan(1);
+        assertThat(mListView.mLayoutRequestsDuringLayout).isEqualTo(0);
+        assertThat(mListView.getChildAt(2).getLeft()).isEqualTo(100);
+    }
+
+    private void fling() {
+        mListView.mGestureListener.onDown(down());
+        mListView.mGestureListener.onFling(down(), moveTo(100f), FLING_VELOCITY, 0f);
+        mListView.mGestureListener.onUp();
+        assertThat(mListView.mGestureListener.getState()).isEqualTo(AdapterAnimator.State.flinging);
+    }
+
+    private static MotionEvent down() {
+        return MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 200f, 150f, 0);
+    }
+
+    private static MotionEvent moveTo(final float x) {
+        return MotionEvent.obtain(0, 10, MotionEvent.ACTION_MOVE, x, 150f, 0);
+    }
+
+    public static final class CountingListView extends ListView<BaseAdapter> {
+        int mLayoutRequests;
+        int mLayoutRequestsDuringLayout;
+        int mFrameRequests;
+        int mFramesRun;
+        ChildTouchGestureListener mGestureListener;
+        private boolean mInLayout;
+
+        public CountingListView(final Context context, final AttributeSet attributeSet) {
+            super(context, attributeSet);
+        }
+
+        void reset() {
+            mLayoutRequests = 0;
+            mLayoutRequestsDuringLayout = 0;
+            mFrameRequests = 0;
+            mFramesRun = 0;
+        }
+
+        @Override
+        protected AdapterViewInitializer<View> createAdapterViewInitializer(
+                final Context context,
+                final boolean isViewPager,
+                final AdapterViewManager adapterViewManager,
+                final LayoutManager<View> layoutManager,
+                final boolean isVerticalScroll) {
+            final AdapterViewInitializer<View> initializer =
+                    super.createAdapterViewInitializer(
+                            context,
+                            isViewPager,
+                            adapterViewManager,
+                            layoutManager,
+                            isVerticalScroll);
+            mGestureListener = initializer.getChildTouchListener();
+            return initializer;
+        }
+
+        @Override
+        public void requestLayout() {
+            mLayoutRequests++;
+            if (mInLayout) mLayoutRequestsDuringLayout++;
+            super.requestLayout();
+        }
+
+        @Override
+        public void requestAnimationFrame() {
+            mFrameRequests++;
+            super.requestAnimationFrame();
+        }
+
+        @Override
+        protected void onAnimationFrame() {
+            mFramesRun++;
+            super.onAnimationFrame();
+        }
+
+        @Override
+        protected void onLayout(
+                final boolean changed,
+                final int left,
+                final int top,
+                final int right,
+                final int bottom) {
+            mInLayout = true;
+            super.onLayout(changed, left, top, right, bottom);
+            mInLayout = false;
+        }
+    }
+
+    private static final class FixedSizeAdapter extends BaseAdapter {
+        private final Context mContext;
+
+        FixedSizeAdapter(final Context context) {
+            mContext = context;
+        }
+
+        @Override
+        public int getCount() {
+            return ADAPTER_SIZE;
+        }
+
+        @Override
+        public Object getItem(final int position) {
+            return position;
+        }
+
+        @Override
+        public long getItemId(final int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(final int position, final View convertView, final ViewGroup parent) {
+            if (convertView != null) return convertView;
+            final FrameLayout view = new FrameLayout(mContext);
+            view.setLayoutParams(new ViewGroup.LayoutParams(CELL_SIZE, CELL_SIZE));
+            return view;
+        }
+    }
+}

--- a/library/src/test/res/layout/counting_list_view.xml
+++ b/library/src/test/res/layout/counting_list_view.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<view xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:parchment="http://schemas.android.com/apk/res-auto"
+      class="mobi.parchment.widget.adapterview.AnimationFrameSchedulingTest$CountingListView"
+      android:id="@+id/counting_list_view"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      parchment:orientation="horizontal"
+      parchment:snapToPosition="true"
+      parchment:snapPosition="center"/>


### PR DESCRIPTION
## Description
Stacked on #31 (base branch `fix/measure-specs`); only the last commit belongs to this PR.

`AdapterAnimator` called `mViewGroup.requestLayout()` whenever it started a fling, drag frame, tap-to-snap, programmatic scroll, or the snap that follows a stop. The stop happens inside `LayoutManager.layout` (the draw-limit clamp) and inside `computeScrollOffset`, both of which run from `onLayout`, so the snap's `requestLayout()` landed during layout. `ViewRootImpl` logs "requestLayout() improperly called ... during layout" and runs a second measure and layout pass in the same frame.

The animator now takes an `AnimationFrameScheduler` and asks it for the next frame. `AbstractAdapterView` implements it by posting one `AnimationFrameRunnable` (a named class replacing the anonymous `Runnable`), coalescing repeated requests until the frame runs, and dropping a pending frame on detach. `onLayout` continues a running animation through the same scheduler. `onAnimationFrame()` is a protected hook so the next PR can turn the frame into a direct layout step without a full traversal.

Constructor signatures of `AdapterAnimator` and `ChildTouchGestureListener` gain the scheduler parameter; both are implementation details per CONTRIBUTING. No XML attribute or public view method changes.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## How Has This Been Tested?
- `AdapterAnimatorTest`: each animation start (fling, scroll, tap, programmatic, snap after a drag) asks the scheduler exactly once and never marks the view as needing layout; a drag that ends on the snap position asks for nothing.
- New `AnimationFrameSchedulingTest` drives an attached `ListView` inflated from a test layout: a request runs one frame on the next looper pass and not synchronously, repeated requests coalesce, a frame can be requested again after it ran, a detached view drops its pending frame, a drag moves the cells on the next frame, `onLayout` continues a fling through the scheduler, and a fling that ends mid-content starts its snap inside `onLayout` and runs to rest with zero `requestLayout()` calls during layout.

- [x] Unit tests (`./gradlew :library:test`: 93 pass, `spotlessCheck` and `:library:lintDebug` clean)
- [ ] Instrumented tests
- [ ] Manual testing on device/emulator

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
