### PR TITLE
Sample: Picasso 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ everything around them is new.
   cell sizes themselves; the three that a layout dimension already states
   alias it rather than repeating the number. Requests are in device pixels,
   so density is applied once by `getDimensionPixelSize`.
+- Sample: Picasso 2.8 (was 2.71828). Same okhttp, but it depends on
+  `androidx.exifinterface` instead of `com.android.support:exifinterface` and
+  `support-annotations`, which were the last `com.android.support` artifacts
+  in the build.
+
 - Sample: Picasso is built with a memory cache of a third of the heap instead
   of the seventh it sizes itself at. A photo requested at the size of the view
   is several times larger than the fixed 800px one it replaces, and on a

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ androidxTestRules = "1.7.0"
 espresso = "3.7.0"
 
 # Sample
-picasso = "2.71828"
+picasso = "2.8"
 
 [libraries]
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidxAnnotation" }


### PR DESCRIPTION
## Description

Stacked on #40.

Picasso 2.71828 pulls in the last two `com.android.support` artifacts left in
the build:

```
2.71828 -> com.squareup.okhttp3:okhttp:3.10.0
           com.android.support:support-annotations:27.1.0
           com.android.support:exifinterface:27.1.0

2.8     -> com.squareup.okhttp3:okhttp:3.10.0
           androidx.annotation:1.0.0
           androidx.exifinterface:1.0.0
```

Same library, same okhttp, AndroidX instead of the support library.

Worth recording because it is easy to get wrong: **2.8 is the newest release
Picasso has**, not 2.71828. Maven Central reports `<release>2.71828</release>`
because version ordering puts 71828 above 8, but 2.8 was published later
(2020-08-10, the repository's `lastUpdated`). Picasso has had no release
since, which is its own reason to look at Glide or Coil eventually; that is
not this PR.

This does not change the memory cache — that is #40's `SampleApplication`.

## Type of Change
- [x] Refactor (code change that neither fixes a bug nor adds a feature)

Sample only. One line in the version catalog.

## How Has This Been Tested?
- [x] Manual testing on device/emulator

`:sample:dependencies` confirms the support-library artifacts are gone and
`androidx.exifinterface:1.0.0` replaces them. Installed on a Pixel 8: the app
starts, `SampleApplication.onCreate` builds the 2.8 `Picasso` with its custom
`LruCache` without error (an API break would fail here), images load — the
okhttp disk cache grew from 27MB to 51MB over the run — and logcat shows no
crash.

One cosmetic note: okhttp 3.10.0 reaches `dalvik.system.CloseGuard` by
reflection, so logcat carries three `hiddenapi: ... allowed` lines at startup.
Allowed, not an error, and it predates this change.

Gates run locally: `spotlessCheck`, `:library:lintDebug`, `:sample:lintDebug`,
`:library:test`, `:sample:installDebug`.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
