### PR TITLE
End a fling on the nearest snap position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ everything around them is new.
 
 ### Changed
 
+- With `snapToPosition` on, a fling ends on the nearest snap position
+  instead of decelerating to a stop and then starting a separate snap. The
+  layout manager computes the adjustment when the fling starts, extrapolating
+  with the edge cell's size when the end lies beyond the visible cells, and
+  the fling's end point is moved there while its physics stay the same.
 - Snap, page, tap-to-snap, and programmatic scrolls use a decelerate curve
   with a duration proportional to the distance (100 ms per inch, stretched
   for the deceleration, capped at 500 ms), the same numbers RecyclerView's

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,17 @@ the content must move to get it there. `LayoutManager` picks the strategy
 once from the attributes; `onScreen` is the default and never moves
 content on its own.
 
+With `snapToPosition` on, a fling is retargeted when it starts:
+`LayoutManager.getFlingSnapAdjustment` takes the distance the fling would
+travel, finds the cell that would land nearest the snap position (walking
+the visible cells, and extrapolating with the edge cell's size plus spacing
+when the end lies beyond them, never past the first or last cell unless
+scrolling is circular), and the animator moves the fling's end point there.
+The fling keeps its physics; only its end changes, so there is one motion
+from finger-up to rest. The snap that follows a stop still runs as a safety
+net for anything the extrapolation could not know, such as cells of
+different sizes.
+
 ## Circular scrolling
 
 `isCircularScroll` is handled entirely in `LayoutManager`: adapter positions

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
@@ -73,10 +73,18 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
             mScrollAnimator.snapTo(viewPageDistance);
         } else {
             mScrollAnimator.flingBy(velocityX, velocityY);
+            endTheFlingOnASnapPosition();
         }
 
         mFrameScheduler.requestAnimationFrame();
         return true;
+    }
+
+    private void endTheFlingOnASnapPosition() {
+        final int finalOffset = mScrollAnimator.getFinalOffset();
+        final int adjustment = mLayoutManagerBridge.getFlingSnapAdjustment(mViewGroup, finalOffset);
+        if (adjustment == 0) return;
+        mScrollAnimator.setFinalOffset(finalOffset + adjustment);
     }
 
     @Override

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
@@ -754,6 +754,59 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         }
     }
 
