### PR TITLE
Hand off from a finished animation to its snap in the same frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ everything around them is new.
 
 ### Fixed
 
+- A fling, page, or programmatic scroll that ends hands off to its snap in
+  the same frame, after that frame's layout. The snap used to start one frame
+  later and was started twice, which left a frame with no motion at the
+  handoff. A layout pass while the view is at rest away from a snap position
+  still starts the snap, as before.
 - Animations no longer call `requestLayout()` from inside the layout pass.
   `AdapterAnimator` asks an `AnimationFrameScheduler` (implemented by the
   view) for the next frame, and the view posts a single coalesced request,

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
@@ -221,6 +221,7 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
         if (layoutManager != null) {
             layoutManager.layout(this, animation, left, top, right, bottom);
         }
+        childTouchListener.onFrameLaidOut();
         final AdapterAnimator.State state = childTouchListener.getState();
         switch (state) {
             case animatingTo:

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
@@ -163,19 +163,23 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
     }
 
     public void computeScrollOffset() {
-        mComputedOffsetReady =
-                !mScrollAnimator.isFinished() && mScrollAnimator.computeScrollOffset();
+        mComputedOffsetReady = false;
+        if (mState == State.scrolling) return;
 
-        if (!mComputedOffsetReady) {
-            final boolean isScrolling = mState.equals(State.scrolling);
-            if (!isScrolling) setState(State.notMoving);
-            return;
-        }
+        if (mScrollAnimator.isFinished()) setState(State.notMoving);
+        if (mState == State.notMoving) return;
+
+        mComputedOffsetReady = mScrollAnimator.computeScrollOffset();
+        if (!mComputedOffsetReady) return;
 
         final int currentOffset = mScrollAnimator.getCurrrentOffset();
-
         mAnimation.setDisplacement(currentOffset - mPreviousDisplacement);
         mPreviousDisplacement = currentOffset;
+    }
+
+    public void onFrameLaidOut() {
+        if (mState == State.scrolling || mState == State.notMoving) return;
+        if (mScrollAnimator.isFinished()) setState(State.notMoving);
     }
 
     public Animation getAnimation() {
@@ -188,9 +192,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
             case animatingTo:
             case snapingTo:
             case flinging:
-                if (mComputedOffsetReady) return mAnimation;
-                setState(State.notMoving);
-                mAnimation.newAnimation();
+                if (!mComputedOffsetReady) mAnimation.setDisplacement(0);
                 return mAnimation;
             case notMoving:
             default:

--- a/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.FrameLayout;
 import androidx.test.core.app.ApplicationProvider;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import mobi.parchment.widget.adapterview.listview.ListLayoutManager;
@@ -20,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowSystemClock;
 
 @RunWith(RobolectricTestRunner.class)
 public class AdapterAnimatorTest {
@@ -27,11 +29,16 @@ public class AdapterAnimatorTest {
     private static final int VIEW_GROUP_SIZE = 300;
     private static final int VIEW_SIZE = 100;
     private static final int ADAPTER_SIZE = 10;
+    private static final float FLING_VELOCITY = -1000f;
+    private static final int FLING_DISTANCE = -194;
+    private static final long FLING_DURATION = 555;
+    private static final long MAX_SNAP_DURATION = 500;
 
     private final Context mContext = ApplicationProvider.getApplicationContext();
     private final RecordingFrameScheduler mFrameScheduler = new RecordingFrameScheduler();
     private final MyViewGroup mViewGroup = new MyViewGroup(mContext);
     private final AdapterViewManager mAdapterViewManager = new AdapterViewManager();
+    private final Animation mAnimation = new Animation();
     private ListLayoutManager mLayoutManager;
     private AdapterAnimator mAdapterAnimator;
 
@@ -75,14 +82,111 @@ public class AdapterAnimatorTest {
     }
 
     @Test
-    public void getAnimation_beforeAnyScrollOffsetIsComputed_stopsTheFling() {
+    public void getAnimation_beforeAnyScrollOffsetIsComputed_appliesNothingAndKeepsFlinging() {
         mAdapterAnimator.onFling(down(), up(), 1000f, 0f);
         assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.flinging);
 
         final Animation animation = mAdapterAnimator.getAnimation();
 
-        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.notMoving);
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.flinging);
         assertThat(animation.getDisplacement()).isEqualTo(0);
+    }
+
+    @Test
+    public void aFlingThatEndsThisFrame_handsOffToItsSnapInTheSameFrame() {
+        layOutCenterSnappingList();
+        mAdapterAnimator.onFling(down(), up(), FLING_VELOCITY, 0f);
+        mAdapterAnimator.onUp();
+        ShadowSystemClock.advanceBy(Duration.ofMillis(FLING_DURATION + 1));
+        mFrameScheduler.mRequests = 0;
+
+        layout();
+        assertThat(mLayoutManager.getViewForPosition(0).getLeft()).isEqualTo(100 + FLING_DISTANCE);
+        mAdapterAnimator.onFrameLaidOut();
+
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.snapingTo);
+        assertThat(mFrameScheduler.mRequests).isEqualTo(1);
+
+        ShadowSystemClock.advanceBy(Duration.ofMillis(16));
+        assertThat(nextFrameDisplacement()).isNotEqualTo(0);
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.snapingTo);
+    }
+
+    @Test
+    public void anAnimationThatEndsOnTheSnapPosition_comesToRestWithoutASnap() {
+        layOutCenterSnappingList();
+        mAdapterAnimator.setAnimateToDistance(-VIEW_GROUP_SIZE);
+        ShadowSystemClock.advanceBy(Duration.ofMillis(MAX_SNAP_DURATION + 1));
+        mFrameScheduler.mRequests = 0;
+
+        layout();
+        assertThat(mLayoutManager.getViewForPosition(3).getLeft()).isEqualTo(100);
+        mAdapterAnimator.onFrameLaidOut();
+
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.notMoving);
+        assertThat(mFrameScheduler.mRequests).isEqualTo(0);
+    }
+
+    @Test
+    public void onFrameLaidOut_whileStillAnimating_keepsTheAnimationGoing() {
+        layOutCenterSnappingList();
+        mAdapterAnimator.onFling(down(), up(), FLING_VELOCITY, 0f);
+        mAdapterAnimator.onUp();
+        ShadowSystemClock.advanceBy(Duration.ofMillis(16));
+        layout();
+
+        mAdapterAnimator.onFrameLaidOut();
+
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.flinging);
+    }
+
+    @Test
+    public void onFrameLaidOut_whileDragging_keepsScrolling() {
+        layOutCenterSnappingList();
+        mAdapterAnimator.onDown(down());
+        mAdapterAnimator.onScroll(down(), moveTo(45f), 45f, 0f);
+        layout();
+
+        mAdapterAnimator.onFrameLaidOut();
+
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.scrolling);
+    }
+
+    @Test
+    public void onFrameLaidOut_atRest_staysAtRest() {
+        layOutCenterSnappingList();
+        mFrameScheduler.mRequests = 0;
+
+        mAdapterAnimator.onFrameLaidOut();
+
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.notMoving);
+        assertThat(mFrameScheduler.mRequests).isEqualTo(0);
+    }
+
+    @Test
+    public void computeScrollOffset_afterTheScrollerEndedInAnEarlierFrame_stillHandsOff() {
+        layOutCenterSnappingList();
+        mAdapterAnimator.onFling(down(), up(), FLING_VELOCITY, 0f);
+        mAdapterAnimator.onUp();
+        ShadowSystemClock.advanceBy(Duration.ofMillis(FLING_DURATION + 1));
+        layout();
+
+        assertThat(nextFrameDisplacement()).isEqualTo(0);
+
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.snapingTo);
+    }
+
+    @Test
+    public void computeScrollOffset_atRestAwayFromTheSnapPosition_startsTheSnap() {
+        layOutCenterSnappingList();
+        mAnimation.newAnimation();
+        mAnimation.setDisplacement(-45);
+        mLayoutManager.layout(mViewGroup, mAnimation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.notMoving);
+
+        assertThat(nextFrameDisplacement()).isEqualTo(0);
+
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.snapingTo);
     }
 
     @Test

