### PR TITLE
Run animation frames from postOnAnimation without a layout pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ everything around them is new.
 
 ### Changed
 
+- Animation frames (fling, snap, page, drag) run the layout step directly
+  from a `postOnAnimation` callback and invalidate, instead of posting a
+  `requestLayout()` that re-measured and re-laid out the whole ancestor
+  tree every frame. A full layout pass still happens whenever the framework
+  asks for one, and a frame that fires while one is pending yields to it.
 - **Breaking:** minimum SDK is 21 (was 8) and the library is compiled with
   Java 17 against SDK 37.
 - **Breaking:** the library is an AAR built by Gradle. The Maven `apklib`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,17 @@ Adapter (any android.widget.Adapter)
 
 ## The layout pass
 
-`AbstractAdapterView.onLayout` runs on every frame while anything moves:
+`AbstractAdapterView` runs the same frame step from two places: `onLayout`
+when the framework lays the view out (size change, adapter change,
+`setSelection`), and `onAnimationFrame` on every Choreographer frame while
+anything moves. The animation path is scheduled with `postOnAnimation`
+through the `AnimationFrameScheduler` the animator holds, runs the step
+against the view's current bounds, and invalidates; it never calls
+`requestLayout()`, so a fling does not re-measure the ancestor tree once
+per frame. If a real layout is already pending when the frame fires, the
+frame yields and the layout pass carries the animation forward.
+
+The step itself:
 
 1. `ChildTouchGestureListener.computeScrollOffset()` advances the active
    animation (fling, snap, page, or programmatic jump) and produces an
@@ -41,8 +51,8 @@ Adapter (any android.widget.Adapter)
    (which is `addViewInLayout`, so no re-layout storm) and positioned with
    `ScrollDirectionManager`, which maps start/end/size onto left/right/width
    or top/bottom/height depending on orientation.
-4. If the animation is still running, the view posts another
-   `requestLayout()`; when it settles with `snapToPosition` on, the
+4. If the animation is still running, the view asks the scheduler for the
+   next frame; when it settles with `snapToPosition` on, the
    `SnapPositionInterface` computes the displacement to the nearest cell
    and a snap animation starts.
 

