### PR TITLE
Accumulate drag displacement between layouts and consume it once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ everything around them is new.
 
 ### Fixed
 
+- Drag distance is accumulated between layout passes and consumed by the pass
+  that applies it. Two move events before one layout used to lose the first
+  delta, and an extra layout pass during a drag (an image loading into a
+  child, for instance) applied the last delta a second time.
 - The post-layout over-scroll check now reuses the draw-limit clamp in both
   directions. `center` and `end` snap positions no longer stop a fling (and
   start a snap) while the first or last cell is merely visible, a frame that

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
@@ -33,6 +33,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
     private boolean mTouchSlopExceeded = false;
 
     private int mPreviousDisplacement;
+    private int mPendingScrollDisplacement;
     private State mState = State.notMoving;
 
     private boolean mComputedOffsetReady;
@@ -102,7 +103,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
         setState(State.scrolling);
         final int displacement =
                 (int) mLayoutManagerBridge.getScrollDisplacement(distanceX, distanceY);
-        mAnimation.setDisplacement(displacement);
+        mPendingScrollDisplacement += displacement;
         mViewGroup.requestLayout();
         return true;
     }
@@ -149,6 +150,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
 
         mState = state;
         mPreviousDisplacement = 0;
+        if (state != State.scrolling) mPendingScrollDisplacement = 0;
 
         // This snaps to the position when the animation is finished.
         if (state == State.notMoving && mLayoutManagerBridge != null) {
@@ -179,6 +181,8 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
     public Animation getAnimation() {
         switch (mState) {
             case scrolling:
+                mAnimation.setDisplacement(mPendingScrollDisplacement);
+                mPendingScrollDisplacement = 0;
                 return mAnimation;
             case jumpingTo:
             case animatingTo:

--- a/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
@@ -60,8 +60,70 @@ public class AdapterAnimatorTest {
         assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.flinging);
     }
 
+    @Test
+    public void onScroll_twiceBeforeALayout_accumulatesTheDisplacement() {
+        mAdapterAnimator.onDown(down());
+        mAdapterAnimator.onScroll(down(), moveTo(100f), -100f, 0f);
+        mAdapterAnimator.onScroll(down(), moveTo(130f), -30f, 0f);
+
+        assertThat(nextFrameDisplacement()).isEqualTo(130);
+    }
+
+    @Test
+    public void getAnimation_whileScrolling_consumesTheDisplacement() {
+        mAdapterAnimator.onDown(down());
+        mAdapterAnimator.onScroll(down(), moveTo(100f), -100f, 0f);
+        assertThat(nextFrameDisplacement()).isEqualTo(100);
+
+        assertThat(nextFrameDisplacement()).isEqualTo(0);
+        assertThat(mAdapterAnimator.getState()).isEqualTo(AdapterAnimator.State.scrolling);
+    }
+
+    @Test
+    public void onScroll_afterTheDisplacementWasConsumed_startsFromZero() {
+        mAdapterAnimator.onDown(down());
+        mAdapterAnimator.onScroll(down(), moveTo(100f), -100f, 0f);
+        nextFrameDisplacement();
+
+        mAdapterAnimator.onScroll(down(), moveTo(120f), -20f, 0f);
+
+        assertThat(nextFrameDisplacement()).isEqualTo(20);
+    }
+
+    @Test
+    public void onDown_dropsAScrollDisplacementThatWasNeverLaidOut() {
+        mAdapterAnimator.onDown(down());
+        mAdapterAnimator.onScroll(down(), moveTo(100f), -100f, 0f);
+
+        mAdapterAnimator.onDown(down());
+        mAdapterAnimator.onScroll(down(), moveTo(105f), -5f, 0f);
+
+        assertThat(nextFrameDisplacement()).isEqualTo(5);
+    }
+
+    @Test
+    public void onFling_dropsAScrollDisplacementThatWasNeverLaidOut() {
+        mAdapterAnimator.onDown(down());
+        mAdapterAnimator.onScroll(down(), moveTo(100f), -100f, 0f);
+        mAdapterAnimator.onFling(down(), up(), 1000f, 0f);
+
+        mAdapterAnimator.onDown(down());
+        mAdapterAnimator.onScroll(down(), moveTo(105f), -5f, 0f);
+
+        assertThat(nextFrameDisplacement()).isEqualTo(5);
+    }
+
+    private int nextFrameDisplacement() {
+        mAdapterAnimator.computeScrollOffset();
+        return mAdapterAnimator.getAnimation().getDisplacement();
+    }
+
     private static MotionEvent down() {
         return MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 0f, 0f, 0);
+    }
+
+    private static MotionEvent moveTo(final float x) {
+        return MotionEvent.obtain(0, 10, MotionEvent.ACTION_MOVE, x, 0f, 0);
     }
 
     private static MotionEvent up() {


### PR DESCRIPTION
## Description
Replaces #29, which GitHub closed when its base branch was deleted after #28 merged; same commit, rebased onto `main`.

`AdapterAnimator.onScroll` overwrote the pending displacement with each move event, and `getAnimation()` handed the same value back on every layout pass while the state stayed `scrolling`. Two move events before one layout lost the first delta. An extra layout pass during a drag (a child `ImageView` requesting layout when its bitmap arrives, or a second pass forced by `ViewRootImpl`) applied the last delta a second time, which shows as a jump under the finger.

Move deltas now add up in a pending counter, `getAnimation()` moves the sum into the frame's `Animation` and zeroes it, and any state change away from `scrolling` drops what was never laid out.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## How Has This Been Tested?
Five new cases in `AdapterAnimatorTest`, written first (accumulation and consumption failed on the old code): two moves before a layout add up, a second layout in the same drag gets 0, a move after a consumed frame starts from zero, and `onDown`/`onFling` drop a displacement that was never laid out.

- [x] Unit tests (`./gradlew :library:test`: 70 pass, `spotlessCheck` clean)
- [ ] Instrumented tests
- [ ] Manual testing on device/emulator

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
