### PR TITLE
Sample: request each photo at the size the layout will show it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ everything around them is new.
 
 ### Changed
 
+- Sample: each photo is requested from the Unsplash resizer at the size it
+  will be shown at, instead of a fixed 800px wide image for every cell. The
+  size is a pair of dimension resources per sample screen, so the existing
+  `-port` and `sw###dp` qualifiers pick it the same way they already pick the
+  cell sizes themselves; the three that a layout dimension already states
+  alias it rather than repeating the number. Requests are in device pixels,
+  so density is applied once by `getDimensionPixelSize`.
 - With `snapToPosition` on, a fling ends on the nearest snap position
   instead of decelerating to a stop and then starting a separate snap. The
   layout manager computes the adjustment when the fling starts, extrapolating

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ everything around them is new.
   cell sizes themselves; the three that a layout dimension already states
   alias it rather than repeating the number. Requests are in device pixels,
   so density is applied once by `getDimensionPixelSize`.
+- Sample: Picasso is built with a memory cache of a third of the heap instead
+  of the seventh it sizes itself at. A photo requested at the size of the view
+  is several times larger than the fixed 800px one it replaces, and on a
+  256MB-heap device only three GridPatternView cells fit in the default cache,
+  so scrolling back evicted almost everything: 4 hits against 104 misses over
+  a pass through the pattern view and back. A third of the heap, with the
+  pattern view's request trimmed, makes that 24 hits against 72.
+
 - With `snapToPosition` on, a fling ends on the nearest snap position
   instead of decelerating to a stop and then starting a separate snap. The
   layout manager computes the adjustment when the fling starts, extrapolating

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name="mobi.parchment.SampleApplication"
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/sample/src/main/java/mobi/parchment/BaseActivity.java
+++ b/sample/src/main/java/mobi/parchment/BaseActivity.java
@@ -4,13 +4,30 @@
 package mobi.parchment;
 
 import android.app.Activity;
+import android.content.res.Resources;
+import android.os.Bundle;
 
 public abstract class BaseActivity extends Activity {
-    private ProductsAdapter mProductsAdapter = new ProductsAdapter(getLayoutResourceId());
+
+    private ProductsAdapter mProductsAdapter;
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        final Resources resources = getResources();
+        final int widthPixels = resources.getDimensionPixelSize(getPictureRequestWidthDimension());
+        final int heightPixels =
+                resources.getDimensionPixelSize(getPictureRequestHeightDimension());
+        mProductsAdapter = new ProductsAdapter(getLayoutResourceId(), widthPixels, heightPixels);
+    }
 
     public ProductsAdapter getProductsAdapter() {
         return mProductsAdapter;
     }
 
     public abstract int getLayoutResourceId();
+
+    public abstract int getPictureRequestWidthDimension();
+
+    public abstract int getPictureRequestHeightDimension();
 }

--- a/sample/src/main/java/mobi/parchment/PictureUrl.java
+++ b/sample/src/main/java/mobi/parchment/PictureUrl.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment;
+
+public final class PictureUrl {
+
+    private static final String PHOTO_PREFIX = "https://images.unsplash.com/photo-";
+    private static final int QUALITY = 75;
+
+    private PictureUrl() {}
+
+    public static String forSize(final String slug, final int widthPixels, final int heightPixels) {
+        final String size = "?w=" + widthPixels + "&h=" + heightPixels;
+        final String crop = "&fit=crop";
+        final String quality = "&q=" + QUALITY;
+        return PHOTO_PREFIX + slug + size + crop + quality;
+    }
+}

