### PR TITLE
Snap with a decelerate curve and a distance-proportional duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ everything around them is new.
 
 ### Changed
 
+- Snap, page, tap-to-snap, and programmatic scrolls use a decelerate curve
+  with a duration proportional to the distance (100 ms per inch, stretched
+  for the deceleration, capped at 500 ms), the same numbers RecyclerView's
+  snap helper uses. The old fixed 500 ms viscous-fluid curve covered 97% of
+  the distance in its first half and crawled the last few pixels one at a
+  time over the second half, which read as stutter at the end of a scroll.
+  Fling physics are unchanged.
 - Animation frames (fling, snap, page, drag) run the layout step directly
   from a `postOnAnimation` callback and invalidate, instead of posting a
   `requestLayout()` that re-measured and re-laid out the whole ancestor

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
@@ -20,9 +20,6 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
         notMoving
     }
 
-    private static final int FINAL_ANIMATE_TO_DURATION_IN_MILLISECONDS = 500;
-
-    private static final int ANIMATION_DURATION = 500;
     private final int mScaledTouchSlop;
     private final boolean mIsVerticalScroll;
     private final Animation mAnimation = new Animation();
@@ -73,7 +70,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
         if (mIsViewPager) {
             final int viewPageDistance =
                     mLayoutManagerBridge.getViewPagerScrollDistance(velocityX, velocityY);
-            mScrollAnimator.startScroll(viewPageDistance, ANIMATION_DURATION);
+            mScrollAnimator.snapTo(viewPageDistance);
         } else {
             mScrollAnimator.flingBy(velocityX, velocityY);
         }
@@ -122,7 +119,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
         final int scrollDistance = mLayoutManagerBridge.onSingleTapUp(mViewGroup, view);
         setState(State.flinging);
 
-        mScrollAnimator.startScroll(scrollDistance, ANIMATION_DURATION);
+        mScrollAnimator.snapTo(scrollDistance);
         mFrameScheduler.requestAnimationFrame();
 
         return true;
@@ -160,7 +157,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
             final int scrollDistance = mLayoutManagerBridge.snapTo(mViewGroup);
             if (scrollDistance == 0) return;
             setState(State.snapingTo);
-            mScrollAnimator.startScroll(scrollDistance, ANIMATION_DURATION);
+            mScrollAnimator.snapTo(scrollDistance);
             mFrameScheduler.requestAnimationFrame();
         }
     }
@@ -205,7 +202,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
     // Is this used at all?
     public void setAnimateToDistance(final int animate) {
         setState(State.animatingTo);
-        mScrollAnimator.startScroll(animate, FINAL_ANIMATE_TO_DURATION_IN_MILLISECONDS);
+        mScrollAnimator.snapTo(animate);
         mFrameScheduler.requestAnimationFrame();
     }
 

--- a/library/src/main/java/mobi/parchment/widget/adapterview/ScrollAnimator.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/ScrollAnimator.java
@@ -4,27 +4,49 @@
 package mobi.parchment.widget.adapterview;
 
 import android.content.Context;