--- a/library/src/test/java/mobi/parchment/widget/adapterview/AnimationFrameSchedulingTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/AnimationFrameSchedulingTest.java
@@ -191,18 +191,17 @@ public class AnimationFrameSchedulingTest {
     }
 
     @Test
-    public void aSnapThatStartsInsideOnLayout_isScheduledNotRequestedDuringLayout() {
+    public void aFlingThatEndsInsideOnLayout_handsOffToItsSnapInThatFrame() {
         fling();
         ShadowSystemClock.advanceBy(Duration.ofSeconds(5));
-        measureAndLayout();
-        assertThat(firstChild().getLeft()).isNotEqualTo(100);
         mListView.reset();
 
         measureAndLayout();
 
+        assertThat(firstChild().getLeft()).isNotEqualTo(100);
         assertThat(mListView.mGestureListener.getState())
                 .isEqualTo(AdapterAnimator.State.snapingTo);
-        assertThat(mListView.mFrameRequests).isGreaterThanOrEqualTo(1);
+        assertThat(mListView.mFramesRun).isEqualTo(0);
         assertThat(mListView.mLayoutRequestsDuringLayout).isEqualTo(0);
         assertThat(mListView.mLayoutRequests).isEqualTo(0);
 


### PR DESCRIPTION
## Description
Stacked on #34 (base branch `fix/snap-animation-curve`); only the last commit belongs to this PR.

When a fling (or page or programmatic scroll) reached its end, the frame that applied the final displacement left the state as `flinging`. The next frame's `computeScrollOffset` found the scroller finished, moved to `notMoving`, computed the snap and started it; `getAnimation` then saw no computed offset, reset the state to `notMoving` again, restarted the same snap, and returned a zero displacement. The result was one frame with no motion at the handoff and a snap started twice.

`AdapterAnimator.onFrameLaidOut`, called by the view right after the layout step, now moves a finished animation to `notMoving` (and into its snap) in the frame the scroller ends, against the positions that frame laid out, so the next frame already carries the first snap displacement. `computeScrollOffset` keeps the same transition as a fallback and still re-checks the snap when a layout pass runs at rest (unchanged behaviour after rotation or a data change). `getAnimation` no longer changes state: without a computed offset it hands back a zero displacement.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## How Has This Been Tested?
Written first against a stub hook (4 failed): `AdapterAnimatorTest` covers the same-frame handoff with a single frame request and a non-zero displacement on the very next frame, an animation that ends on the snap position resting without a snap, the hook while animating, while dragging, and at rest, the fallback in `computeScrollOffset`, and the snap started by a layout at rest; `getAnimation` without a computed offset now keeps flinging with a zero displacement. `AnimationFrameSchedulingTest` checks the handoff inside `onLayout` on an attached `ListView` and that the snap then runs to rest on animation frames.

- [x] Unit tests (`./gradlew :library:test`: 110 pass, `spotlessCheck` and `:library:lintDebug` clean, instrumented sources compile)
- [ ] Instrumented tests
- [ ] Manual testing on device/emulator

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