--- a/library/src/androidTest/java/mobi/parchment/widget/adapterview/listview/ListViewInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/widget/adapterview/listview/ListViewInstrumentedTest.java
@@ -76,9 +76,9 @@ public class ListViewInstrumentedTest {
     @Test
     public void animationFrames_moveTheChildrenWithoutALayoutPass() throws InterruptedException {
         final Context context = ApplicationProvider.getApplicationContext();
-        final FrameListView listView = new FrameListView(context);
-        final LayOutVertically layOut = new LayOutVertically(listView, context);
-        InstrumentationRegistry.getInstrumentation().runOnMainSync(layOut);
+        final CreateAndLayOutVertically create = new CreateAndLayOutVertically(context);
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(create);
+        final FrameListView listView = create.listView();
         assertEquals(0, listView.getChildAt(0).getTop());
         assertFalse(listView.isLayoutRequested());
 
@@ -135,17 +135,21 @@ public class ListViewInstrumentedTest {
         }
     }
 
-    private static final class LayOutVertically implements Runnable {
-        private final FrameListView mListView;
+    private static final class CreateAndLayOutVertically implements Runnable {
         private final Context mContext;
+        private FrameListView mListView;
 
-        LayOutVertically(final FrameListView listView, final Context context) {
-            mListView = listView;
+        CreateAndLayOutVertically(final Context context) {
             mContext = context;
+        }
+
+        FrameListView listView() {
+            return mListView;
         }
 
         @Override
         public void run() {
+            mListView = new FrameListView(mContext);
             mListView.setAdapter(new FixedHeightAdapter(mContext));
             final int widthSpec = View.MeasureSpec.makeMeasureSpec(WIDTH, View.MeasureSpec.EXACTLY);
             final int heightSpec =

--- a/library/src/androidTest/java/mobi/parchment/widget/adapterview/listview/ListViewInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/widget/adapterview/listview/ListViewInstrumentedTest.java
@@ -35,6 +35,9 @@ public class ListViewInstrumentedTest {
     private static final int ITEM_WIDTH = 200;
     private static final int ITEM_HEIGHT = 100;
     private static final int ITEM_COUNT = 50;
+    // A ListView built without attributes defaults to snapPosition=center.
+    private static final int CENTERED_TOP = (HEIGHT - ITEM_HEIGHT) / 2;
+    private static final int DRAG_DISTANCE = 45;
 
     @Test
     public void inflatedHorizontalListView_laysOutOnlyVisibleChildren() {
@@ -79,12 +82,12 @@ public class ListViewInstrumentedTest {
         final CreateAndLayOutVertically create = new CreateAndLayOutVertically(context);
         InstrumentationRegistry.getInstrumentation().runOnMainSync(create);
         final FrameListView listView = create.listView();
-        assertEquals(0, listView.getChildAt(0).getTop());
+        assertEquals(CENTERED_TOP, listView.getChildAt(0).getTop());
         assertFalse(listView.isLayoutRequested());
 
         final DragThenFrame dragThenFrame = new DragThenFrame(listView);
         InstrumentationRegistry.getInstrumentation().runOnMainSync(dragThenFrame);
-        assertEquals(-45, listView.getChildAt(0).getTop());
+        assertEquals(CENTERED_TOP - DRAG_DISTANCE, listView.getChildAt(0).getTop());
         assertFalse(listView.isLayoutRequested());
         assertEquals(0, listView.getPositionForView(listView.getChildAt(0)));
 
@@ -95,7 +98,7 @@ public class ListViewInstrumentedTest {
         InstrumentationRegistry.getInstrumentation().runOnMainSync(runFrame);
         assertTrue(
                 "the fling should have moved the content further than the drag",
-                listView.getChildAt(0).getTop() < -45
+                listView.getChildAt(0).getTop() < CENTERED_TOP - DRAG_DISTANCE
                         || listView.getPositionForView(listView.getChildAt(0)) > 0);
         assertFalse(listView.isLayoutRequested());
         assertTrue(listView.getChildCount() < ITEM_COUNT);

--- a/library/src/androidTest/java/mobi/parchment/widget/adapterview/listview/ListViewInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/widget/adapterview/listview/ListViewInstrumentedTest.java
@@ -4,11 +4,13 @@
 package mobi.parchment.widget.adapterview.listview;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
@@ -18,6 +20,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 import java.util.concurrent.atomic.AtomicReference;
 import mobi.parchment.test.R;
+import mobi.parchment.widget.adapterview.AdapterViewInitializer;
+import mobi.parchment.widget.adapterview.AdapterViewManager;
+import mobi.parchment.widget.adapterview.ChildTouchGestureListener;
+import mobi.parchment.widget.adapterview.LayoutManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -27,6 +33,7 @@ public class ListViewInstrumentedTest {
     private static final int WIDTH = 1000;
     private static final int HEIGHT = 300;
     private static final int ITEM_WIDTH = 200;
+    private static final int ITEM_HEIGHT = 100;
     private static final int ITEM_COUNT = 50;
 
     @Test
@@ -64,6 +71,174 @@ public class ListViewInstrumentedTest {
         assertEquals(0, listView.getChildAt(0).getLeft());
         assertEquals(ITEM_WIDTH, listView.getChildAt(0).getWidth());
         assertEquals(0, listView.getPositionForView(listView.getChildAt(0)));
+    }
+
+    @Test
+    public void animationFrames_moveTheChildrenWithoutALayoutPass() throws InterruptedException {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final FrameListView listView = new FrameListView(context);
+        final LayOutVertically layOut = new LayOutVertically(listView, context);
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(layOut);
+        assertEquals(0, listView.getChildAt(0).getTop());
+        assertFalse(listView.isLayoutRequested());
+
+        final DragThenFrame dragThenFrame = new DragThenFrame(listView);
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(dragThenFrame);
+        assertEquals(-45, listView.getChildAt(0).getTop());
+        assertFalse(listView.isLayoutRequested());
+        assertEquals(0, listView.getPositionForView(listView.getChildAt(0)));
+
+        final FlingThenFrame flingThenFrame = new FlingThenFrame(listView);
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(flingThenFrame);
+        Thread.sleep(2000);
+        final RunFrame runFrame = new RunFrame(listView);
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(runFrame);
+        assertTrue(
+                "the fling should have moved the content further than the drag",
+                listView.getChildAt(0).getTop() < -45
+                        || listView.getPositionForView(listView.getChildAt(0)) > 0);
+        assertFalse(listView.isLayoutRequested());
+        assertTrue(listView.getChildCount() < ITEM_COUNT);
+    }
+
+    public static final class FrameListView extends ListView<BaseAdapter> {
+        private ChildTouchGestureListener mGestureListener;
+
+        public FrameListView(final Context context) {
+            super(context);
+        }
+
+        @Override
+        protected AdapterViewInitializer<View> createAdapterViewInitializer(
+                final Context context,
+                final boolean isViewPager,
+                final AdapterViewManager adapterViewManager,
+                final LayoutManager<View> layoutManager,
+                final boolean isVerticalScroll) {
+            final AdapterViewInitializer<View> initializer =
+                    super.createAdapterViewInitializer(
+                            context,
+                            isViewPager,
+                            adapterViewManager,
+                            layoutManager,
+                            isVerticalScroll);
+            mGestureListener = initializer.getChildTouchListener();
+            return initializer;
+        }
+
+        ChildTouchGestureListener gestureListener() {
+            return mGestureListener;
+        }
+
+        void runFrame() {
+            onAnimationFrame();
+        }
+    }
+
+    private static final class LayOutVertically implements Runnable {
+        private final FrameListView mListView;
+        private final Context mContext;
+
+        LayOutVertically(final FrameListView listView, final Context context) {
+            mListView = listView;
+            mContext = context;
+        }
+
+        @Override
+        public void run() {
+            mListView.setAdapter(new FixedHeightAdapter(mContext));
+            final int widthSpec = View.MeasureSpec.makeMeasureSpec(WIDTH, View.MeasureSpec.EXACTLY);
+            final int heightSpec =
+                    View.MeasureSpec.makeMeasureSpec(HEIGHT, View.MeasureSpec.EXACTLY);
+            mListView.measure(widthSpec, heightSpec);
+            mListView.layout(0, 0, WIDTH, HEIGHT);
+        }
+    }
+
+    private static final class DragThenFrame implements Runnable {
+        private final FrameListView mListView;
+
+        DragThenFrame(final FrameListView listView) {
+            mListView = listView;
+        }
+
+        @Override
+        public void run() {
+            final MotionEvent down =
+                    MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 100f, 200f, 0);
+            final MotionEvent move =
+                    MotionEvent.obtain(0, 10, MotionEvent.ACTION_MOVE, 100f, 155f, 0);
+            mListView.gestureListener().onDown(down);
+            mListView.gestureListener().onScroll(down, move, 0f, 45f);
+            mListView.runFrame();
+        }
+    }
+
+    private static final class FlingThenFrame implements Runnable {
+        private final FrameListView mListView;
+
+        FlingThenFrame(final FrameListView listView) {
+            mListView = listView;
+        }
+
+        @Override
+        public void run() {
+            final MotionEvent down =
+                    MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 100f, 200f, 0);
+            final MotionEvent up = MotionEvent.obtain(0, 40, MotionEvent.ACTION_UP, 100f, 100f, 0);
+            mListView.gestureListener().onDown(down);
+            mListView.gestureListener().onFling(down, up, 0f, -2000f);
+            mListView.gestureListener().onUp();
+            mListView.runFrame();
+        }
+    }
+
+    private static final class RunFrame implements Runnable {
+        private final FrameListView mListView;
+
+        RunFrame(final FrameListView listView) {
+            mListView = listView;
+        }
+
+        @Override
+        public void run() {
+            mListView.runFrame();
+        }
+    }
+
+    private static final class FixedHeightAdapter extends BaseAdapter {
+        private final Context context;
+
+        FixedHeightAdapter(final Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public int getCount() {
+            return ITEM_COUNT;
+        }
+
+        @Override
+        public Object getItem(final int position) {
+            return position;
+        }
+
+        @Override
+        public long getItemId(final int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(final int position, final View convertView, final ViewGroup parent) {
+            final TextView view =
+                    convertView instanceof TextView
+                            ? (TextView) convertView
+                            : new TextView(context);
+            view.setText(String.valueOf(position));
+            view.setLayoutParams(
+                    new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ITEM_HEIGHT));
+            return view;
+        }
     }
 
     private static final class FixedWidthAdapter extends BaseAdapter {

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
@@ -160,12 +160,14 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
     public void requestAnimationFrame() {
         if (mAnimationFrameRequested) return;
         mAnimationFrameRequested = true;
-        post(mAnimationFrameRunnable);
+        postOnAnimation(mAnimationFrameRunnable);
     }
 
     protected void onAnimationFrame() {
         mAnimationFrameRequested = false;
-        requestLayout();
+        if (isLayoutRequested()) return;
+        layoutFrame(getLeft(), getTop(), getRight(), getBottom());
+        invalidate();
     }
 
     @Override
@@ -205,7 +207,10 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
             final int top,
             final int right,
             final int bottom) {
+        layoutFrame(left, top, right, bottom);
+    }
 
+    private void layoutFrame(final int left, final int top, final int right, final int bottom) {
         final ChildTouchGestureListener childTouchListener =
                 mAdapterViewInitializer.getChildTouchListener();
         final LayoutManager<Cell> layoutManager = mAdapterViewInitializer.getLayoutManager();

--- a/library/src/test/java/mobi/parchment/widget/adapterview/AnimationFrameSchedulingTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/AnimationFrameSchedulingTest.java
@@ -76,11 +76,54 @@ public class AnimationFrameSchedulingTest {
         mListView.requestAnimationFrame();
 
         assertThat(mListView.mFramesRun).isEqualTo(0);
-        assertThat(mListView.mLayoutRequests).isEqualTo(0);
 
         idleMainLooper();
 
         assertThat(mListView.mFramesRun).isEqualTo(1);
+        assertThat(mListView.mLayoutRequests).isEqualTo(0);
+        assertThat(mListView.mLayoutPasses).isEqualTo(0);
+    }
+
+    @Test
+    public void aFrame_movesTheCellsWithoutALayoutPass() {
+        mListView.mGestureListener.onDown(down());
+        mListView.mGestureListener.onScroll(down(), moveTo(155f), 45f, 0f);
+
+        idleMainLooper();
+
+        assertThat(firstChild().getLeft()).isEqualTo(55);
+        assertThat(mListView.mFramesRun).isEqualTo(1);
+        assertThat(mListView.mLayoutPasses).isEqualTo(0);
+        assertThat(mListView.mLayoutRequests).isEqualTo(0);
+        assertThat(mListView.isLayoutRequested()).isFalse();
+    }
+
+    @Test
+    public void aFling_runsToRestOnAnimationFramesWithoutLayoutPasses() {
+        fling();
+
+        idleMainLooper();
+
+        assertThat(mListView.mGestureListener.getState())
+                .isEqualTo(AdapterAnimator.State.notMoving);
+        assertThat(mListView.mFramesRun).isGreaterThan(1);
+        assertThat(mListView.mLayoutPasses).isEqualTo(0);
+        assertThat(mListView.mLayoutRequests).isEqualTo(0);
+        assertThat(mListView.getChildAt(2).getLeft()).isEqualTo(100);
+    }
+
+    @Test
+    public void aFrame_whileALayoutIsPending_leavesTheWorkToTheLayoutPass() {
+        mListView.mGestureListener.onDown(down());
+        mListView.mGestureListener.onScroll(down(), moveTo(155f), 45f, 0f);
+        mListView.requestLayout();
+        assertThat(mListView.mLayoutRequests).isEqualTo(1);
+
+        idleMainLooper();
+
+        assertThat(firstChild().getLeft()).isEqualTo(55);
+        assertThat(mListView.mFramesRun).isEqualTo(1);
+        assertThat(mListView.mLayoutPasses).isEqualTo(1);
         assertThat(mListView.mLayoutRequests).isEqualTo(1);
     }
 
@@ -192,6 +235,7 @@ public class AnimationFrameSchedulingTest {
         int mLayoutRequestsDuringLayout;
         int mFrameRequests;
         int mFramesRun;
+        int mLayoutPasses;
         ChildTouchGestureListener mGestureListener;
         private boolean mInLayout;
 
@@ -204,6 +248,7 @@ public class AnimationFrameSchedulingTest {
             mLayoutRequestsDuringLayout = 0;
             mFrameRequests = 0;
             mFramesRun = 0;
+            mLayoutPasses = 0;
         }
 
         @Override
@@ -250,6 +295,7 @@ public class AnimationFrameSchedulingTest {
                 final int top,
                 final int right,
                 final int bottom) {
+            mLayoutPasses++;
             mInLayout = true;
             super.onLayout(changed, left, top, right, bottom);
             mInLayout = false;


### PR DESCRIPTION
## Description
Stacked on #32 (base branch `refactor/animation-frame-scheduler`); only the last commit belongs to this PR.

Every animation frame used to post a `requestLayout()`, which re-measured and re-laid out the whole ancestor tree once per frame (the new test counted 71 layout passes for one fling to come to rest) and re-measured every visible cell in `onMeasure` along the way. A parent like `ConstraintLayout` pays for that on every frame.

`AbstractAdapterView` now schedules frames with `postOnAnimation` and runs the same step `onLayout` runs (compute the offset, lay out the cells, continue the animation) against its current bounds, then invalidates. The layout engine already adds and removes children with `addViewInLayout`/`removeViewInLayout`, so the step is valid outside a layout pass; this is how the platform `ListView` moves children during a fling. If a real layout is pending when the frame fires, the frame yields and the layout pass carries the animation forward. `docs/architecture.md` describes the two entry points.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update

## How Has This Been Tested?
- `AnimationFrameSchedulingTest` (written first; 4 cases failed on the previous commit): a drag frame moves the cells with zero layout passes and zero layout requests, a fling runs to rest on animation frames alone and lands on the snap position, a frame that fires while a layout is pending yields to the layout pass, and the earlier scheduling cases still hold.
- `ListViewInstrumentedTest.animationFrames_moveTheChildrenWithoutALayoutPass` drives the frame step on a real framework (CI emulator): a drag frame and a fling frame move the children, the view is never marked as needing layout, and recycling keeps the child count below the item count. Compiled locally; runs in CI.

- [x] Unit tests (`./gradlew :library:test`: 96 pass, `spotlessCheck` and `:library:lintDebug` clean)
- [x] Instrumented tests (added; run by the CI emulator job)
- [ ] Manual testing on device/emulator

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