+import android.util.DisplayMetrics;
+import android.view.animation.DecelerateInterpolator;
 import android.widget.Scroller;
 
 public class ScrollAnimator {
+    private static final float SNAP_MILLISECONDS_PER_INCH = 100f;
+    // RecyclerView's LinearSmoothScroller stretches a snap's time by this ratio so a
+    // DecelerateInterpolator starts at the linear scrolling speed instead of faster.
+    private static final float DECELERATION_TIME_RATIO = 0.3356f;
+    private static final int MAX_SNAP_DURATION_MILLISECONDS = 500;
+
     private final boolean mIsVertical;
     private final Scroller mScroller;
+    private final float mSnapMillisecondsPerPixel;
 
     public ScrollAnimator(final Context context, final boolean isVertical) {
         mIsVertical = isVertical;
-        mScroller = new Scroller(context);
+        mScroller = new Scroller(context, new DecelerateInterpolator());
+        final DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+        mSnapMillisecondsPerPixel = SNAP_MILLISECONDS_PER_INCH / displayMetrics.densityDpi;
     }
 
-    public void startScroll(final int scrollDistance, final int animationDuration) {
-        if (mIsVertical) mScroller.startScroll(0, 0, 0, scrollDistance, animationDuration);
-        else mScroller.startScroll(0, 0, scrollDistance, 0, animationDuration);
+    public void snapTo(final int scrollDistance) {
+        final int duration = getSnapDuration(scrollDistance);
+        if (mIsVertical) mScroller.startScroll(0, 0, 0, scrollDistance, duration);
+        else mScroller.startScroll(0, 0, scrollDistance, 0, duration);
+    }
+
+    private int getSnapDuration(final int scrollDistance) {
+        final float scrollTime = Math.abs(scrollDistance) * mSnapMillisecondsPerPixel;
+        final int duration = (int) Math.ceil(scrollTime / DECELERATION_TIME_RATIO);
+        return Math.min(duration, MAX_SNAP_DURATION_MILLISECONDS);
+    }
+
+    public int getDuration() {
+        return mScroller.getDuration();
     }
 
     public boolean isFinished() {
         return mScroller.isFinished();
     }
 
-    public void forceFinished(boolean finished) {
+    public void forceFinished(final boolean finished) {
         mScroller.forceFinished(finished);
     }
 
@@ -37,7 +59,7 @@ public class ScrollAnimator {
         else return mScroller.getCurrX();
     }
 
-    public void flingBy(float velocityX, float velocityY) {
+    public void flingBy(final float velocityX, final float velocityY) {
         if (mIsVertical)
             mScroller.fling(0, 0, 0, (int) velocityY, 0, 0, Integer.MIN_VALUE, Integer.MAX_VALUE);
         else mScroller.fling(0, 0, (int) velocityX, 0, Integer.MIN_VALUE, Integer.MAX_VALUE, 0, 0);

--- a/library/src/test/java/mobi/parchment/widget/adapterview/ScrollAnimatorTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/ScrollAnimatorTest.java
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+import java.time.Duration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowSystemClock;
+
+@RunWith(RobolectricTestRunner.class)
+public class ScrollAnimatorTest {
+
+    private static final boolean HORIZONTAL = false;
+    private static final boolean VERTICAL = true;
+    private static final int ONE_INCH_AT_ROBOLECTRIC_DENSITY = 160;
+
+    private final Context mContext = ApplicationProvider.getApplicationContext();
+
+    @Test
+    public void snapTo_takesOneHundredMillisecondsPerInchStretchedForDeceleration() {
+        final ScrollAnimator animator = new ScrollAnimator(mContext, HORIZONTAL);
+
+        animator.snapTo(ONE_INCH_AT_ROBOLECTRIC_DENSITY);
+
+        assertThat(animator.getDuration()).isEqualTo(298);
+    }
+
+    @Test
+    public void snapTo_backwardsTakesTheSameTimeAsForwards() {
+        final ScrollAnimator animator = new ScrollAnimator(mContext, HORIZONTAL);
+
+        animator.snapTo(-ONE_INCH_AT_ROBOLECTRIC_DENSITY);
+
+        assertThat(animator.getDuration()).isEqualTo(298);
+    }
+
+    @Test
+    public void snapTo_isCappedAtHalfASecond() {
+        final ScrollAnimator animator = new ScrollAnimator(mContext, HORIZONTAL);
+
+        animator.snapTo(5000);
+
+        assertThat(animator.getDuration()).isEqualTo(500);
+    }
+
+    @Test
+    public void snapTo_deceleratesInsteadOfCrawlingAtTheEnd() {
+        final ScrollAnimator animator = new ScrollAnimator(mContext, HORIZONTAL);
+        animator.snapTo(100);
+        final int duration = animator.getDuration();
+
+        ShadowSystemClock.advanceBy(Duration.ofMillis(duration / 2));
+        assertThat(animator.computeScrollOffset()).isTrue();
+        assertThat(animator.getCurrrentOffset()).isEqualTo(75);
+
+        ShadowSystemClock.advanceBy(Duration.ofMillis(duration / 4));
+        assertThat(animator.computeScrollOffset()).isTrue();
+        assertThat(animator.getCurrrentOffset()).isEqualTo(93);
+
+        ShadowSystemClock.advanceBy(Duration.ofMillis(duration));
+        assertThat(animator.computeScrollOffset()).isTrue();
+        assertThat(animator.getCurrrentOffset()).isEqualTo(100);
+        assertThat(animator.isFinished()).isTrue();
+    }
+
+    @Test
+    public void snapTo_vertical_movesTheVerticalOffset() {
+        final ScrollAnimator animator = new ScrollAnimator(mContext, VERTICAL);
+        animator.snapTo(100);
+
+        ShadowSystemClock.advanceBy(Duration.ofMillis(animator.getDuration()));
+        animator.computeScrollOffset();
+
+        assertThat(animator.getCurrrentOffset()).isEqualTo(100);
+    }
+
+    @Test
+    public void flingBy_keepsTheFlingPhysicsUnchangedByTheSnapCurve() {
+        final ScrollAnimator animator = new ScrollAnimator(mContext, HORIZONTAL);
+
+        animator.flingBy(-1000f, 0f);
+
+        assertThat(animator.getDuration()).isEqualTo(555);
+        ShadowSystemClock.advanceBy(Duration.ofMillis(555));
+        animator.computeScrollOffset();
+        assertThat(animator.getCurrrentOffset()).isEqualTo(-194);
+    }
+
+    @Test
+    public void flingBy_vertical_movesTheVerticalOffset() {
+        final ScrollAnimator animator = new ScrollAnimator(mContext, VERTICAL);
+
+        animator.flingBy(0f, -1000f);
+
+        ShadowSystemClock.advanceBy(Duration.ofMillis(animator.getDuration()));
+        animator.computeScrollOffset();
+        assertThat(animator.getCurrrentOffset()).isEqualTo(-194);
+    }
+}


### PR DESCRIPTION
## Description
Stacked on #33 (base branch `refactor/animation-frames-without-layout`); only the last commit belongs to this PR.

Every `startScroll`-based animation (snap after a stop, tap-to-snap, page flip, programmatic scroll) ran for a fixed 500 ms on `Scroller`'s default viscous-fluid interpolator. That curve covers 97% of the distance in its first half (measured in Robolectric: 97 of 100 px at 250 ms) and crawls the remaining 3% over the second half, one pixel every few frames; a 5 px snap after a fling moved one pixel every 100 ms. That is the visible stutter at the end of a scroll.

`ScrollAnimator` now builds its `Scroller` with a `DecelerateInterpolator`, and `snapTo(distance)` derives the duration from the distance: 100 ms per inch, stretched by the deceleration ratio RecyclerView's `LinearSmoothScroller` uses so the curve starts at the linear speed, capped at 500 ms. Fling mode ignores the interpolator, so fling physics are unchanged (pinned by a test).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## How Has This Been Tested?
New `ScrollAnimatorTest` (7 cases): duration for one inch at the Robolectric density (298 ms), the same backwards, the 500 ms cap, the decelerate samples (75 px at half time, 93 px at three quarters, 100 px and finished at the end), the vertical axis for snaps and flings, and a fling's distance and duration unchanged by the new interpolator. The animator and view-level suites (drag, fling, snap to rest) still pass on the new curve.

- [x] Unit tests (`./gradlew :library:test`: 103 pass, `spotlessCheck` and `:library:lintDebug` clean)
- [ ] Instrumented tests
- [ ] Manual testing on device/emulator

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