--- a/sample/src/main/java/mobi/parchment/ProductsAdapter.java
+++ b/sample/src/main/java/mobi/parchment/ProductsAdapter.java
@@ -18,48 +18,45 @@ import mobi.parchment.sample.R;
 
 public class ProductsAdapter extends BaseAdapter {
 
-    private static final String UNSPLASH_PREFIX = "https://images.unsplash.com/photo-";
-    private static final String UNSPLASH_SUFFIX = "?w=800&q=75";
-
     private final int mLayoutResourceId;
+    private final int mWidthPixels;
+    private final int mHeightPixels;
+    private final List<Picture> mPictures;
 
-    public ProductsAdapter(final int layoutResourceId) {
+    public ProductsAdapter(
+            final int layoutResourceId, final int widthPixels, final int heightPixels) {
         super();
         mLayoutResourceId = layoutResourceId;
+        mWidthPixels = widthPixels;
+        mHeightPixels = heightPixels;
         mPictures = getPictures();
-    }
-
-    private static String url(final String slug) {
-        return UNSPLASH_PREFIX + slug + UNSPLASH_SUFFIX;
     }
 
     public static List<Picture> getPictures() {
         final List<Picture> pictures = new ArrayList<Picture>();
-        pictures.add(new Picture(url("1506905925346-21bda4d32df4"), "Above the cloud line"));
-        pictures.add(new Picture(url("1418065460487-3e41a6c84dc5"), "Fog in the pines"));
-        pictures.add(new Picture(url("1439853949127-fa647821eba0"), "Glacier valley"));
-        pictures.add(new Picture(url("1444927714506-8492d94b4e3d"), "Blue ridges"));
-        pictures.add(new Picture(url("1505765050516-f72dcac9c60e"), "Peaks in cloud"));
-        pictures.add(new Picture(url("1483728642387-6c3bdd6c93e5"), "Watzmann at dusk"));
-        pictures.add(new Picture(url("1470071459604-3b5ec3a7fe05"), "Highland light"));
-        pictures.add(new Picture(url("1433086966358-54859d0ed716"), "Multnomah Falls"));
-        pictures.add(new Picture(url("1441974231531-c6227db76b6e"), "Old growth"));
-        pictures.add(new Picture(url("1447752875215-b2761acb3c5d"), "Boardwalk"));
-        pictures.add(new Picture(url("1472214103451-9374bd1c798e"), "Fairy pools"));
-        pictures.add(new Picture(url("1470252649378-9c29740c9fa8"), "Dawn on the lake"));
-        pictures.add(new Picture(url("1501785888041-af3ef285b470"), "Boathouse, Braies"));
-        pictures.add(new Picture(url("1504893524553-b855bce32c67"), "Green gorge"));
-        pictures.add(new Picture(url("1519681393784-d120267933ba"), "Peaks at night"));
-        pictures.add(new Picture(url("1470240731273-7821a6eeb6bd"), "Meadow, storm light"));
-        pictures.add(new Picture(url("1441716844725-09cedc13a4e7"), "Still water"));
-        pictures.add(new Picture(url("1454372182658-c712e4c5a1db"), "Jetty"));
-        pictures.add(new Picture(url("1439405326854-014607f694d7"), "Cold sea"));
-        pictures.add(new Picture(url("1464822759023-fed622ff2c3b"), "Alpine valley"));
-        pictures.add(new Picture(url("1477346611705-65d1883cee1e"), "Ridge at dusk"));
+        pictures.add(new Picture("1506905925346-21bda4d32df4", "Above the cloud line"));
+        pictures.add(new Picture("1418065460487-3e41a6c84dc5", "Fog in the pines"));
+        pictures.add(new Picture("1439853949127-fa647821eba0", "Glacier valley"));
+        pictures.add(new Picture("1444927714506-8492d94b4e3d", "Blue ridges"));
+        pictures.add(new Picture("1505765050516-f72dcac9c60e", "Peaks in cloud"));
+        pictures.add(new Picture("1483728642387-6c3bdd6c93e5", "Watzmann at dusk"));
+        pictures.add(new Picture("1470071459604-3b5ec3a7fe05", "Highland light"));
+        pictures.add(new Picture("1433086966358-54859d0ed716", "Multnomah Falls"));
+        pictures.add(new Picture("1441974231531-c6227db76b6e", "Old growth"));
+        pictures.add(new Picture("1447752875215-b2761acb3c5d", "Boardwalk"));
+        pictures.add(new Picture("1472214103451-9374bd1c798e", "Fairy pools"));
+        pictures.add(new Picture("1470252649378-9c29740c9fa8", "Dawn on the lake"));
+        pictures.add(new Picture("1501785888041-af3ef285b470", "Boathouse, Braies"));
+        pictures.add(new Picture("1504893524553-b855bce32c67", "Green gorge"));
+        pictures.add(new Picture("1519681393784-d120267933ba", "Peaks at night"));
+        pictures.add(new Picture("1470240731273-7821a6eeb6bd", "Meadow, storm light"));
+        pictures.add(new Picture("1441716844725-09cedc13a4e7", "Still water"));
+        pictures.add(new Picture("1454372182658-c712e4c5a1db", "Jetty"));
+        pictures.add(new Picture("1439405326854-014607f694d7", "Cold sea"));
+        pictures.add(new Picture("1464822759023-fed622ff2c3b", "Alpine valley"));
+        pictures.add(new Picture("1477346611705-65d1883cee1e", "Ridge at dusk"));
         return pictures;
     }
-
-    private List<Picture> mPictures = new ArrayList<Picture>();
 
     @Override
     public int getCount() {
@@ -96,10 +93,10 @@ public class ProductsAdapter extends BaseAdapter {
         final View view = getView(context, convertView, parent);
         final Picture picture = (Picture) getItem(position);
 
-        final ImageView imageView =
-                (ImageView) view.findViewById(R.id.list_item_picture_image_view);
+        final String url = PictureUrl.forSize(picture.mSlug, mWidthPixels, mHeightPixels);
+        final ImageView imageView = view.findViewById(R.id.list_item_picture_image_view);
         imageView.setImageBitmap(null);
-        Picasso.get().load(picture.mUrl).into(imageView);
+        Picasso.get().load(url).into(imageView);
 
         final TextView textView = (TextView) view.findViewById(R.id.list_item_picture_text_view);
         textView.setText(picture.mCaption);

--- a/sample/src/main/java/mobi/parchment/ProductsAdapter.java
+++ b/sample/src/main/java/mobi/parchment/ProductsAdapter.java
@@ -93,9 +93,11 @@ public class ProductsAdapter extends BaseAdapter {
         final View view = getView(context, convertView, parent);
         final Picture picture = (Picture) getItem(position);
 
-        final String url = PictureUrl.forSize(picture.mSlug, mWidthPixels, mHeightPixels);
-        final ImageView imageView = view.findViewById(R.id.list_item_picture_image_view);
+        final ImageView imageView =
+                (ImageView) view.findViewById(R.id.list_item_picture_image_view);
         imageView.setImageBitmap(null);
+
+        final String url = PictureUrl.forSize(picture.mSlug, mWidthPixels, mHeightPixels);
         Picasso.get().load(url).into(imageView);
 
         final TextView textView = (TextView) view.findViewById(R.id.list_item_picture_text_view);

--- a/sample/src/main/java/mobi/parchment/SampleApplication.java
+++ b/sample/src/main/java/mobi/parchment/SampleApplication.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment;
+
+import android.app.ActivityManager;
+import android.app.Application;
+import android.content.Context;
+import com.squareup.picasso.LruCache;
+import com.squareup.picasso.Picasso;
+
+public final class SampleApplication extends Application {
+
+    private static final int BYTES_PER_MEGABYTE = 1024 * 1024;
+
+    // Picasso sizes its own cache at a seventh of the heap. Now that a photo is requested at the
+    // size of the view, a GridPatternView cell is over 11MB and only three of them fit, so every
+    // scroll back evicts. A third of the heap holds a screenful and its neighbours.
+    private static final int HEAP_FRACTION = 3;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        final ActivityManager activityManager =
+                (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
+        final int memoryClassMegabytes = activityManager.getMemoryClass();
+        final int cacheBytes = memoryClassMegabytes * BYTES_PER_MEGABYTE / HEAP_FRACTION;
+        final LruCache memoryCache = new LruCache(cacheBytes);
+        final Picasso picasso = new Picasso.Builder(this).memoryCache(memoryCache).build();
+        Picasso.setSingletonInstance(picasso);
+    }
+}

--- a/sample/src/main/java/mobi/parchment/SimpleGridPatternViewActivity.java
+++ b/sample/src/main/java/mobi/parchment/SimpleGridPatternViewActivity.java
@@ -14,7 +14,7 @@ import mobi.parchment.widget.adapterview.gridpatternview.GridPatternView;
 public class SimpleGridPatternViewActivity extends BaseActivity {
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_simple_grid_pattern_view);
 
@@ -43,6 +43,16 @@ public class SimpleGridPatternViewActivity extends BaseActivity {
         gridPatternView.addGridPatternGroupDefinition(gridPatternItemDefinitions);
 
         gridPatternView.setAdapter(getProductsAdapter());
+    }
+
+    @Override
+    public int getPictureRequestWidthDimension() {
+        return R.dimen.picture_request_grid_pattern_width;
+    }
+
+    @Override
+    public int getPictureRequestHeightDimension() {
+        return R.dimen.picture_request_grid_pattern_height;
     }
 
     @Override

--- a/sample/src/main/java/mobi/parchment/SimpleGridViewActivity.java
+++ b/sample/src/main/java/mobi/parchment/SimpleGridViewActivity.java
@@ -11,12 +11,22 @@ import mobi.parchment.widget.adapterview.gridview.GridView;
 public class SimpleGridViewActivity extends BaseActivity {
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_simple_gridview);
 
         final GridView<BaseAdapter> gridView = findViewById(R.id.parchment_view);
         gridView.setAdapter(getProductsAdapter());
+    }
+
+    @Override
+    public int getPictureRequestWidthDimension() {
+        return R.dimen.picture_request_gridview_width;
+    }
+
+    @Override
+    public int getPictureRequestHeightDimension() {
+        return R.dimen.picture_request_gridview_height;
     }
 
     @Override

--- a/sample/src/main/java/mobi/parchment/SimpleListViewActivity.java
+++ b/sample/src/main/java/mobi/parchment/SimpleListViewActivity.java
@@ -11,12 +11,22 @@ import mobi.parchment.widget.adapterview.listview.ListView;
 public class SimpleListViewActivity extends BaseActivity {
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_simple_horizontal);
 
         final ListView<BaseAdapter> horizontalListView = findViewById(R.id.parchment_view);
         horizontalListView.setAdapter(getProductsAdapter());
+    }
+
+    @Override
+    public int getPictureRequestWidthDimension() {
+        return R.dimen.picture_request_horizontal_width;
+    }
+
+    @Override
+    public int getPictureRequestHeightDimension() {
+        return R.dimen.picture_request_horizontal_height;
     }
 
     @Override

--- a/sample/src/main/java/mobi/parchment/SimpleViewPagerActivity.java
+++ b/sample/src/main/java/mobi/parchment/SimpleViewPagerActivity.java
@@ -11,12 +11,22 @@ import mobi.parchment.widget.adapterview.listview.ListView;
 public class SimpleViewPagerActivity extends BaseActivity {
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_simple_view_pager);
 
         final ListView<BaseAdapter> viewPager = findViewById(R.id.parchment_view);
         viewPager.setAdapter(getProductsAdapter());
+    }
+
+    @Override
+    public int getPictureRequestWidthDimension() {
+        return R.dimen.picture_request_view_pager_width;
+    }
+
+    @Override
+    public int getPictureRequestHeightDimension() {
+        return R.dimen.picture_request_view_pager_height;
     }
 
     @Override

--- a/sample/src/main/java/mobi/parchment/models/Picture.java
+++ b/sample/src/main/java/mobi/parchment/models/Picture.java
@@ -3,12 +3,12 @@
 
 package mobi.parchment.models;
 
-public class Picture {
-    public final String mUrl;
+public final class Picture {
+    public final String mSlug;
     public final String mCaption;
 
-    public Picture(String url, String caption) {
-        mUrl = url;
+    public Picture(final String slug, final String caption) {
+        mSlug = slug;
         mCaption = caption;
     }
 }

--- a/sample/src/main/res/values-sw330dp-port/picture_request.xml
+++ b/sample/src/main/res/values-sw330dp-port/picture_request.xml
@@ -4,6 +4,6 @@
     <dimen name="picture_request_horizontal_height">900dp</dimen>
     <dimen name="picture_request_gridview_width">190dp</dimen>
     <dimen name="picture_request_view_pager_width">400dp</dimen>
-    <dimen name="picture_request_grid_pattern_width">700dp</dimen>
-    <dimen name="picture_request_grid_pattern_height">620dp</dimen>
+    <dimen name="picture_request_grid_pattern_width">600dp</dimen>
+    <dimen name="picture_request_grid_pattern_height">530dp</dimen>
 </resources>

--- a/sample/src/main/res/values-sw330dp-port/picture_request.xml
+++ b/sample/src/main/res/values-sw330dp-port/picture_request.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Phone, portrait: measured 300x883, 176x300, 371x250, cells to 915x881. -->
+<resources>
+    <dimen name="picture_request_horizontal_height">900dp</dimen>
+    <dimen name="picture_request_gridview_width">190dp</dimen>
+    <dimen name="picture_request_view_pager_width">400dp</dimen>
+    <dimen name="picture_request_grid_pattern_width">700dp</dimen>
+    <dimen name="picture_request_grid_pattern_height">620dp</dimen>
+</resources>

--- a/sample/src/main/res/values-sw330dp/picture_request.xml
+++ b/sample/src/main/res/values-sw330dp/picture_request.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Phone, landscape: 411x923dp measured 300x371, 281x200, 883x250, cells to 362x369. -->
+<resources>
+    <dimen name="picture_request_horizontal_height">400dp</dimen>
+    <dimen name="picture_request_gridview_width">300dp</dimen>
+    <dimen name="picture_request_view_pager_width">920dp</dimen>
+    <dimen name="picture_request_grid_pattern_width">380dp</dimen>
+    <dimen name="picture_request_grid_pattern_height">380dp</dimen>
+</resources>

--- a/sample/src/main/res/values-sw540dp-port/picture_request.xml
+++ b/sample/src/main/res/values-sw540dp-port/picture_request.xml
@@ -4,6 +4,6 @@
     <dimen name="picture_request_horizontal_height">960dp</dimen>
     <dimen name="picture_request_gridview_width">290dp</dimen>
     <dimen name="picture_request_view_pager_width">600dp</dimen>
-    <dimen name="picture_request_grid_pattern_width">740dp</dimen>
-    <dimen name="picture_request_grid_pattern_height">660dp</dimen>
+    <dimen name="picture_request_grid_pattern_width">640dp</dimen>
+    <dimen name="picture_request_grid_pattern_height">570dp</dimen>
 </resources>

--- a/sample/src/main/res/values-sw540dp-port/picture_request.xml
+++ b/sample/src/main/res/values-sw540dp-port/picture_request.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 600dp tablet, portrait: measured 550x920, 270x300, 560x400, cells to 953x918. -->
+<resources>
+    <dimen name="picture_request_horizontal_height">960dp</dimen>
+    <dimen name="picture_request_gridview_width">290dp</dimen>
+    <dimen name="picture_request_view_pager_width">600dp</dimen>
+    <dimen name="picture_request_grid_pattern_width">740dp</dimen>
+    <dimen name="picture_request_grid_pattern_height">660dp</dimen>
+</resources>

--- a/sample/src/main/res/values-sw540dp/picture_request.xml
+++ b/sample/src/main/res/values-sw540dp/picture_request.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 600dp tablet, landscape: measured 300x560, 293x200, 920x400, cells to 565x558. -->
+<resources>
+    <dimen name="picture_request_horizontal_height">600dp</dimen>
+    <dimen name="picture_request_gridview_width">310dp</dimen>
+    <dimen name="picture_request_view_pager_width">960dp</dimen>
+    <dimen name="picture_request_grid_pattern_width">580dp</dimen>
+    <dimen name="picture_request_grid_pattern_height">580dp</dimen>
+</resources>

--- a/sample/src/main/res/values-sw720dp-port/picture_request.xml
+++ b/sample/src/main/res/values-sw720dp-port/picture_request.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 800dp tablet, portrait: measured 750x1240, 240x300, 760x550, cells to 1299x1239. -->
+<resources>
+    <dimen name="picture_request_horizontal_height">1280dp</dimen>
+    <dimen name="picture_request_gridview_width">260dp</dimen>
+    <dimen name="picture_request_view_pager_width">800dp</dimen>
+    <dimen name="picture_request_grid_pattern_width">1000dp</dimen>
+    <dimen name="picture_request_grid_pattern_height">960dp</dimen>
+</resources>

--- a/sample/src/main/res/values-sw720dp-port/picture_request.xml
+++ b/sample/src/main/res/values-sw720dp-port/picture_request.xml
@@ -4,6 +4,6 @@
     <dimen name="picture_request_horizontal_height">1280dp</dimen>
     <dimen name="picture_request_gridview_width">260dp</dimen>
     <dimen name="picture_request_view_pager_width">800dp</dimen>
-    <dimen name="picture_request_grid_pattern_width">1000dp</dimen>
-    <dimen name="picture_request_grid_pattern_height">960dp</dimen>
+    <dimen name="picture_request_grid_pattern_width">860dp</dimen>
+    <dimen name="picture_request_grid_pattern_height">820dp</dimen>
 </resources>

--- a/sample/src/main/res/values-sw720dp/picture_request.xml
+++ b/sample/src/main/res/values-sw720dp/picture_request.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 800dp tablet, landscape: measured 400x760, 400x200, 1240x550, cells to 781x759. -->
+<resources>
+    <dimen name="picture_request_horizontal_height">800dp</dimen>
+    <dimen name="picture_request_gridview_width">420dp</dimen>
+    <dimen name="picture_request_view_pager_width">1280dp</dimen>
+    <dimen name="picture_request_grid_pattern_width">800dp</dimen>
+    <dimen name="picture_request_grid_pattern_height">780dp</dimen>
+</resources>

--- a/sample/src/main/res/values/picture_request.xml
+++ b/sample/src/main/res/values/picture_request.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- The size each sample asks the Unsplash resizer for. The width of a
+     horizontal list cell, the height of a grid cell and the height of a pager
+     page are already dimensions, so those alias them and follow the same
+     qualifiers; the rest are the sizes measured on a phone and on 600dp and
+     800dp tablets, rounded up so a request is never smaller than the view. -->
+<resources>
+    <dimen name="picture_request_horizontal_width">@dimen/list_item_horizontal_height</dimen>
+    <dimen name="picture_request_horizontal_height">640dp</dimen>
+
+    <dimen name="picture_request_gridview_width">200dp</dimen>
+    <dimen name="picture_request_gridview_height">@dimen/list_item_gridview_picture_height</dimen>
+
+    <dimen name="picture_request_view_pager_width">340dp</dimen>
+    <dimen name="picture_request_view_pager_height">@dimen/list_item_view_pager_height</dimen>
+
+    <dimen name="picture_request_grid_pattern_width">400dp</dimen>
+    <dimen name="picture_request_grid_pattern_height">400dp</dimen>
+</resources>


### PR DESCRIPTION
## Description

Every cell in the sample asked the Unsplash resizer for the same 800px-wide
image (`?w=800&q=75`), regardless of the view it landed in. On a Pixel 8 that
means a GridPatternView 6x4 cell was upscaled from 800px to 2373px, while a
2x2 cell in the same pattern group decoded almost three times the pixels it
could show.

`Picture` now carries the photo slug instead of a finished URL, and the
request size comes from a pair of dimensions per sample screen, so the same
`-port` and `sw###dp` qualifiers that already choose the cell sizes choose the
request too. `getDimensionPixelSize` applies the device's density once, so the
URL is in device pixels and needs no `dpr` parameter.

Three of the eight numbers are aliases rather than values:

```xml
<dimen name="picture_request_horizontal_width">@dimen/list_item_horizontal_height</dimen>
```

A dimension reference is resolved against the current configuration, so the
horizontal cell width, grid cell height and pager page height follow their
existing qualifiers without a number being repeated anywhere. Only the five
that no existing dimension states are declared per bucket.

Note that `smallestWidth` outranks orientation in resource precedence, so each
orientation variant carries its `sw` qualifier (`values-sw330dp-port`, not
`values-port`); a bare `values-port` would lose to `values-sw330dp` on every
phone.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

Sample only. The library is untouched, and no layout changed.

## How Has This Been Tested?
- [x] Manual testing on device/emulator

No automated tests: this is the sample app.

The declared sizes are measured, not guessed. Each screen was laid out on a
411dp phone and on 600dp and 800dp tablets (`wm size` / `wm density`) in both
orientations, with a temporary log of the view size and of the resolved
dimensions, both removed before commit. Requested vs. actual, in dp:

| Config | Horizontal | GridView | ViewPager | GridPattern |
|---|---|---|---|---|
| phone port | 300x900 ≥ 300x883 | 190x300 ≥ 176x300 | 400x250 ≥ 371x250 | 700x620, cells 450x284..915x881 |
| phone land | 300x400 ≥ 300x371 | 300x200 ≥ 281x200 | 920x250 ≥ 883x250 | 380x380 ≥ 362x369 |
| sw600 port | 550x960 ≥ 550x920 | 290x300 ≥ 270x300 | 600x400 ≥ 560x400 | 740x660, cells 469x296..953x918 |
| sw600 land | 300x600 ≥ 300x560 | 310x200 ≥ 293x200 | 960x400 ≥ 920x400 | 580x580 ≥ 565x558 |
| sw800 port | 750x1280 ≥ 750x1240 | 260x300 ≥ 240x300 | 800x550 ≥ 760x550 | 1000x960, cells 642x403..1299x1239 |
| sw800 land | 400x800 ≥ 400x760 | 420x200 ≥ 400x200 | 1280x550 ≥ 1240x550 | 800x780 ≥ 781x759 |

Every screen but one is covered in every configuration, and the aliases were
confirmed to track their qualifiers (the horizontal width resolves to
300/550/750/400 exactly as `list_item_horizontal_height` does).

**The GridPatternView is the one approximation.** Its cells range from 2x2 to
6x4 within a single screen and share one request. In landscape the largest
cell is small enough to cover exactly. In portrait it is sized to a middle of
the range, so the 6x4 cell is upscaled about 1.3x: covering it outright would
mean a 22MB bitmap decoded for every 2x2 cell beside it. If the hero cell
should be sharper, it is one number per bucket to change.

All four screens were then re-checked visually with the probes removed: images
load, captions intact, no crashes in logcat.

Gates run locally: `spotlessCheck`, `:library:lintDebug`, `:sample:lintDebug`,
`:library:test`, `:sample:installDebug`.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


---

## Follow-up in this PR: the memory cache

Right-sizing the requests made each bitmap several times larger than the fixed
800px one it replaced, and Picasso sizes its memory cache at a seventh of the
heap (confirmed in `Utils.calculateMemoryCacheSize`: `memoryClass * 1MB / 7`).
On a 256MB-heap device that is 36MB, which holds three GridPatternView cells,
so scrolling evicted almost everything.

Measured on a Pixel 8 with a temporary counter on the cache, one pass through
a screen and back:

| | pattern hits | misses | evictions | horizontal hits | evictions |
|---|---|---|---|---|---|
| heap/7, pattern 700x620 | 4 | 104 | 35 | 380 | 31 |
| heap/3, pattern 700x620 | 13 | 96 | 37 | 410 | 17 |
| heap/3, pattern 600x530 | 24 | 72 | 22 | — | — |

`SampleApplication` builds Picasso with a third of the heap, and the pattern
view's portrait request is trimmed. Together that is a 6x better hit rate and
37% fewer evictions on the pattern view; the horizontal list, whose cells are
all one size, roughly halves its evictions from the cache change alone.

The trim costs the 6x4 cell sharpness, 1.3x to 1.5x upscaled. It is one number
per bucket if that is the wrong trade. The other ten cells in the pattern were
already over-served by a size chosen for the largest of them.

Since API 26 bitmap pixels live in native memory, so a larger cache does not
push on the Java heap; it raises the app's footprint, which is the intended
trade for a photo demo. The fraction is computed from
`ActivityManager.getMemoryClass()` rather than hardcoded, so a low-memory
device gets a proportionally smaller cache.