+    public int getFlingSnapAdjustment(final ViewGroup viewGroup, final int displacement) {
+        final boolean isSnapToPosition = mLayoutManagerAttributes.isSnapToPosition();
+        final boolean isOnScreen = mLayoutManagerAttributes.isSnapPositionOnScreen();
+        if (!isSnapToPosition || isOnScreen || mCells.isEmpty()) return 0;
+
+        final int size = getSizeInsidePadding(viewGroup);
+        final int cellSpacing = getCellSpacing();
+        final Cell firstCell = mCells.get(0);
+        final Cell lastCell = mCells.get(mCells.size() - 1);
+        final int firstDistance = getSnapToPixelDistance(size, getView(firstCell));
+        final int lastDistance = getSnapToPixelDistance(size, getView(lastCell));
+
+        if (displacement > firstDistance) {
+            final int step = getCellSize(firstCell) + cellSpacing;
+            final int steps =
+                    getExtrapolationSteps(
+                            displacement - firstDistance, step, getCellsBeforeFirst());
+            return firstDistance + steps * step - displacement;
+        }
+
+        if (displacement < lastDistance) {
+            final int step = getCellSize(lastCell) + cellSpacing;
+            final int steps =
+                    getExtrapolationSteps(lastDistance - displacement, step, getCellsAfterLast());
+            return lastDistance - steps * step - displacement;
+        }
+
+        int nearestDistance = firstDistance;
+        for (final Cell cell : mCells) {
+            final int distance = getSnapToPixelDistance(size, getView(cell));
+            final boolean isNearer =
+                    Math.abs(distance - displacement) < Math.abs(nearestDistance - displacement);
+            if (isNearer) nearestDistance = distance;
+        }
+        return nearestDistance - displacement;
+    }
+
+    private int getExtrapolationSteps(final int distance, final int step, final int cellLimit) {
+        final int steps = Math.round(distance / (float) step);
+        return Math.min(steps, cellLimit);
+    }
+
+    private int getCellsBeforeFirst() {
+        if (mLayoutManagerAttributes.isCircularScroll()) return Integer.MAX_VALUE;
+        return mStartCellPosition;
+    }
+
+    private int getCellsAfterLast() {
+        if (mLayoutManagerAttributes.isCircularScroll()) return Integer.MAX_VALUE;
+        final int lastCellPosition = mStartCellPosition + mCells.size() - 1;
+        return getCellCount() - 1 - lastCellPosition;
+    }
+
     public int snapTo(final ViewGroup viewGroup) {
         final boolean isSnapToPosition = mLayoutManagerAttributes.isSnapToPosition();
         if (!isSnapToPosition) return 0;

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerBridge.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerBridge.java
@@ -35,6 +35,12 @@ public class LayoutManagerBridge {
         return mLayoutManager.snapTo(viewGroup);
     }
 
+    public int getFlingSnapAdjustment(final ViewGroup viewGroup, final int displacement) {
+        if (mLayoutManager == null) return 0;
+
+        return mLayoutManager.getFlingSnapAdjustment(viewGroup, displacement);
+    }
+
     public int getViewPagerScrollDistance(final float velocityX, final float velocityY) {
         if (mLayoutManager == null) return 0;
         final Move move = getMove(mLayoutManager.isVerticalScroll() ? velocityY : velocityX);

--- a/library/src/main/java/mobi/parchment/widget/adapterview/ScrollAnimator.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/ScrollAnimator.java
@@ -59,6 +59,16 @@ public class ScrollAnimator {
         else return mScroller.getCurrX();
     }
 
+    public int getFinalOffset() {
+        if (mIsVertical) return mScroller.getFinalY();
+        else return mScroller.getFinalX();
+    }
+
+    public void setFinalOffset(final int finalOffset) {
+        if (mIsVertical) mScroller.setFinalY(finalOffset);
+        else mScroller.setFinalX(finalOffset);
+    }
+
     public void flingBy(final float velocityX, final float velocityY) {
         if (mIsVertical)
             mScroller.fling(0, 0, 0, (int) velocityY, 0, 0, Integer.MIN_VALUE, Integer.MAX_VALUE);

--- a/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
@@ -48,15 +48,30 @@ public class AdapterAnimatorTest {
     }
 
     private void setup(final boolean snapToPosition, final SnapPosition snapPosition) {
+        setup(snapToPosition, snapPosition, false);
+    }
+
+    private void setup(
+            final boolean snapToPosition,
+            final SnapPosition snapPosition,
+            final boolean isViewPager) {
         final LayoutManagerAttributes attributes =
                 new LayoutManagerAttributes(
-                        false, snapToPosition, false, 0, snapPosition, 0, false, false, false);
+                        false,
+                        snapToPosition,
+                        isViewPager,
+                        0,
+                        snapPosition,
+                        0,
+                        false,
+                        false,
+                        false);
         mLayoutManager = new ListLayoutManager(mViewGroup, null, mAdapterViewManager, attributes);
         mAdapterAnimator =
                 new AdapterAnimator(
                         mViewGroup,
                         mFrameScheduler,
-                        false,
+                        isViewPager,
                         false,
                         new LayoutManagerBridge(mLayoutManager),
                         ViewConfiguration.get(mContext));
@@ -68,7 +83,14 @@ public class AdapterAnimatorTest {
     }
 
     private void layOutCenterSnappingList() {
-        setup(true, SnapPosition.center);
+        layOutList(true, SnapPosition.center, false);
+    }
+
+    private void layOutList(
+            final boolean snapToPosition,
+            final SnapPosition snapPosition,
+            final boolean isViewPager) {
+        setup(snapToPosition, snapPosition, isViewPager);
         final TestAdapter adapter = new TestAdapter();
         mAdapterViewManager.setAdapter(adapter);
         adapter.setAdapterSize(ADAPTER_SIZE);
@@ -93,15 +115,14 @@ public class AdapterAnimatorTest {
     }
 
     @Test
-    public void aFlingThatEndsThisFrame_handsOffToItsSnapInTheSameFrame() {
+    public void anAnimationThatEndsThisFrameOffTheSnapPosition_handsOffToItsSnapInTheSameFrame() {
         layOutCenterSnappingList();
-        mAdapterAnimator.onFling(down(), up(), FLING_VELOCITY, 0f);
-        mAdapterAnimator.onUp();
-        ShadowSystemClock.advanceBy(Duration.ofMillis(FLING_DURATION + 1));
+        mAdapterAnimator.setAnimateToDistance(-45);
+        ShadowSystemClock.advanceBy(Duration.ofMillis(MAX_SNAP_DURATION + 1));
         mFrameScheduler.mRequests = 0;
 
         layout();
-        assertThat(mLayoutManager.getViewForPosition(0).getLeft()).isEqualTo(100 + FLING_DISTANCE);
+        assertThat(mLayoutManager.getViewForPosition(0).getLeft()).isEqualTo(55);
         mAdapterAnimator.onFrameLaidOut();
 
         assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.snapingTo);
@@ -110,6 +131,50 @@ public class AdapterAnimatorTest {
         ShadowSystemClock.advanceBy(Duration.ofMillis(16));
         assertThat(nextFrameDisplacement()).isNotEqualTo(0);
         assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.snapingTo);
+    }
+
+    @Test
+    public void onFling_withSnapping_endsTheFlingOnTheNearestSnapPosition() {
+        layOutCenterSnappingList();
+        mAdapterAnimator.onFling(down(), up(), FLING_VELOCITY, 0f);
+        mAdapterAnimator.onUp();
+        ShadowSystemClock.advanceBy(Duration.ofMillis(FLING_DURATION + 1));
+        mFrameScheduler.mRequests = 0;
+
+        layout();
+        mAdapterAnimator.onFrameLaidOut();
+
+        assertThat(mLayoutManager.getViewForPosition(2).getLeft()).isEqualTo(100);
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.notMoving);
+        assertThat(mFrameScheduler.mRequests).isEqualTo(0);
+    }
+
+    @Test
+    public void onFling_withoutSnapping_keepsTheNaturalFlingEnd() {
+        layOutList(false, SnapPosition.onScreen, false);
+        mAdapterAnimator.onFling(down(), up(), FLING_VELOCITY, 0f);
+        mAdapterAnimator.onUp();
+        ShadowSystemClock.advanceBy(Duration.ofMillis(FLING_DURATION + 1));
+
+        layout();
+
+        assertThat(mLayoutManager.getViewForPosition(0)).isNull();
+        assertThat(mLayoutManager.getViewForPosition(1).getLeft())
+                .isEqualTo(VIEW_SIZE + FLING_DISTANCE);
+    }
+
+    @Test
+    public void onFling_asAViewPager_movesExactlyOnePage() {
+        layOutList(true, SnapPosition.start, true);
+        layout();
+        mFrameScheduler.mRequests = 0;
+
+        mAdapterAnimator.onFling(down(), up(), FLING_VELOCITY, 0f);
+        mAdapterAnimator.onUp();
+        ShadowSystemClock.advanceBy(Duration.ofMillis(MAX_SNAP_DURATION + 1));
+
+        assertThat(mFrameScheduler.mRequests).isEqualTo(1);
+        assertThat(nextFrameDisplacement()).isEqualTo(-VIEW_GROUP_SIZE);
     }
 
     @Test
@@ -166,9 +231,8 @@ public class AdapterAnimatorTest {
     @Test
     public void computeScrollOffset_afterTheScrollerEndedInAnEarlierFrame_stillHandsOff() {
         layOutCenterSnappingList();
-        mAdapterAnimator.onFling(down(), up(), FLING_VELOCITY, 0f);
-        mAdapterAnimator.onUp();
-        ShadowSystemClock.advanceBy(Duration.ofMillis(FLING_DURATION + 1));
+        mAdapterAnimator.setAnimateToDistance(-45);
+        ShadowSystemClock.advanceBy(Duration.ofMillis(MAX_SNAP_DURATION + 1));
         layout();
 
         assertThat(nextFrameDisplacement()).isEqualTo(0);

--- a/library/src/test/java/mobi/parchment/widget/adapterview/AnimationFrameSchedulingTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/AnimationFrameSchedulingTest.java
@@ -191,14 +191,29 @@ public class AnimationFrameSchedulingTest {
     }
 
     @Test
-    public void aFlingThatEndsInsideOnLayout_handsOffToItsSnapInThatFrame() {
+    public void aFlingThatEndsInsideOnLayout_comesToRestOnTheSnapPosition() {
         fling();
         ShadowSystemClock.advanceBy(Duration.ofSeconds(5));
         mListView.reset();
 
         measureAndLayout();
 
-        assertThat(firstChild().getLeft()).isNotEqualTo(100);
+        assertThat(mListView.mGestureListener.getState())
+                .isEqualTo(AdapterAnimator.State.notMoving);
+        assertThat(mListView.getChildAt(2).getLeft()).isEqualTo(100);
+        assertThat(mListView.mLayoutRequestsDuringLayout).isEqualTo(0);
+        assertThat(mListView.mLayoutRequests).isEqualTo(0);
+    }
+
+    @Test
+    public void anAnimationThatEndsInsideOnLayoutOffTheSnapPosition_handsOffToItsSnapInThatFrame() {
+        mListView.mGestureListener.setAnimateToDistance(-45);
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(5));
+        mListView.reset();
+
+        measureAndLayout();
+
+        assertThat(firstChild().getLeft()).isEqualTo(55);
         assertThat(mListView.mGestureListener.getState())
                 .isEqualTo(AdapterAnimator.State.snapingTo);
         assertThat(mListView.mFramesRun).isEqualTo(0);
@@ -211,7 +226,7 @@ public class AnimationFrameSchedulingTest {
                 .isEqualTo(AdapterAnimator.State.notMoving);
         assertThat(mListView.mFramesRun).isGreaterThan(1);
         assertThat(mListView.mLayoutRequestsDuringLayout).isEqualTo(0);
-        assertThat(mListView.getChildAt(2).getLeft()).isEqualTo(100);
+        assertThat(firstChild().getLeft()).isEqualTo(100);
     }
 
     private void fling() {

--- a/library/src/test/java/mobi/parchment/widget/adapterview/ListLayoutManagerFlingSnapTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/ListLayoutManagerFlingSnapTest.java
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import androidx.test.core.app.ApplicationProvider;
+import java.util.ArrayList;
+import java.util.List;
+import mobi.parchment.widget.adapterview.listview.ListLayoutManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class ListLayoutManagerFlingSnapTest {
+
+    private static final int VIEW_GROUP_SIZE = 300;
+    private static final int VIEW_SIZE = 100;
+    private static final int ADAPTER_SIZE = 10;
+    private static final boolean NOT_CIRCULAR = false;
+    private static final boolean CIRCULAR = true;
+    private static final boolean SNAP_TO_POSITION = true;
+    private static final boolean NO_SNAP_TO_POSITION = false;
+    private static final boolean NOT_VIEW_PAGER = false;
+    private static final boolean NO_SELECT_ON_SNAP = false;
+    private static final boolean NO_SELECT_WHILE_SCROLLING = false;
+    private static final boolean HORIZONTAL = false;
+
+    private final MyViewGroup mViewGroup =
+            new MyViewGroup(ApplicationProvider.getApplicationContext());
+    private final AdapterViewManager mAdapterViewManager = new AdapterViewManager();
+    private final TestAdapter mTestAdapter = new TestAdapter();
+    private final Animation mAnimation = new Animation();
+    private ListLayoutManager mListLayoutManager;
+
+    private void setup(final SnapPosition snapPosition) {
+        setup(snapPosition, SNAP_TO_POSITION, NOT_CIRCULAR, 0, 0, 0, ADAPTER_SIZE);
+    }
+
+    private void setup(
+            final SnapPosition snapPosition,
+            final boolean snapToPosition,
+            final boolean isCircularScroll,
+            final int cellSpacing,
+            final int startPadding,
+            final int endPadding,
+            final int adapterSize) {
+        final LayoutManagerAttributes attributes =
+                new LayoutManagerAttributes(
+                        isCircularScroll,
+                        snapToPosition,
+                        NOT_VIEW_PAGER,
+                        0,
+                        snapPosition,
+                        cellSpacing,
+                        NO_SELECT_ON_SNAP,
+                        NO_SELECT_WHILE_SCROLLING,
+                        HORIZONTAL);
+        mViewGroup.setPadding(startPadding, 0, endPadding, 0);
+        mListLayoutManager =
+                new ListLayoutManager(mViewGroup, null, mAdapterViewManager, attributes);
+        mAdapterViewManager.setAdapter(mTestAdapter);
+        mTestAdapter.setAdapterSize(adapterSize);
+
+        final int measureSpec =
+                View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
+        mViewGroup.measure(measureSpec, measureSpec);
+        mViewGroup.layout(0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+
+        mAnimation.newAnimation();
+        layout();
+    }
+
+    private void layout() {
+        mListLayoutManager.layout(mViewGroup, mAnimation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+    }
+
+    private void scrollBy(final int displacement) {
+        mAnimation.setDisplacement(displacement);
+        layout();
+    }
+
+    private int adjustmentFor(final int flingDisplacement) {
+        return mListLayoutManager.getFlingSnapAdjustment(mViewGroup, flingDisplacement);
+    }
+
+    @Test
+    public void centerSnap_flingEndingBetweenVisibleCells_endsOnTheNearerOne() {
+        setup(SnapPosition.center);
+        assertThat(mListLayoutManager.getViewForPosition(0).getLeft()).isEqualTo(100);
+
+        assertThat(adjustmentFor(-230)).isEqualTo(30);
+        assertThat(adjustmentFor(-160)).isEqualTo(-40);
+    }
+
+    @Test
+    public void centerSnap_flingEndingOnAVisibleCell_needsNoAdjustment() {
+        setup(SnapPosition.center);
+
+        assertThat(adjustmentFor(-100)).isEqualTo(0);
+    }
+
+    @Test
+    public void centerSnap_flingEndingBeyondTheVisibleCells_extrapolatesWithTheLastCellSize() {
+        setup(SnapPosition.center);
+
+        assertThat(adjustmentFor(-730)).isEqualTo(30);
+    }
+
+    @Test
+    public void centerSnap_flingEndingPastTheLastCell_endsOnTheLastCell() {
+        setup(SnapPosition.center);
+
+        assertThat(adjustmentFor(-2000)).isEqualTo(1100);
+    }
+
+    @Test
+    public void centerSnap_flingBackBeyondTheVisibleCells_extrapolatesWithTheFirstCellSize() {
+        setup(SnapPosition.center);
+        scrollBy(-500);
+        assertThat(mListLayoutManager.getViewForPosition(5).getLeft()).isEqualTo(100);
+
+        assertThat(adjustmentFor(330)).isEqualTo(-30);
+    }
+
+    @Test
+    public void centerSnap_flingBackPastTheFirstCell_endsOnTheFirstCell() {
+        setup(SnapPosition.center);
+        scrollBy(-500);
+
+        assertThat(adjustmentFor(2000)).isEqualTo(-1500);
+    }
+
+    @Test
+    public void cellSpacing_isPartOfTheExtrapolationStep() {
+        setup(SnapPosition.center, SNAP_TO_POSITION, NOT_CIRCULAR, 10, 0, 0, ADAPTER_SIZE);
+
+        assertThat(adjustmentFor(-560)).isEqualTo(10);
+    }
+
+    @Test
+    public void padding_movesTheSnapPositionInsideThePadding() {
+        setup(SnapPosition.center, SNAP_TO_POSITION, NOT_CIRCULAR, 0, 10, 30, ADAPTER_SIZE);
+        assertThat(mListLayoutManager.getViewForPosition(0).getLeft()).isEqualTo(90);
+
+        assertThat(adjustmentFor(-230)).isEqualTo(30);
+    }
+
+    @Test
+    public void startSnap_flingEndsOnACellStart() {
+        setup(SnapPosition.start);
+        assertThat(mListLayoutManager.getViewForPosition(0).getLeft()).isEqualTo(0);
+
+        assertThat(adjustmentFor(-140)).isEqualTo(40);
+        assertThat(adjustmentFor(-660)).isEqualTo(-40);
+    }
+
+    @Test
+    public void endSnap_flingEndsOnACellEnd() {
+        setup(SnapPosition.end);
+        assertThat(mListLayoutManager.getViewForPosition(0).getRight()).isEqualTo(300);
+
+        assertThat(adjustmentFor(-140)).isEqualTo(40);
+    }
+
+    @Test
+    public void onScreenSnap_neverAdjustsAFling() {
+        setup(SnapPosition.onScreen);
+
+        assertThat(adjustmentFor(-230)).isEqualTo(0);
+    }
+
+    @Test
+    public void withoutSnapToPosition_neverAdjustsAFling() {
+        setup(SnapPosition.center, NO_SNAP_TO_POSITION, NOT_CIRCULAR, 0, 0, 0, ADAPTER_SIZE);
+
+        assertThat(adjustmentFor(-230)).isEqualTo(0);
+    }
+
+    @Test
+    public void circularScroll_extrapolatesWithoutAnEnd() {
+        setup(SnapPosition.center, SNAP_TO_POSITION, CIRCULAR, 0, 0, 0, ADAPTER_SIZE);
+
+        assertThat(adjustmentFor(-2030)).isEqualTo(30);
+        assertThat(adjustmentFor(2030)).isEqualTo(-30);
+    }
+
+    @Test
+    public void emptyAdapter_neverAdjustsAFling() {
+        setup(SnapPosition.center, SNAP_TO_POSITION, NOT_CIRCULAR, 0, 0, 0, 0);
+
+        assertThat(adjustmentFor(-230)).isEqualTo(0);
+    }
+
+    public static final class MyViewGroup extends LinearLayout implements AdapterViewHandler {
+        public final List<View> mViews = new ArrayList<View>();
+
+        public MyViewGroup(final Context context) {
+            super(context);
+        }
+
+        @Override
+        public boolean addViewInAdapterView(
+                final View view, final int index, final ViewGroup.LayoutParams layoutParams) {
+            mViews.add(index, view);
+            return true;
+        }
+
+        @Override
+        public void removeViewInAdapterView(final View view) {
+            mViews.remove(view);
+        }
+    }
+
+    public static final class TestAdapter extends BaseAdapter {
+        private int mAdapterSize;
+
+        public void setAdapterSize(final int adapterSize) {
+            mAdapterSize = adapterSize;
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public int getCount() {
+            return mAdapterSize;
+        }
+
+        @Override
+        public Object getItem(final int position) {
+            return position;
+        }
+
+        @Override
+        public long getItemId(final int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(final int position, final View convertView, final ViewGroup parent) {
+            final FrameLayout view = new FrameLayout(ApplicationProvider.getApplicationContext());
+            view.setTag(position);
+            view.setLayoutParams(
+                    new ViewGroup.LayoutParams(VIEW_SIZE, ViewGroup.LayoutParams.MATCH_PARENT));
+            return view;
+        }
+    }
+}

--- a/library/src/test/java/mobi/parchment/widget/adapterview/ScrollAnimatorTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/ScrollAnimatorTest.java
@@ -93,6 +93,43 @@ public class ScrollAnimatorTest {
     }
 
     @Test
+    public void getFinalOffset_reportsWhereTheFlingWillEnd() {
+        final ScrollAnimator animator = new ScrollAnimator(mContext, HORIZONTAL);
+
+        animator.flingBy(-1000f, 0f);
+
+        assertThat(animator.getFinalOffset()).isEqualTo(-194);
+    }
+
+    @Test
+    public void setFinalOffset_retargetsTheFlingAndKeepsItsDuration() {
+        final ScrollAnimator animator = new ScrollAnimator(mContext, HORIZONTAL);
+        animator.flingBy(-1000f, 0f);
+
+        animator.setFinalOffset(-231);
+
+        assertThat(animator.getFinalOffset()).isEqualTo(-231);
+        assertThat(animator.getDuration()).isEqualTo(555);
+        ShadowSystemClock.advanceBy(Duration.ofMillis(555));
+        animator.computeScrollOffset();
+        assertThat(animator.getCurrrentOffset()).isEqualTo(-231);
+        assertThat(animator.isFinished()).isTrue();
+    }
+
+    @Test
+    public void setFinalOffset_vertical_retargetsTheVerticalFling() {
+        final ScrollAnimator animator = new ScrollAnimator(mContext, VERTICAL);
+        animator.flingBy(0f, -1000f);
+
+        animator.setFinalOffset(-231);
+
+        assertThat(animator.getFinalOffset()).isEqualTo(-231);
+        ShadowSystemClock.advanceBy(Duration.ofMillis(555));
+        animator.computeScrollOffset();
+        assertThat(animator.getCurrrentOffset()).isEqualTo(-231);
+    }
+
+    @Test
     public void flingBy_vertical_movesTheVerticalOffset() {
         final ScrollAnimator animator = new ScrollAnimator(mContext, VERTICAL);
 


### PR DESCRIPTION
## Description
Stacked on #35 (base branch `fix/fling-snap-handoff`); only the last commit belongs to this PR.

With `snapToPosition` on, a fling decelerated to a natural stop and only then started a separate snap animation, so the content came to rest, sped up again, and settled: two motions where the finger expects one.

`LayoutManager.getFlingSnapAdjustment` takes the distance a fling would travel and returns the extra displacement that lands the nearest cell on the snap position. It walks the visible cells, extrapolates with the edge cell's size plus spacing when the end lies beyond them, and never reaches past the first or last cell unless scrolling is circular. `AdapterAnimator.onFling` asks for that adjustment right after starting the fling and moves the `Scroller`'s end point with `setFinalX/Y`, which rescales the fling to the new end while keeping its duration and physics (verified in Robolectric against the real `android.widget.Scroller` and pinned in `ScrollAnimatorTest`). ViewPager flings already move exactly one page and are untouched. The snap after a stop stays as a safety net for cells of different sizes. `docs/architecture.md` describes the retargeting under Snapping.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update

## How Has This Been Tested?
Written first against stubs (16 failed):
- New `ListLayoutManagerFlingSnapTest` (14 cases): landing between and on visible cells, extrapolation forwards and backwards with the edge cell's size, the clamps at the first and last cell, cell spacing in the step, padding, start and end snap positions, `onScreen` and `snapToPosition` off returning no adjustment, circular scrolling without clamps, and an empty adapter.
- `ScrollAnimatorTest`: the fling's final offset, retargeting keeps the duration and ends exactly on the new offset, on both axes.
- `AdapterAnimatorTest`: a fling rests on the snap position with no follow-up snap and no extra frame request, the natural end without snapping, and a ViewPager fling moving exactly one page. The same-frame handoff tests from #35 now use a programmatic scroll, since a fling no longer needs a snap.

- [x] Unit tests (`./gradlew :library:test`: 130 pass, `spotlessCheck` and `:library:lintDebug` clean, instrumented sources compile)
- [ ] Instrumented tests
- [ ] Manual testing on device/emulator

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
