### PR TITLE
Carry both paging modes behind parchment_viewPagerInterval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,22 +83,24 @@ everything around them is new.
 - Tests: Robolectric 4.16.1, AssertJ 3.27, androidx.test 1.7; the old
   `integration` Maven module lives in `library/src/test` now.
 - Sample: targets SDK 37, Material theme, RTL-aware padding, Picasso 2.71828.
-- **Breaking:** `parchment_isViewPager="true"` advances exactly one cell per
-  gesture, in both directions. It used to advance the whole run of cells
-  fully visible in the viewport, so with three 100px cells on a 300px
-  screen a single slow swipe jumped three cells; with two cells visible it
-  jumped two. A page is now measured from the cell at the snap position to
-  the cell `parchment_viewPagerInterval` away, using each cell's own size, so
-  cells of different sizes page correctly and the landing point is a cell
-  boundary even when the gesture starts part-way through a cell. Any layout
-  where more than one cell fits on screen will page differently; set
-  `parchment_viewPagerInterval` to the old visible-cell count to keep the
-  previous distance. Closes #26. A cell larger than the viewport already
-  paged one cell at a time (fixed in 1.6.6) and still does.
+- `parchment_isViewPager="true"` still advances a whole viewport of cells per
+  gesture by default, and it is now measured rather than summed. A page runs
+  from the cell nearest the snap position to the first cell that does not fit
+  the size inside the padding whole, in each direction separately, so cells of
+  different sizes page correctly, the landing point is a cell boundary even
+  when the gesture starts part-way through a cell, and a padded view counts
+  only what fits inside its padding. A cell larger than the viewport is
+  the first cell that does not fit, so it is still one page on its own
+  (fixed in 1.6.6) without a case of its own. Paging back is the mirror of
+  paging forward instead of reusing the forward distance.
 - Sample: the demo photo set moved from imgur to the Unsplash CDN, and each
   of the 21 photos now carries its own caption. Eighteen of them read
   "National photo contest", which made paging and snapping hard to follow
   because the caption did not change as the cell did.
+- Sample: the ViewPager demo no longer declares `parchment_snapPosition`.
+  It also sets `parchment_isCircularScroll`, which the layout engine answers
+  with `onScreen` whatever the attribute says, so the line was dead
+  configuration that misread as the demo snapping to the start.
 - `AbstractAdapterView` invalidates the whole view after adding or removing
   a child instead of the deprecated `invalidate(Rect)`.
 
@@ -110,10 +112,12 @@ everything around them is new.
   real gestures, and hands a test an immutable snapshot of where the
   children landed. All eleven `parchment_` attributes are covered by
   on-device tests built on it, asserting geometry rather than getters, as is
-  paging: a real fling and a real slow drag each advance
-  `parchment_viewPagerInterval` cells with several cells on screen, with cells
-  of unequal size, with a cell taller than the viewport, from a resting
-  position part-way through a cell, at both ends of the adapter, wrapping with
+  paging in both modes: a real fling and a real slow drag each page by the
+  cells that fit the viewport, or by `parchment_viewPagerInterval` cells, with
+  several cells on screen, with cells that do not divide the viewport, with
+  cells of unequal size, with a cell taller than the viewport, from a resting
+  position part-way through a cell, inside `android:padding`, in both
+  orientations, at both ends of the adapter, wrapping with
   `parchment_isCircularScroll`, and on `GridView` and `GridPatternView` where
   a cell is a whole group.
 - Spotless (google-java-format, AOSP style) with SPDX license headers on
@@ -123,11 +127,17 @@ everything around them is new.
   instrumented tests (`android-ci.yml`), security gates (`security.yml`:
   action-pin lint, allowlist expiry, OSV-Scanner, dependency review,
   gitleaks), and CodeQL (`codeql.yml`). Dependabot for Gradle and Actions.
-- `parchment_viewPagerInterval`, an integer on all three views, for how many
-  cells one ViewPager gesture advances. It defaults to 1 and clamps to 1: a
-  gesture that advanced no cells would leave the view stuck, so 0 and
-  negative values are read as 1, the same way `parchment_numberOfViewsPerCell`
-  clamps. The attribute was named in `LayoutManagerAttributes` since 2014 and
+- `parchment_viewPagerInterval`, on all three views, for how far one ViewPager
+  gesture pages. It carries an integer plus a named constant the way
+  `layout_width` carries a dimension plus `match_parent`: `viewport`, or the
+  literal `0`, or leaving the attribute out, keeps the viewport paging
+  Parchment has always done, while `N` advances exactly N cells from the cell
+  nearest the snap position, which is the carousel issue #26 asked for. Zero
+  is both the default and the value an absent attribute already yields, so
+  unset and `viewport` are one state and upgrading changes nothing until the
+  attribute is set. A negative interval is not a number of cells — it would
+  page backwards when the finger went forwards — so it is read as `viewport`
+  too. The attribute was named in `LayoutManagerAttributes` since 2014 and
   carried as far as the layout manager, but nothing ever declared it in XML
   or assigned it, so it always arrived as 0.
 - An instrumented smoke test that inflates a `ListView` from XML on a real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ everything around them is new.
   byte-for-byte identical. Format, meaning, and the enum and flag values
   are unchanged, and the old names are not kept as deprecated aliases:
   2.0 is the breaking window and reading both would double the parsing
-  code. The README tables list all eleven names. Substituting your own
+  code. The README tables list them all. Substituting your own
   res-auto prefix for `parchment` below — never `android`, whose own
   `orientation` and `gravity` are a different namespace and must not be
   touched — this is the whole migration:
@@ -83,6 +83,18 @@ everything around them is new.
 - Tests: Robolectric 4.16.1, AssertJ 3.27, androidx.test 1.7; the old
   `integration` Maven module lives in `library/src/test` now.
 - Sample: targets SDK 37, Material theme, RTL-aware padding, Picasso 2.71828.
+- **Breaking:** `parchment_isViewPager="true"` advances exactly one cell per
+  gesture, in both directions. It used to advance the whole run of cells
+  fully visible in the viewport, so with three 100px cells on a 300px
+  screen a single slow swipe jumped three cells; with two cells visible it
+  jumped two. A page is now measured from the cell at the snap position to
+  the cell `parchment_viewPagerInterval` away, using each cell's own size, so
+  cells of different sizes page correctly and the landing point is a cell
+  boundary even when the gesture starts part-way through a cell. Any layout
+  where more than one cell fits on screen will page differently; set
+  `parchment_viewPagerInterval` to the old visible-cell count to keep the
+  previous distance. Closes #26. A cell larger than the viewport already
+  paged one cell at a time (fixed in 1.6.6) and still does.
 - Sample: the demo photo set moved from imgur to the Unsplash CDN, and each
   of the 21 photos now carries its own caption. Eighteen of them read
   "National photo contest", which made paging and snapping hard to follow
@@ -105,6 +117,13 @@ everything around them is new.
   instrumented tests (`android-ci.yml`), security gates (`security.yml`:
   action-pin lint, allowlist expiry, OSV-Scanner, dependency review,
   gitleaks), and CodeQL (`codeql.yml`). Dependabot for Gradle and Actions.
+- `parchment_viewPagerInterval`, an integer on all three views, for how many
+  cells one ViewPager gesture advances. It defaults to 1 and clamps to 1: a
+  gesture that advanced no cells would leave the view stuck, so 0 and
+  negative values are read as 1, the same way `parchment_numberOfViewsPerCell`
+  clamps. The attribute was named in `LayoutManagerAttributes` since 2014 and
+  carried as far as the layout manager, but nothing ever declared it in XML
+  or assigned it, so it always arrived as 0.
 - An instrumented smoke test that inflates a `ListView` from XML on a real
   framework.
 - `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,21 +86,21 @@ everything around them is new.
 - `parchment_isViewPager="true"` still advances a whole viewport of cells per
   gesture by default, and it is now measured rather than summed. A page runs
   from the cell nearest the snap position to the first cell that does not fit
-  the size inside the padding whole, in each direction separately, so cells of
-  different sizes page correctly, the landing point is a cell boundary even
-  when the gesture starts part-way through a cell, and a padded view counts
-  only what fits inside its padding. A cell larger than the viewport is
-  the first cell that does not fit, so it is still one page on its own
-  (fixed in 1.6.6) without a case of its own. Paging back is the mirror of
-  paging forward instead of reusing the forward distance.
+  the viewport whole, in each direction separately, so cells of different sizes
+  page by their own sizes, the landing point is a cell boundary even when the
+  gesture starts part-way through a cell, and a padded view counts only what
+  fits inside its padding. The room a page has is measured from where the
+  anchor cell settles, so `center` and `end` snapping page fewer cells than the
+  viewport would hold and no cell is skipped between pages. A cell larger than
+  the viewport is the first cell that does not fit, so it is still one page on
+  its own (fixed in 1.6.6) without a case of its own. Paging back is the mirror
+  of paging forward instead of reusing the forward distance, exactly for cells
+  still drawn and extrapolated from the first drawn cell's size for those
+  behind them.
 - Sample: the demo photo set moved from imgur to the Unsplash CDN, and each
   of the 21 photos now carries its own caption. Eighteen of them read
   "National photo contest", which made paging and snapping hard to follow
   because the caption did not change as the cell did.
-- Sample: the ViewPager demo no longer declares `parchment_snapPosition`.
-  It also sets `parchment_isCircularScroll`, which the layout engine answers
-  with `onScreen` whatever the attribute says, so the line was dead
-  configuration that misread as the demo snapping to the start.
 - `AbstractAdapterView` invalidates the whole view after adding or removing
   a child instead of the deprecated `invalidate(Rect)`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,13 @@ everything around them is new.
   an exact pixel size, drives real measure and layout passes, dispatches
   real gestures, and hands a test an immutable snapshot of where the
   children landed. All eleven `parchment_` attributes are covered by
-  on-device tests built on it, asserting geometry rather than getters.
+  on-device tests built on it, asserting geometry rather than getters, as is
+  paging: a real fling and a real slow drag each advance
+  `parchment_viewPagerInterval` cells with several cells on screen, with cells
+  of unequal size, with a cell taller than the viewport, from a resting
+  position part-way through a cell, at both ends of the adapter, wrapping with
+  `parchment_isCircularScroll`, and on `GridView` and `GridPatternView` where
+  a cell is a whole group.
 - Spotless (google-java-format, AOSP style) with SPDX license headers on
   every Java file; `javac -Xlint:all -Werror`; Android Lint with warnings
   as errors and no baseline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,17 @@ everything around them is new.
 
 ### Fixed
 
+- A gesture whose first frame is held by the start or the end of the list no
+  longer counts the movement it was denied. The layout pass folded the
+  clamp's correction back into the distance a gesture has travelled only
+  while an animation continued, never on the frame that began it, so a first
+  frame carrying a drag the bounds refused left that drag in the running
+  total. In ViewPager mode the page that followed was then short by it in one
+  direction and long by it in the other: a backward swipe at the first cell
+  crept forward by the first frame's drag instead of holding still. Whether a
+  gesture's first frame carries a drag at all depends on whether a touch move
+  and an animation frame land in the same pass, which made it intermittent
+  and invisible to a unit test that drives layout by hand.
 - A fling, page, or programmatic scroll that ends hands off to its snap in
   the same frame, after that frame's layout. The snap used to start one frame
   later and was started twice, which left a frame with no motion at the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,17 @@ everything around them is new.
   because the caption did not change as the cell did.
 - `AbstractAdapterView` invalidates the whole view after adding or removing
   a child instead of the deprecated `invalidate(Rect)`.
+- The two ViewPager paging modes are a strategy per mode in `pageinterval/`,
+  the way snapping has been one per mode in `snapposition/`:
+  `CellCountPageInterval` and `ViewportPageInterval` behind
+  `PageIntervalInterface`, picked once from `parchment_viewPagerInterval` by
+  `PageIntervalSelector` and held on `LayoutManager`. They had been methods
+  on `LayoutManager` with no access modifier so that unit tests in the same
+  package could reach them. Every remaining declaration in the library was
+  given an explicit `public`, `protected` or `private` at the same time, and
+  the unused `Animation.setId` was deleted rather than widened; none of them
+  was reachable from outside its package before, so no consumer loses a call.
+  Paging behaviour is unchanged.
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,15 +97,17 @@ a gate.
   documentation; the debugger can show each value; and a test can pin each
   step.
 - **One method, one flow.** When a method would hold two algorithms chosen
-  by a condition, the condition dispatches to two named methods that each do
-  one thing, and the dispatcher does nothing else:
+  by a condition, the condition dispatches to two named things that each do
+  one thing -- two methods, or two strategies that each hold one algorithm --
+  and the dispatcher does nothing else:
 
   ```java
-  long getPageCellIndexForward(...) {
+  public static <Cell> PageIntervalInterface<Cell> getPageIntervalInterface(
+          final int viewPagerInterval) {
       if (pagesByCellCount(viewPagerInterval)) {
-          return getPageCellIndexForwardByCellCount(viewPagerInterval, anchorIndex);
+          return new CellCountPageInterval<Cell>(viewPagerInterval);
       }
-      return getPageCellIndexForwardByViewport(maximumPageSize, anchorIndex, anchorStart);
+      return new ViewportPageInterval<Cell>();
   }
   ```
 
@@ -128,6 +130,11 @@ scroll frame.
 - Snap behaviour lives in `snapposition/`. A new snap mode is a new
   `SnapPositionInterface` implementation plus an enum value, not a branch
   in `LayoutManager`.
+- Paging behaviour lives in `pageinterval/`. A new way of deciding what a
+  page is is a new `PageIntervalInterface` implementation picked by
+  `PageIntervalSelector`, not a branch in `LayoutManager`. The strategy is
+  chosen once from `parchment_viewPagerInterval` and takes what it needs as
+  parameters, so none of it needs package-private access to test.
 - Circular scrolling wraps positions in the layout engine. Never leak
   wrapped positions to the adapter.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,24 @@ a gate.
   not `if (cellStart + getCellSize(cell) < 0)`. The names are the
   documentation; the debugger can show each value; and a test can pin each
   step.
+- **One method, one flow.** When a method would hold two algorithms chosen
+  by a condition, the condition dispatches to two named methods that each do
+  one thing, and the dispatcher does nothing else:
+
+  ```java
+  long getPageCellIndexForward(...) {
+      if (pagesByCellCount(viewPagerInterval)) {
+          return getPageCellIndexForwardByCellCount(viewPagerInterval, anchorIndex);
+      }
+      return getPageCellIndexForwardByViewport(maximumPageSize, anchorIndex, anchorStart);
+  }
+  ```
+
+  not an early return with the second algorithm falling through underneath
+  it. The name says which algorithm it is, not which branch it came from, so
+  the dispatcher reads as a table of contents and each algorithm can be read
+  and tested on its own. A guard clause is not an algorithm: do not invent
+  indirection where there is only one flow.
 
 ### Layout engine
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ every child in memory. The story, and a feature-by-feature comparison with
 - Four snap modes built into the layout engine: `center`, `start`, `end`,
   `onScreen`
 - Circular (infinite) scrolling with a single boolean, no adapter tricks
-- ViewPager behaviour on the same ListView and the same adapter
+- ViewPager behaviour on the same ListView and the same adapter: one
+  completed gesture advances exactly one cell, or `parchment_viewPagerInterval`
+  of them
 - GridView whose rows wrap to the tallest cell
 - GridPatternView: declare a repeating pattern of mixed-span cells and let
   the engine tile your data through it
@@ -100,7 +102,8 @@ cd parchment
     parchment:parchment_snapPosition="center"
     parchment:parchment_snapToPosition="true"
     parchment:parchment_isCircularScroll="false"
-    parchment:parchment_isViewPager="false" />
+    parchment:parchment_isViewPager="false"
+    parchment:parchment_viewPagerInterval="1" />
 ```
 
 ### Java
@@ -141,6 +144,7 @@ All views:
 | `parchment_selectOnSnap` | boolean | Fire `OnItemSelectedListener` when a snap completes |
 | `parchment_selectWhileScrolling` | boolean | Fire selection while the content is still moving |
 | `parchment_isViewPager` | boolean | One cell per gesture, ViewPager style |
+| `parchment_viewPagerInterval` | integer | Cells a ViewPager gesture advances; defaults to 1, values below 1 are read as 1 |
 
 GridView:
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ every child in memory. The story, and a feature-by-feature comparison with
   `onScreen`
 - Circular (infinite) scrolling with a single boolean, no adapter tricks
 - ViewPager behaviour on the same ListView and the same adapter: one
-  completed gesture advances exactly one cell, or `parchment_viewPagerInterval`
-  of them
+  completed gesture advances a whole viewport of cells, or exactly
+  `parchment_viewPagerInterval` of them
 - GridView whose rows wrap to the tallest cell
 - GridPatternView: declare a repeating pattern of mixed-span cells and let
   the engine tile your data through it
@@ -103,7 +103,7 @@ cd parchment
     parchment:parchment_snapToPosition="true"
     parchment:parchment_isCircularScroll="false"
     parchment:parchment_isViewPager="false"
-    parchment:parchment_viewPagerInterval="1" />
+    parchment:parchment_viewPagerInterval="viewport" />
 ```
 
 ### Java
@@ -143,8 +143,8 @@ All views:
 | `parchment_snapPosition` | `center`, `start`, `end`, `onScreen` | Where a cell settles |
 | `parchment_selectOnSnap` | boolean | Fire `OnItemSelectedListener` when a snap completes |
 | `parchment_selectWhileScrolling` | boolean | Fire selection while the content is still moving |
-| `parchment_isViewPager` | boolean | One cell per gesture, ViewPager style |
-| `parchment_viewPagerInterval` | integer | Cells a ViewPager gesture advances; defaults to 1, values below 1 are read as 1 |
+| `parchment_isViewPager` | boolean | One page per gesture, ViewPager style |
+| `parchment_viewPagerInterval` | integer, or `viewport` | How far one ViewPager gesture pages. `viewport` (or `0`, or unset, the default) advances every cell that fits the viewport whole; `N` advances exactly N cells. Values below zero are read as `viewport` |
 
 GridView:
 
@@ -158,6 +158,42 @@ GridPatternView:
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `parchment_ratio` | float | Aspect ratio of one grid cell |
+
+### Paging
+
+`parchment_isViewPager="true"` turns a completed gesture into a page, however
+far the finger travelled. `parchment_viewPagerInterval` says how far a page is,
+and it carries two kinds of value in the way `layout_width` carries a dimension
+plus `match_parent`:
+
+```xml
+<!-- Magazine spread: advance every cell that fits the viewport whole.
+     This is the default, so the attribute can be left out entirely. -->
+<mobi.parchment.widget.adapterview.gridpatternview.GridPatternView
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_isViewPager="true"
+    parchment:parchment_viewPagerInterval="viewport" />
+
+<!-- Carousel: advance exactly one cell, whatever else is on screen. -->
+<mobi.parchment.widget.adapterview.listview.ListView
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_isViewPager="true"
+    parchment:parchment_viewPagerInterval="1" />
+```
+
+Viewport paging adapts to the screen with no configuration: three cells on a
+tablet, one on a phone, and a cell larger than the viewport is one page on its
+own. Pages do not overlap, so every cell is shown whole exactly once per pass.
+A partial cell left at the edge is not counted, and the last page is short
+rather than running off the end.
+
+An interval of `N` ignores what fits and advances N cells from the cell nearest
+the snap position, measured from each cell's own start, so cells of different
+sizes still land on a cell boundary. Both modes wrap when
+`parchment_isCircularScroll` is on and stop at the adapter's ends when it is
+not.
 
 ## Project layout
 

--- a/README.md
+++ b/README.md
@@ -185,9 +185,10 @@ plus `match_parent`:
 
 Viewport paging adapts to the screen with no configuration: three cells on a
 tablet, one on a phone, and a cell larger than the viewport is one page on its
-own. Pages do not overlap, so every cell is shown whole exactly once per pass.
-A partial cell left at the edge is not counted, and the last page is short
-rather than running off the end.
+own. A page is the run of cells that fit the viewport whole from wherever the
+nearest cell settles, so a partial cell at the edge is not counted this page
+and is the first cell of the next one. The last page is short rather than
+running off the end.
 
 An interval of `N` ignores what fits and advances N cells from the cell nearest
 the snap position, measured from each cell's own start, so cells of different

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,4 +199,4 @@ same content position without the adapter's help.
 | Why did scrolling stop early / overshoot? | `LayoutManager.layout` bounds handling, `*OverScrollTest` |
 | Why did the snap land in the wrong place? | the strategy in `snapposition/`, `getCellDisplacementFromSnapPositionTests` |
 | Why is padding wrong? | `ListLayoutPaddingTest`; padding is applied in the layout managers, not the views |
-| Why did a ViewPager gesture land where it did? | `LayoutManager.setViewPageDistances` + `ViewPagerTest` |
+| Why did a ViewPager gesture land where it did? | `LayoutManager.setViewPageDistances` + `ViewPagerTest`, with each method it is built from in `LayoutManagerPagingMethodsTest` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,19 +146,30 @@ on a cell boundary even when the gesture starts part-way through a cell.
 Only the choice of landing cell differs between the two modes, so one place
 decides where a page ends up. Counting mode takes the cell `N` along from the
 anchor. Viewport mode walks out from the anchor while the next cell still fits
-entirely inside the size within the padding, and lands on the first one that
-does not; a cell larger than the viewport is simply the first cell that does
-not fit, which is why it stays one cell per gesture without a special case.
-The walk mirrors backwards, so a page back covers the run of cells that would
-fill one viewport ending at the anchor. A page always advances at least one
-cell.
+entirely inside the viewport, and lands on the first one that does not; a cell
+larger than the viewport is simply the first cell that does not fit, which is
+why it stays one cell per gesture without a special case. The walk mirrors
+backwards, so a page back covers the run of cells that would fill one viewport
+ending at the anchor. A page always advances at least one cell.
+
+The room a page has is `maximumPageSize`: the distance from where the anchor
+will sit once snapped to the end of the size inside the padding, not the whole
+of that size. The two are the same only when the anchor snaps to the start
+edge. With `center` or `end`, or with `onScreen` resting part-way through a
+cell, the anchor sits further in and less of the viewport is left for the page,
+so measuring against the whole size would count a cell that is only partly
+visible and skip it for good.
 
 Cells past the ends of the visible run are extrapolated from the edge cell's
 size plus spacing and capped at the adapter's ends, the same way
 `getFlingSnapAdjustment` extrapolates, so a gesture at the last cell asks for
-no movement rather than running off the end, and viewport mode's walk stops
-when the cap means the next index names the same cell again. Circular
-scrolling lifts that cap and the positions wrap.
+no movement rather than running off the end. Circular scrolling lifts that cap
+and the positions wrap, which is also why the cap is not what ends the walk:
+the walk stops when the page no longer fits, and the guard that the next index
+names a further cell is what stops it when the cap, a zero cell size or a
+negative `parchment_cellSpacing` leaves the start where it was. Because the
+extrapolation knows only the edge cell's size, a page back over cells that are
+no longer drawn is exact only while those cells match it.
 
 The snap position is *not* forced: `parchment_snapPosition` applies as it does
 everywhere else (`onScreen` for a view inflated from XML), and the anchor is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,9 +117,32 @@ positions. `GridLayoutManagerCircularScrollTest` covers the wrap points.
 ## ViewPager mode
 
 `parchment_isViewPager` changes the gesture interpretation, not the layout: a
-completed gesture advances exactly one cell in the fling direction
-(`AdapterAnimator` with the `mViewPageDistance`), and the snap position is
-forced to `start` so pages align. It composes with `parchment_isCircularScroll`.
+completed gesture advances exactly `parchment_viewPagerInterval` cells (one by
+default) in the fling direction, however far the finger travelled.
+`AdapterAnimator.onFling` asks `LayoutManagerBridge` for the distance instead
+of handing the velocity to the scroller.
+
+`LayoutManager` measures that distance in `layout`, only when
+`parchment_isViewPager` is on, whenever a new animation id arrives and before
+that frame's displacement is applied. A new id arrives when a gesture starts
+and again on every layout taken while the view is at rest, so the distance is
+always the one measured from the layout the gesture started from. It takes the
+cell nearest the snap position as the anchor, and the distance is the gap
+between the anchor's snapped start and the start of the cell the interval
+away, in each direction separately (`mViewPageDistanceForward` and
+`mViewPageDistanceBack`). Measuring from starts rather than summing sizes is
+what makes cells of different sizes page correctly, puts the landing point on
+a cell boundary even when the gesture starts part-way through a cell, and
+keeps a cell wider than the viewport to one cell per gesture. Cells past the
+ends of the visible run are extrapolated from the edge cell's size plus
+spacing and capped at the adapter's ends, the same way `getFlingSnapAdjustment`
+extrapolates, so a gesture at the last cell asks for no movement rather than
+running off the end. Circular scrolling lifts that cap and the positions wrap.
+
+The snap position is *not* forced: `parchment_snapPosition` applies as it does
+everywhere else (`onScreen` for a view inflated from XML), and the anchor is
+found through the same `SnapPositionInterface` the snaps use, so paging works
+from wherever a cell rests. It composes with `parchment_isCircularScroll`.
 
 ## Touch
 
@@ -144,4 +167,4 @@ same content position without the adapter's help.
 | Why did scrolling stop early / overshoot? | `LayoutManager.layout` bounds handling, `*OverScrollTest` |
 | Why did the snap land in the wrong place? | the strategy in `snapposition/`, `getCellDisplacementFromSnapPositionTests` |
 | Why is padding wrong? | `ListLayoutPaddingTest`; padding is applied in the layout managers, not the views |
-| Why does the ViewPager page twice? | `AdapterAnimator` + `ViewPagerTest` |
+| Why did a ViewPager gesture land where it did? | `LayoutManager.setViewPageDistances` + `ViewPagerTest` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,7 @@ The `Cell` type parameter is what differs between the three views:
 |---|---|---|
 | `ListView` | `View` | the view's measured size along the scroll axis |
 | `GridView` | `Group` | `parchment_numberOfViewsPerCell` views laid across the breadth; the tallest (or widest) view sets the cell size, `parchment_gravity` places the rest |
-| `GridPatternView` | `GridPatternGroup` | one repeat of a `GridPatternGroupDefinition`: a list of `GridPatternItemDefinition(left, top, width, height)` in grid units; `parchment_ratio` fixes the unit's aspect |
+| `GridPatternView` | `GridPatternGroup` | one repeat of a `GridPatternGroupDefinition`: a list of `GridPatternItemDefinition(top, left, height, width)` in grid units; `parchment_ratio` fixes the unit's aspect |
 
 `GridPatternLayoutManager` walks the adapter through the group
 definitions in order, so a pattern of "one hero, two small" followed by

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,8 +117,12 @@ positions. `GridLayoutManagerCircularScrollTest` covers the wrap points.
 ## ViewPager mode
 
 `parchment_isViewPager` changes the gesture interpretation, not the layout: a
-completed gesture advances exactly `parchment_viewPagerInterval` cells (one by
-default) in the fling direction, however far the finger travelled.
+completed gesture advances one page in the fling direction, however far the
+finger travelled. `parchment_viewPagerInterval` says what a page is. Zero, the
+value an absent attribute already yields and the name `viewport` also resolves
+to, pages by the run of cells that fit the viewport whole; a positive N pages
+by exactly N cells.
+
 `AdapterAnimator.onFling` asks `LayoutManagerBridge` for the distance instead
 of handing the velocity to the scroller. What the scroller is handed is that
 distance *minus* how far the gesture has already dragged the content, so the
@@ -133,16 +137,28 @@ that frame's displacement is applied. A new id arrives when a gesture starts
 and again on every layout taken while the view is at rest, so the distance is
 always the one measured from the layout the gesture started from. It takes the
 cell nearest the snap position as the anchor, and the distance is the gap
-between the anchor's snapped start and the start of the cell the interval
-away, in each direction separately (`mViewPageDistanceForward` and
+between the anchor's snapped start and the start of the cell the page lands
+on, in each direction separately (`mViewPageDistanceForward` and
 `mViewPageDistanceBack`). Measuring from starts rather than summing sizes is
-what makes cells of different sizes page correctly, puts the landing point on
-a cell boundary even when the gesture starts part-way through a cell, and
-keeps a cell wider than the viewport to one cell per gesture. Cells past the
-ends of the visible run are extrapolated from the edge cell's size plus
-spacing and capped at the adapter's ends, the same way `getFlingSnapAdjustment`
-extrapolates, so a gesture at the last cell asks for no movement rather than
-running off the end. Circular scrolling lifts that cap and the positions wrap.
+what makes cells of different sizes page correctly and puts the landing point
+on a cell boundary even when the gesture starts part-way through a cell.
+
+Only the choice of landing cell differs between the two modes, so one place
+decides where a page ends up. Counting mode takes the cell `N` along from the
+anchor. Viewport mode walks out from the anchor while the next cell still fits
+entirely inside the size within the padding, and lands on the first one that
+does not; a cell larger than the viewport is simply the first cell that does
+not fit, which is why it stays one cell per gesture without a special case.
+The walk mirrors backwards, so a page back covers the run of cells that would
+fill one viewport ending at the anchor. A page always advances at least one
+cell.
+
+Cells past the ends of the visible run are extrapolated from the edge cell's
+size plus spacing and capped at the adapter's ends, the same way
+`getFlingSnapAdjustment` extrapolates, so a gesture at the last cell asks for
+no movement rather than running off the end, and viewport mode's walk stops
+when the cap means the next index names the same cell again. Circular
+scrolling lifts that cap and the positions wrap.
 
 The snap position is *not* forced: `parchment_snapPosition` applies as it does
 everywhere else (`onScreen` for a view inflated from XML), and the anchor is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,7 +120,12 @@ positions. `GridLayoutManagerCircularScrollTest` covers the wrap points.
 completed gesture advances exactly `parchment_viewPagerInterval` cells (one by
 default) in the fling direction, however far the finger travelled.
 `AdapterAnimator.onFling` asks `LayoutManagerBridge` for the distance instead
-of handing the velocity to the scroller.
+of handing the velocity to the scroller. What the scroller is handed is that
+distance *minus* how far the gesture has already dragged the content, so the
+finger and the animation together move exactly one page from where the gesture
+started. That running total counts only movement the bounds actually allowed:
+a frame the over-draw clamp refuses adds nothing to it, or a gesture held at
+either end of the list would answer with the drag it was denied.
 
 `LayoutManager` measures that distance in `layout`, only when
 `parchment_isViewPager` is on, whenever a new animation id arrives and before

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,9 +92,9 @@ a plain list (`GridPatternLayoutManagerNoDefinitionTest`).
 `snapposition/` holds one strategy per `parchment_snapPosition` value. Each answers
 two questions for a cell: where it should sit when snapped, and how far
 the content must move to get it there. `LayoutManager` picks the strategy
-once from the attributes; `onScreen` is the default for a view inflated
-from XML, `center` for one built in Java, and neither moves content on
-its own.
+once from the attributes and holds it as `mSnapPositionInterface`;
+`onScreen` is the default for a view inflated from XML, `center` for one
+built in Java, and neither moves content on its own.
 
 With `parchment_snapToPosition` on, a fling is retargeted when it starts:
 `LayoutManager.getFlingSnapAdjustment` takes the distance the fling would
@@ -143,9 +143,27 @@ on, in each direction separately (`mViewPageDistanceForward` and
 what makes cells of different sizes page correctly and puts the landing point
 on a cell boundary even when the gesture starts part-way through a cell.
 
-Only the choice of landing cell differs between the two modes, so one place
-decides where a page ends up. Counting mode takes the cell `N` along from the
-anchor. Viewport mode walks out from the anchor while the next cell still fits
+Only the choice of landing cell differs between the two modes, so that choice is
+all that a mode is. `pageinterval/` holds one strategy per mode, as
+`snapposition/` holds one per snap position: `PageIntervalInterface` asks for the
+cell index a page lands on in each direction, `CellCountPageInterval` answers it
+by counting and `ViewportPageInterval` by walking the viewport.
+`LayoutManager`'s constructor reads `parchment_viewPagerInterval` once, hands the
+value to `PageIntervalSelector` to pick between the two, and keeps the answer as
+`mPageIntervalInterface`. Nothing can set the interval afterwards, so choosing
+once gives the same answer the old per-call branch gave. That selection is a small
+public factory rather than the private switch `snapposition/` uses, which is the
+one place the two packages differ: it lets the tests exercise the real choice
+instead of a copy of it.
+
+`ViewportPageInterval` takes the anchor and the room a page has as parameters and
+calls back into `LayoutManager` for the drawn cells and the cell spacing, the way
+the snap strategies call back into it. `CellCountPageInterval` needs only the
+interval it was built with and touches no cell. Neither is consulted per frame:
+`setViewPageDistances` runs when a new animation id arrives, once per gesture.
+
+`CellCountPageInterval` takes the cell `N` along from the anchor.
+`ViewportPageInterval` walks out from the anchor while the next cell still fits
 entirely inside the viewport, and lands on the first one that does not; a cell
 larger than the viewport is simply the first cell that does not fit, which is
 why it stays one cell per gesture without a special case. The walk mirrors
@@ -199,4 +217,4 @@ same content position without the adapter's help.
 | Why did scrolling stop early / overshoot? | `LayoutManager.layout` bounds handling, `*OverScrollTest` |
 | Why did the snap land in the wrong place? | the strategy in `snapposition/`, `getCellDisplacementFromSnapPositionTests` |
 | Why is padding wrong? | `ListLayoutPaddingTest`; padding is applied in the layout managers, not the views |
-| Why did a ViewPager gesture land where it did? | `LayoutManager.setViewPageDistances` + `ViewPagerTest`, with each method it is built from in `LayoutManagerPagingMethodsTest` |
+| Why did a ViewPager gesture land where it did? | `LayoutManager.setViewPageDistances` and the strategy in `pageinterval/` + `ViewPagerTest`, with each method it is built from in `LayoutManagerPagingMethodsTest` |

--- a/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerGroupCellInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerGroupCellInstrumentedTest.java
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.attributes;
+
+import static org.junit.Assert.assertEquals;
+
+import android.content.Context;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.util.ArrayList;
+import java.util.List;
+import mobi.parchment.harness.FixedSizeAdapter;
+import mobi.parchment.harness.HarnessActivity;
+import mobi.parchment.harness.LaidOutChildren;
+import mobi.parchment.harness.ParchmentViewHarness;
+import mobi.parchment.test.R;
+import mobi.parchment.widget.adapterview.gridpatternview.GridPatternItemDefinition;
+import mobi.parchment.widget.adapterview.gridpatternview.GridPatternView;
+import mobi.parchment.widget.adapterview.gridview.GridView;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Proves that a ViewPager page is one cell on the two views whose cell is a whole group of items: a
+ * GridView cell is a row of parchment_numberOfViewsPerCell views, and a GridPatternView cell is one
+ * repeat of the pattern. Both are laid out three groups to a viewport here, so a page that counted
+ * what was visible would move three groups instead of one.
+ */
+@RunWith(AndroidJUnit4.class)
+public final class ViewPagerGroupCellInstrumentedTest {
+
+    private static final int GRID_VIEWPORT_WIDTH = 900;
+    private static final int VIEWPORT_HEIGHT = 600;
+    private static final int ROW_HEIGHT = 200;
+    private static final int VIEWS_PER_ROW = 3;
+    private static final int GRID_ITEM_WIDTH = GRID_VIEWPORT_WIDTH / VIEWS_PER_ROW;
+    private static final int GRID_ITEM_COUNT = 30;
+    private static final int FIRST_ITEM_OF_THE_SECOND_ROW = VIEWS_PER_ROW;
+    private static final int FIRST_ITEM_OF_THE_THIRD_ROW = VIEWS_PER_ROW * 2;
+
+    private static final int PATTERN_VIEWPORT_WIDTH = 600;
+    private static final int UNITS_ACROSS = 3;
+    private static final int UNIT_SIZE = PATTERN_VIEWPORT_WIDTH / UNITS_ACROSS;
+    private static final int PATTERN_ITEM_COUNT = 30;
+    private static final int FIRST_ITEM_OF_THE_SECOND_GROUP = UNITS_ACROSS;
+
+    private static final int MATCH_PARENT = ViewGroup.LayoutParams.MATCH_PARENT;
+    private static final int SNAP_POSITION_TOP = 0;
+    private static final int FIRST_ITEM = 0;
+
+    private static final int GESTURE_START_Y = 500;
+    private static final int GESTURE_END_Y = 100;
+    private static final int GESTURE_STEPS = 4;
+
+    @Rule
+    public final ActivityScenarioRule<HarnessActivity> mActivityRule =
+            new ActivityScenarioRule<>(HarnessActivity.class);
+
+    @Test
+    public void aGridFling_advancesExactlyOneRowRatherThanTheRowsOnScreen() {
+        final ParchmentViewHarness<GridView<BaseAdapter>> harness =
+                attachGrid(R.layout.instrumented_view_pager_grid);
+        final LaidOutChildren before = harness.children();
+        assertEquals(
+                "the second row should start one row down: " + before,
+                ROW_HEIGHT,
+                before.topOfAdapterPosition(FIRST_ITEM_OF_THE_SECOND_ROW));
+        assertEquals(
+                "three rows should fill the viewport: " + before,
+                VIEWPORT_HEIGHT - ROW_HEIGHT,
+                before.topOfAdapterPosition(FIRST_ITEM_OF_THE_THIRD_ROW));
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling should bring the second row to the top: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(FIRST_ITEM_OF_THE_SECOND_ROW));
+        assertEquals(
+                "the content should have moved by exactly one row: " + after,
+                -ROW_HEIGHT,
+                after.topOfAdapterPosition(FIRST_ITEM));
+    }
+
+    @Test
+    public void aGridWithAnIntervalOfTwo_advancesExactlyTwoRows() {
+        final ParchmentViewHarness<GridView<BaseAdapter>> harness =
+                attachGrid(R.layout.instrumented_view_pager_grid_interval_two);
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "an interval of two should bring the third row to the top: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(FIRST_ITEM_OF_THE_THIRD_ROW));
+        assertEquals(
+                "the second row should sit one row above it: " + after,
+                -ROW_HEIGHT,
+                after.topOfAdapterPosition(FIRST_ITEM_OF_THE_SECOND_ROW));
+    }
+
+    @Test
+    public void aGridPatternFling_advancesExactlyOneGroupRatherThanTheGroupsOnScreen() {
+        final ParchmentViewHarness<GridPatternView<BaseAdapter>> harness = attachPattern();
+        final LaidOutChildren before = harness.children();
+        assertEquals(
+                "the second group should start one group down: " + before,
+                UNIT_SIZE,
+                before.topOfAdapterPosition(FIRST_ITEM_OF_THE_SECOND_GROUP));
+
+        harness.fling(
+                PATTERN_VIEWPORT_WIDTH / 2,
+                GESTURE_START_Y,
+                PATTERN_VIEWPORT_WIDTH / 2,
+                GESTURE_END_Y,
+                GESTURE_STEPS);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling should bring the second group to the top: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(FIRST_ITEM_OF_THE_SECOND_GROUP));
+        assertEquals(
+                "the content should have moved by exactly one group: " + after,
+                -UNIT_SIZE,
+                after.topOfAdapterPosition(FIRST_ITEM));
+    }
+
+    private void flingForward(final ParchmentViewHarness<GridView<BaseAdapter>> harness) {
+        harness.fling(
+                GRID_VIEWPORT_WIDTH / 2,
+                GESTURE_START_Y,
+                GRID_VIEWPORT_WIDTH / 2,
+                GESTURE_END_Y,
+                GESTURE_STEPS);
+    }
+
+    private ParchmentViewHarness<GridView<BaseAdapter>> attachGrid(final int layoutResource) {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<GridView<BaseAdapter>> harness =
+                ParchmentViewHarness.attach(
+                        mActivityRule.getScenario(),
+                        layoutResource,
+                        GRID_VIEWPORT_WIDTH,
+                        VIEWPORT_HEIGHT);
+        final FixedSizeAdapter adapter =
+                new FixedSizeAdapter(context, GRID_ITEM_COUNT, GRID_ITEM_WIDTH, ROW_HEIGHT);
+        harness.setAdapter(adapter);
+        return harness;
+    }
+
+    private ParchmentViewHarness<GridPatternView<BaseAdapter>> attachPattern() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<GridPatternView<BaseAdapter>> harness =
+                ParchmentViewHarness.attach(
+                        mActivityRule.getScenario(),
+                        R.layout.instrumented_view_pager_pattern,
+                        PATTERN_VIEWPORT_WIDTH,
+                        VIEWPORT_HEIGHT);
+        harness.apply(new AddARowOfUnitSquares());
+        final FixedSizeAdapter adapter =
+                new FixedSizeAdapter(context, PATTERN_ITEM_COUNT, MATCH_PARENT, MATCH_PARENT);
+        harness.setAdapter(adapter);
+        return harness;
+    }
+
+    /**
+     * A pattern group of one row of one-by-one grid units, so the group is exactly one unit tall
+     * and three of them fill the viewport. The definition takes its arguments as top, left, height,
+     * width.
+     */
+    private static final class AddARowOfUnitSquares
+            implements ParchmentViewHarness.ViewSetup<GridPatternView<BaseAdapter>> {
+
+        private static final int ONE_UNIT = 1;
+
+        @Override
+        public void setUp(final GridPatternView<BaseAdapter> view) {
+            final List<GridPatternItemDefinition> definitions = new ArrayList<>();
+            for (int column = 0; column < UNITS_ACROSS; column++) {
+                definitions.add(new GridPatternItemDefinition(0, column, ONE_UNIT, ONE_UNIT));
+            }
+            view.addGridPatternGroupDefinition(definitions);
+        }
+    }
+}

--- a/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerGroupCellInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerGroupCellInstrumentedTest.java
@@ -109,10 +109,6 @@ public final class ViewPagerGroupCellInstrumentedTest {
                 after.topOfAdapterPosition(FIRST_ITEM_OF_THE_SECOND_ROW));
     }
 
-    /**
-     * With the interval left at viewport a grid pages by the rows that fit whole, which is the run
-     * of rows on screen: three 200px rows in a 600px viewport.
-     */
     @Test
     public void aGridViewportFling_advancesEveryWholeRowThatFits() {
         final ParchmentViewHarness<GridView<BaseAdapter>> harness =
@@ -136,10 +132,6 @@ public final class ViewPagerGroupCellInstrumentedTest {
                 after.topOfAdapterPosition(FIRST_ITEM_OF_THE_THIRD_ROW));
     }
 
-    /**
-     * The same on a pattern view, where a cell is a whole pattern group: three one-unit groups fit
-     * the viewport, so one fling advances all three.
-     */
     @Test
     public void aGridPatternViewportFling_advancesEveryWholeGroupThatFits() {
         final ParchmentViewHarness<GridPatternView<BaseAdapter>> harness =

--- a/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerGroupCellInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerGroupCellInstrumentedTest.java
@@ -42,12 +42,15 @@ public final class ViewPagerGroupCellInstrumentedTest {
     private static final int GRID_ITEM_COUNT = 30;
     private static final int FIRST_ITEM_OF_THE_SECOND_ROW = VIEWS_PER_ROW;
     private static final int FIRST_ITEM_OF_THE_THIRD_ROW = VIEWS_PER_ROW * 2;
+    private static final int FIRST_ITEM_OF_THE_FOURTH_ROW = VIEWS_PER_ROW * 3;
 
     private static final int PATTERN_VIEWPORT_WIDTH = 600;
     private static final int UNITS_ACROSS = 3;
     private static final int UNIT_SIZE = PATTERN_VIEWPORT_WIDTH / UNITS_ACROSS;
     private static final int PATTERN_ITEM_COUNT = 30;
     private static final int FIRST_ITEM_OF_THE_SECOND_GROUP = UNITS_ACROSS;
+    private static final int FIRST_ITEM_OF_THE_THIRD_GROUP = UNITS_ACROSS * 2;
+    private static final int FIRST_ITEM_OF_THE_FOURTH_GROUP = UNITS_ACROSS * 3;
 
     private static final int MATCH_PARENT = ViewGroup.LayoutParams.MATCH_PARENT;
     private static final int SNAP_POSITION_TOP = 0;
@@ -106,6 +109,61 @@ public final class ViewPagerGroupCellInstrumentedTest {
                 after.topOfAdapterPosition(FIRST_ITEM_OF_THE_SECOND_ROW));
     }
 
+    /**
+     * With the interval left at viewport a grid pages by the rows that fit whole, which is the run
+     * of rows on screen: three 200px rows in a 600px viewport.
+     */
+    @Test
+    public void aGridViewportFling_advancesEveryWholeRowThatFits() {
+        final ParchmentViewHarness<GridView<BaseAdapter>> harness =
+                attachGrid(R.layout.instrumented_view_pager_grid_viewport);
+        final LaidOutChildren before = harness.children();
+        assertEquals(
+                "three rows should fill the viewport: " + before,
+                VIEWPORT_HEIGHT - ROW_HEIGHT,
+                before.topOfAdapterPosition(FIRST_ITEM_OF_THE_THIRD_ROW));
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling should bring the fourth row to the top: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(FIRST_ITEM_OF_THE_FOURTH_ROW));
+        assertEquals(
+                "the content should have moved by three whole rows: " + after,
+                -ROW_HEIGHT,
+                after.topOfAdapterPosition(FIRST_ITEM_OF_THE_THIRD_ROW));
+    }
+
+    /**
+     * The same on a pattern view, where a cell is a whole pattern group: three one-unit groups fit
+     * the viewport, so one fling advances all three.
+     */
+    @Test
+    public void aGridPatternViewportFling_advancesEveryWholeGroupThatFits() {
+        final ParchmentViewHarness<GridPatternView<BaseAdapter>> harness =
+                attachPattern(R.layout.instrumented_view_pager_pattern_viewport);
+        final LaidOutChildren before = harness.children();
+        assertEquals(
+                "three groups should fill the viewport: " + before,
+                VIEWPORT_HEIGHT - UNIT_SIZE,
+                before.topOfAdapterPosition(FIRST_ITEM_OF_THE_THIRD_GROUP));
+
+        harness.fling(
+                PATTERN_VIEWPORT_WIDTH / 2,
+                GESTURE_START_Y,
+                PATTERN_VIEWPORT_WIDTH / 2,
+                GESTURE_END_Y,
+                GESTURE_STEPS);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling should bring the fourth group to the top: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(FIRST_ITEM_OF_THE_FOURTH_GROUP));
+    }
+
     @Test
     public void aGridPatternFling_advancesExactlyOneGroupRatherThanTheGroupsOnScreen() {
         final ParchmentViewHarness<GridPatternView<BaseAdapter>> harness = attachPattern();
@@ -157,11 +215,16 @@ public final class ViewPagerGroupCellInstrumentedTest {
     }
 
     private ParchmentViewHarness<GridPatternView<BaseAdapter>> attachPattern() {
+        return attachPattern(R.layout.instrumented_view_pager_pattern);
+    }
+
+    private ParchmentViewHarness<GridPatternView<BaseAdapter>> attachPattern(
+            final int layoutResource) {
         final Context context = ApplicationProvider.getApplicationContext();
         final ParchmentViewHarness<GridPatternView<BaseAdapter>> harness =
                 ParchmentViewHarness.attach(
                         mActivityRule.getScenario(),
-                        R.layout.instrumented_view_pager_pattern,
+                        layoutResource,
                         PATTERN_VIEWPORT_WIDTH,
                         VIEWPORT_HEIGHT);
         harness.apply(new AddARowOfUnitSquares());

--- a/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerIntervalInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerIntervalInstrumentedTest.java
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.attributes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import mobi.parchment.harness.AlternatingHeightAdapter;
+import mobi.parchment.harness.FixedSizeAdapter;
+import mobi.parchment.harness.HarnessActivity;
+import mobi.parchment.harness.LaidOutChildren;
+import mobi.parchment.harness.ParchmentViewHarness;
+import mobi.parchment.harness.PositionRecordingAdapter;
+import mobi.parchment.test.R;
+import mobi.parchment.widget.adapterview.listview.ListView;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Proves on a real framework that a ViewPager gesture advances exactly parchment_viewPagerInterval
+ * cells, whatever else is on screen. Every cell here is a third of the viewport, so three of them
+ * are visible at once: that is the arrangement issue #26 reported, where one swipe jumped three
+ * cells because the page was the whole run of visible cells rather than one of them.
+ *
+ * <p>The distance is measured, not counted, so these tests assert where a named adapter position
+ * came to rest in pixels rather than how many children are on screen.
+ */
+@RunWith(AndroidJUnit4.class)
+public final class ViewPagerIntervalInstrumentedTest {
+
+    private static final int VIEWPORT_WIDTH = 900;
+    private static final int VIEWPORT_HEIGHT = 600;
+    private static final int CELL_HEIGHT = 200;
+    private static final int CELLS_ON_SCREEN = VIEWPORT_HEIGHT / CELL_HEIGHT;
+    private static final int TALL_CELL_HEIGHT = CELL_HEIGHT;
+    private static final int SHORT_CELL_HEIGHT = 100;
+    private static final int OVERSIZED_CELL_HEIGHT = 900;
+    private static final int ITEM_COUNT = 10;
+    private static final int ITEMS_TO_THE_END = 4;
+    private static final int LAST_ITEM_TO_THE_END = ITEMS_TO_THE_END - 1;
+    private static final int CIRCULAR_ITEM_COUNT = 4;
+    private static final int LAST_CIRCULAR_ITEM = CIRCULAR_ITEM_COUNT - 1;
+    private static final int MATCH_PARENT = ViewGroup.LayoutParams.MATCH_PARENT;
+    private static final int SNAP_POSITION_TOP = 0;
+
+    private static final int GESTURE_X = VIEWPORT_WIDTH / 2;
+    private static final int GESTURE_START_Y = 500;
+    private static final int GESTURE_END_Y = 100;
+    private static final int GESTURE_TRAVEL = GESTURE_START_Y - GESTURE_END_Y;
+    private static final int GESTURE_STEPS = 4;
+    private static final int PART_WAY_TRAVEL = 60;
+    private static final int PART_WAY_END_Y = GESTURE_START_Y - PART_WAY_TRAVEL;
+    private static final int PART_WAY_STEPS = 2;
+
+    private static final int FIRST_ITEM = 0;
+    private static final int SECOND_ITEM = 1;
+    private static final int THIRD_ITEM = 2;
+
+    @Rule
+    public final ActivityScenarioRule<HarnessActivity> mActivityRule =
+            new ActivityScenarioRule<>(HarnessActivity.class);
+
+    /**
+     * The arrangement from issue #26: three cells fit the viewport, and one fling moves the content
+     * by one cell rather than by the three that are visible.
+     */
+    @Test
+    public void aFlingWithThreeCellsVisible_advancesExactlyOneCell() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager, ITEM_COUNT, CELL_HEIGHT);
+        final LaidOutChildren before = harness.children();
+        assertEquals(before.toString(), SNAP_POSITION_TOP, before.topOfAdapterPosition(FIRST_ITEM));
+        assertEquals(before.toString(), CELL_HEIGHT, before.topOfAdapterPosition(SECOND_ITEM));
+        assertEquals(
+                "the cell one short of the viewport should be the third: " + before,
+                VIEWPORT_HEIGHT - CELL_HEIGHT,
+                before.topOfAdapterPosition(CELLS_ON_SCREEN - 1));
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling should bring the second cell to the top: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(SECOND_ITEM));
+        assertEquals(
+                "the content should have moved by exactly one cell: " + after,
+                -CELL_HEIGHT,
+                after.topOfAdapterPosition(FIRST_ITEM));
+    }
+
+    @Test
+    public void aFlingBackWithThreeCellsVisible_advancesExactlyOneCell() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager, ITEM_COUNT, CELL_HEIGHT);
+        flingForward(harness);
+        harness.settle();
+        flingForward(harness);
+        final LaidOutChildren atTheThirdCell = harness.settle();
+        assertEquals(
+                "two flings should have reached the third cell: " + atTheThirdCell,
+                SNAP_POSITION_TOP,
+                atTheThirdCell.topOfAdapterPosition(THIRD_ITEM));
+
+        flingBack(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling back should return exactly one cell: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(SECOND_ITEM));
+        assertEquals(
+                "the third cell should sit one cell below it: " + after,
+                CELL_HEIGHT,
+                after.topOfAdapterPosition(THIRD_ITEM));
+    }
+
+    /**
+     * What the issue reporter actually complained about: the same swipe advanced a different number
+     * of cells depending on how it was made. A drag held still before it is released reports no
+     * fling and is stopped by the page clamp; a quick one reports a fling and is animated to the
+     * page. Both land on the second cell.
+     *
+     * <p>The drag half lands exactly on the cell because the clamp refuses a whole frame rather
+     * than the part of it that would overshoot, and this gesture's travel per frame divides the
+     * cell. A drag whose frames do not divide it stops at the last frame that fits and stays there,
+     * since these layouts do not ask for parchment_snapToPosition.
+     */
+    @Test
+    public void aSlowDragAndAFastFlingOfTheSameLength_bothAdvanceExactlyOneCell() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> dragged =
+                attachList(R.layout.instrumented_view_pager, ITEM_COUNT, CELL_HEIGHT);
+        dragged.dragAndRelease(GESTURE_X, GESTURE_START_Y, GESTURE_X, GESTURE_END_Y, GESTURE_STEPS);
+        final LaidOutChildren afterTheDrag = dragged.settle();
+
+        final ParchmentViewHarness<ListView<BaseAdapter>> flung =
+                attachList(R.layout.instrumented_view_pager, ITEM_COUNT, CELL_HEIGHT);
+        flingForward(flung);
+        final LaidOutChildren afterTheFling = flung.settle();
+
+        assertEquals(
+                "a slow drag of " + GESTURE_TRAVEL + "px should advance one cell: " + afterTheDrag,
+                SNAP_POSITION_TOP,
+                afterTheDrag.topOfAdapterPosition(SECOND_ITEM));
+        assertEquals(
+                "a fast fling of the same length should advance one cell too: " + afterTheFling,
+                SNAP_POSITION_TOP,
+                afterTheFling.topOfAdapterPosition(SECOND_ITEM));
+        assertEquals(
+                "the drag and the fling should leave the first cell in the same place",
+                afterTheDrag.topOfAdapterPosition(FIRST_ITEM),
+                afterTheFling.topOfAdapterPosition(FIRST_ITEM));
+    }
+
+    @Test
+    public void anIntervalOfTwoInXml_advancesExactlyTwoCells() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager_interval_two, ITEM_COUNT, CELL_HEIGHT);
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "an interval of two should bring the third cell to the top: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(THIRD_ITEM));
+        assertEquals(
+                "the content should have moved by exactly two cells: " + after,
+                -CELL_HEIGHT,
+                after.topOfAdapterPosition(SECOND_ITEM));
+    }
+
+    @Test
+    public void anIntervalOfTwoInXml_advancesExactlyTwoCellsBack() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager_interval_two, ITEM_COUNT, CELL_HEIGHT);
+        flingForward(harness);
+        final LaidOutChildren forward = harness.settle();
+        assertEquals(
+                "the forward fling should have reached the third cell: " + forward,
+                SNAP_POSITION_TOP,
+                forward.topOfAdapterPosition(THIRD_ITEM));
+
+        flingBack(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling back should return exactly two cells: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(FIRST_ITEM));
+    }
+
+    /**
+     * An interval of zero would ask a gesture to advance nothing and leave the view stuck, so the
+     * attribute is read as one. This is the clamp working through a real TypedArray rather than
+     * through the attribute getters.
+     */
+    @Test
+    public void anIntervalOfZeroInXml_isReadAsOneCell() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager_interval_zero, ITEM_COUNT, CELL_HEIGHT);
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "an interval of zero should still advance one cell: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(SECOND_ITEM));
+    }
+
+    /**
+     * Cells of different sizes page by their own size. The first page is a 200px cell and the
+     * second a 100px one, so no single cell size multiplied by an interval describes both.
+     */
+    @Test
+    public void cellsOfUnequalSize_pageByTheDistanceToTheNextCellRatherThanAFixedOne() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attach(R.layout.instrumented_view_pager);
+        final AlternatingHeightAdapter adapter =
+                new AlternatingHeightAdapter(
+                        context, ITEM_COUNT, MATCH_PARENT, TALL_CELL_HEIGHT, SHORT_CELL_HEIGHT);
+        harness.setAdapter(adapter);
+        final LaidOutChildren before = harness.children();
+        assertEquals(
+                "the second cell should start one tall cell down: " + before,
+                TALL_CELL_HEIGHT,
+                before.topOfAdapterPosition(SECOND_ITEM));
+
+        flingForward(harness);
+        final LaidOutChildren afterTheFirstPage = harness.settle();
+
+        assertEquals(
+                "the first page should be the tall cell's own height: " + afterTheFirstPage,
+                -TALL_CELL_HEIGHT,
+                afterTheFirstPage.topOfAdapterPosition(FIRST_ITEM));
+        assertEquals(
+                "the second cell should be at the top: " + afterTheFirstPage,
+                SNAP_POSITION_TOP,
+                afterTheFirstPage.topOfAdapterPosition(SECOND_ITEM));
+
+        flingForward(harness);
+        final LaidOutChildren afterTheSecondPage = harness.settle();
+
+        assertEquals(
+                "the second page should be the short cell's own height: " + afterTheSecondPage,
+                -SHORT_CELL_HEIGHT,
+                afterTheSecondPage.topOfAdapterPosition(SECOND_ITEM));
+        assertEquals(
+                "the third cell should be at the top: " + afterTheSecondPage,
+                SNAP_POSITION_TOP,
+                afterTheSecondPage.topOfAdapterPosition(THIRD_ITEM));
+    }
+
+    /**
+     * A cell taller than the viewport is one page on its own, which is what 1.6.6 intended and what
+     * the summing this replaced also happened to do for a cell resting at the snap position.
+     */
+    @Test
+    public void aCellTallerThanTheViewport_advancesExactlyOneCell() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager, ITEM_COUNT, OVERSIZED_CELL_HEIGHT);
+        final LaidOutChildren before = harness.children();
+        final int firstIndex = before.indexOfAdapterPosition(FIRST_ITEM);
+        assertTrue(
+                "the framework should have measured a cell taller than the viewport: " + before,
+                before.height(firstIndex) > before.viewHeight());
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling should move by the oversized cell's own height: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(SECOND_ITEM));
+    }
+
+    /**
+     * A gesture that starts with the content resting part-way through a cell lands on a cell
+     * boundary rather than carrying the offset along with it. The page is measured from where the
+     * cell nearest the snap position would sit once snapped, so it is 140px here, not the 200px a
+     * cell is wide.
+     */
+    @Test
+    public void aGestureFromARestingPositionPartWayThroughACell_landsOnACellBoundary() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager, ITEM_COUNT, CELL_HEIGHT);
+        assertTrue(
+                "a nudge of "
+                        + PART_WAY_TRAVEL
+                        + "px has to clear this device's touch slop of "
+                        + harness.touchSlop()
+                        + "px to move anything at all",
+                PART_WAY_TRAVEL > harness.touchSlop());
+
+        harness.dragAndRelease(
+                GESTURE_X, GESTURE_START_Y, GESTURE_X, PART_WAY_END_Y, PART_WAY_STEPS);
+        final LaidOutChildren partWay = harness.settle();
+        assertEquals(
+                "the nudge should leave the content part-way through the first cell: " + partWay,
+                -PART_WAY_TRAVEL,
+                partWay.topOfAdapterPosition(FIRST_ITEM));
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "the page should land the second cell exactly on the snap position: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(SECOND_ITEM));
+        assertEquals(
+                "the first cell should sit one whole cell above it: " + after,
+                -CELL_HEIGHT,
+                after.topOfAdapterPosition(FIRST_ITEM));
+    }
+
+    @Test
+    public void pagingBackAtTheFirstCell_holdsTheFirstCellOnTheSnapPosition() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager, ITEM_COUNT, CELL_HEIGHT);
+        final LaidOutChildren before = harness.children();
+        assertEquals(before.toString(), SNAP_POSITION_TOP, before.topOfAdapterPosition(FIRST_ITEM));
+
+        flingBack(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "there is nothing before the first cell to page to: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(FIRST_ITEM));
+        assertEquals(
+                "and nothing behind it should have been drawn: " + after,
+                FIRST_ITEM,
+                after.lowestAdapterPosition());
+    }
+
+    @Test
+    public void pagingForwardAtTheLastCell_holdsTheLastCellOnTheSnapPosition() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager, ITEMS_TO_THE_END, CELL_HEIGHT);
+        for (int page = 0; page < LAST_ITEM_TO_THE_END; page++) {
+            flingForward(harness);
+            harness.settle();
+        }
+        final LaidOutChildren atTheEnd = harness.settle();
+        assertEquals(
+                "paging to the end should rest the last cell on the snap position: " + atTheEnd,
+                SNAP_POSITION_TOP,
+                atTheEnd.topOfAdapterPosition(LAST_ITEM_TO_THE_END));
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "the last cell should still be on the snap position: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(LAST_ITEM_TO_THE_END));
+    }
+
+    /**
+     * An interval past the end of the adapter is capped at the adapter's last cell, the same way
+     * the fling snap extrapolation is capped, so a gesture cannot ask for a cell that does not
+     * exist.
+     */
+    @Test
+    public void anIntervalLargerThanTheAdapter_stopsAtTheLastCellInsteadOfRunningOff() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(
+                        R.layout.instrumented_view_pager_interval_beyond_adapter,
+                        ITEMS_TO_THE_END,
+                        CELL_HEIGHT);
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "the page should stop on the last cell: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(LAST_ITEM_TO_THE_END));
+    }
+
+    /**
+     * With circular scrolling the cap comes off, so paging forward from the last cell comes back
+     * round to the first instead of holding still.
+     */
+    @Test
+    public void circularPagingForwardPastTheLastCell_wrapsRoundToTheFirstCell() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(
+                        R.layout.instrumented_view_pager_circular,
+                        CIRCULAR_ITEM_COUNT,
+                        CELL_HEIGHT);
+        for (int page = 0; page < LAST_CIRCULAR_ITEM; page++) {
+            flingForward(harness);
+            harness.settle();
+        }
+        final LaidOutChildren atTheLastCell = harness.settle();
+        assertEquals(
+                "paging should have reached the last cell: " + atTheLastCell,
+                SNAP_POSITION_TOP,
+                atTheLastCell.topOfAdapterPosition(LAST_CIRCULAR_ITEM));
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one more page should come back round to the first cell: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(FIRST_ITEM));
+    }
+
+    @Test
+    public void circularPagingBackFromTheFirstCell_wrapsRoundToTheLastCell() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(
+                        R.layout.instrumented_view_pager_circular,
+                        CIRCULAR_ITEM_COUNT,
+                        CELL_HEIGHT);
+        final LaidOutChildren before = harness.children();
+        assertEquals(before.toString(), SNAP_POSITION_TOP, before.topOfAdapterPosition(FIRST_ITEM));
+
+        flingBack(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "paging back from the first cell should wrap to the last: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(LAST_CIRCULAR_ITEM));
+    }
+
+    /** A wrapped position is a layout-engine index and must never reach the adapter. */
+    @Test
+    public void circularPaging_neverAsksTheAdapterForAWrappedPosition() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attach(R.layout.instrumented_view_pager_circular);
+        final PositionRecordingAdapter adapter =
+                new PositionRecordingAdapter(
+                        context, CIRCULAR_ITEM_COUNT, MATCH_PARENT, CELL_HEIGHT);
+        harness.setAdapter(adapter);
+
+        for (int page = 0; page <= CIRCULAR_ITEM_COUNT; page++) {
+            flingForward(harness);
+            harness.settle();
+        }
+
+        assertTrue(
+                "the adapter was asked for " + adapter.requestedRange(),
+                adapter.lowestRequestedPosition() >= FIRST_ITEM);
+        assertTrue(
+                "the adapter was asked for " + adapter.requestedRange(),
+                adapter.highestRequestedPosition() <= LAST_CIRCULAR_ITEM);
+    }
+
+    private void flingForward(final ParchmentViewHarness<ListView<BaseAdapter>> harness) {
+        harness.fling(GESTURE_X, GESTURE_START_Y, GESTURE_X, GESTURE_END_Y, GESTURE_STEPS);
+    }
+
+    private void flingBack(final ParchmentViewHarness<ListView<BaseAdapter>> harness) {
+        harness.fling(GESTURE_X, GESTURE_END_Y, GESTURE_X, GESTURE_START_Y, GESTURE_STEPS);
+    }
+
+    private ParchmentViewHarness<ListView<BaseAdapter>> attachList(
+            final int layoutResource, final int itemCount, final int itemHeight) {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness = attach(layoutResource);
+        final FixedSizeAdapter adapter =
+                new FixedSizeAdapter(context, itemCount, MATCH_PARENT, itemHeight);
+        harness.setAdapter(adapter);
+        return harness;
+    }
+
+    private ParchmentViewHarness<ListView<BaseAdapter>> attach(final int layoutResource) {
+        return ParchmentViewHarness.attach(
+                mActivityRule.getScenario(), layoutResource, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+    }
+}

--- a/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerIntervalInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerIntervalInstrumentedTest.java
@@ -25,10 +25,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Proves on a real framework that a ViewPager gesture advances exactly parchment_viewPagerInterval
- * cells, whatever else is on screen. Every cell here is a third of the viewport, so three of them
- * are visible at once: that is the arrangement issue #26 reported, where one swipe jumped three
- * cells because the page was the whole run of visible cells rather than one of them.
+ * Proves on a real framework that a ViewPager gesture with a positive parchment_viewPagerInterval
+ * advances exactly that many cells, whatever else is on screen. Every cell here is a third of the
+ * viewport, so three of them are visible at once: that is the arrangement issue #26 reported, where
+ * one swipe jumped three cells because the page was the whole run of visible cells rather than one
+ * of them. An interval of one is what that reporter wants and every layout here declares it, since
+ * the attribute left unset still means viewport paging.
+ *
+ * <p>This class also pins which attribute values select which mode. The paging geometry of viewport
+ * mode is covered by ViewPagerViewportInstrumentedTest.
  *
  * <p>The distance is measured, not counted, so these tests assert where a named adapter position
  * came to rest in pixels rather than how many children are on screen.
@@ -199,22 +204,46 @@ public final class ViewPagerIntervalInstrumentedTest {
     }
 
     /**
-     * An interval of zero would ask a gesture to advance nothing and leave the view stuck, so the
-     * attribute is read as one. This is the clamp working through a real TypedArray rather than
-     * through the attribute getters.
+     * Zero is the value an absent attribute already yields, so "unset" and "viewport" are one
+     * state: both page by the whole run of cells that fit. This is the value arriving through a
+     * real TypedArray rather than through the attribute getters.
      */
     @Test
-    public void anIntervalOfZeroInXml_isReadAsOneCell() {
+    public void anIntervalOfZeroInXml_pagesByTheWholeViewport() {
+        assertPagesByTheWholeViewport(R.layout.instrumented_view_pager_interval_zero);
+    }
+
+    @Test
+    public void noIntervalInXml_pagesByTheWholeViewport() {
+        assertPagesByTheWholeViewport(R.layout.instrumented_view_pager_no_interval);
+    }
+
+    /** The viewport constant is aapt2 resolving a name to the same zero a literal gives. */
+    @Test
+    public void theViewportConstantInXml_pagesByTheWholeViewport() {
+        assertPagesByTheWholeViewport(R.layout.instrumented_view_pager_viewport);
+    }
+
+    /**
+     * A negative interval is not a number of cells, so it falls back to the default rather than
+     * paging backwards when the finger goes forwards.
+     */
+    @Test
+    public void aNegativeIntervalInXml_pagesByTheWholeViewport() {
+        assertPagesByTheWholeViewport(R.layout.instrumented_view_pager_interval_negative);
+    }
+
+    private void assertPagesByTheWholeViewport(final int layoutResource) {
         final ParchmentViewHarness<ListView<BaseAdapter>> harness =
-                attachList(R.layout.instrumented_view_pager_interval_zero, ITEM_COUNT, CELL_HEIGHT);
+                attachList(layoutResource, ITEM_COUNT, CELL_HEIGHT);
 
         flingForward(harness);
         final LaidOutChildren after = harness.settle();
 
         assertEquals(
-                "an interval of zero should still advance one cell: " + after,
+                "the page should be the whole run of cells that fit: " + after,
                 SNAP_POSITION_TOP,
-                after.topOfAdapterPosition(SECOND_ITEM));
+                after.topOfAdapterPosition(CELLS_ON_SCREEN));
     }
 
     /**

--- a/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerIntervalInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerIntervalInstrumentedTest.java
@@ -218,16 +218,11 @@ public final class ViewPagerIntervalInstrumentedTest {
         assertPagesByTheWholeViewport(R.layout.instrumented_view_pager_no_interval);
     }
 
-    /** The viewport constant is aapt2 resolving a name to the same zero a literal gives. */
     @Test
     public void theViewportConstantInXml_pagesByTheWholeViewport() {
         assertPagesByTheWholeViewport(R.layout.instrumented_view_pager_viewport);
     }
 
-    /**
-     * A negative interval is not a number of cells, so it falls back to the default rather than
-     * paging backwards when the finger goes forwards.
-     */
     @Test
     public void aNegativeIntervalInXml_pagesByTheWholeViewport() {
         assertPagesByTheWholeViewport(R.layout.instrumented_view_pager_interval_negative);

--- a/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerViewportInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerViewportInstrumentedTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import androidx.test.core.app.ApplicationProvider;
@@ -40,7 +41,6 @@ public final class ViewPagerViewportInstrumentedTest {
     private static final int CELLS_ON_SCREEN = VIEWPORT_HEIGHT / CELL_HEIGHT;
     private static final int UNEVEN_CELL_HEIGHT = 250;
     private static final int UNEVEN_CELLS_ON_SCREEN = VIEWPORT_HEIGHT / UNEVEN_CELL_HEIGHT;
-    private static final int TALL_CELL_HEIGHT = 200;
     private static final int SHORT_CELL_HEIGHT = 100;
     private static final int ALTERNATING_CELLS_ON_SCREEN = 4;
     private static final int OVERSIZED_CELL_HEIGHT = 900;
@@ -56,7 +56,6 @@ public final class ViewPagerViewportInstrumentedTest {
     private static final int CIRCULAR_ITEM_COUNT = 4;
     private static final int LAST_CIRCULAR_ITEM = CIRCULAR_ITEM_COUNT - 1;
     private static final int MATCH_PARENT = ViewGroup.LayoutParams.MATCH_PARENT;
-    private static final int SNAP_POSITION_TOP = 0;
     private static final int SNAP_POSITION_START = 0;
 
     private static final int GESTURE_X = VIEWPORT_WIDTH / 2;
@@ -89,7 +88,7 @@ public final class ViewPagerViewportInstrumentedTest {
 
         assertEquals(
                 "one fling should bring the fourth cell to the top: " + after,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 after.topOfAdapterPosition(CELLS_ON_SCREEN));
         assertEquals(
                 "the content should have moved by a whole viewport: " + after,
@@ -105,7 +104,7 @@ public final class ViewPagerViewportInstrumentedTest {
         final LaidOutChildren forward = harness.settle();
         assertEquals(
                 "the forward fling should have paged a viewport: " + forward,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 forward.topOfAdapterPosition(CELLS_ON_SCREEN));
 
         flingBack(harness);
@@ -113,14 +112,10 @@ public final class ViewPagerViewportInstrumentedTest {
 
         assertEquals(
                 "one fling back should return the whole viewport: " + after,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 after.topOfAdapterPosition(FIRST_ITEM));
     }
 
-    /**
-     * Cells that do not divide the viewport leave a partial cell behind rather than counting it:
-     * two 250px cells fit a 600px viewport whole and the third does not, so the page is 500px.
-     */
     @Test
     public void cellsThatDoNotDivideTheViewport_leaveThePartialCellForTheNextPage() {
         final ParchmentViewHarness<ListView<BaseAdapter>> harness =
@@ -132,7 +127,7 @@ public final class ViewPagerViewportInstrumentedTest {
 
         assertEquals(
                 "the third cell should come to the top: " + after,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 after.topOfAdapterPosition(UNEVEN_CELLS_ON_SCREEN));
         assertEquals(
                 "the page should be the two whole cells only: " + after,
@@ -140,10 +135,6 @@ public final class ViewPagerViewportInstrumentedTest {
                 after.topOfAdapterPosition(UNEVEN_CELLS_ON_SCREEN - 1));
     }
 
-    /**
-     * Cells of unequal size are measured, not counted: 200, 100, 200 and 100 fill exactly 600, so
-     * four of them make one page where a fixed cell size would give three or six.
-     */
     @Test
     public void cellsOfUnequalSize_advanceByTheCellsThatFitWhole() {
         final Context context = ApplicationProvider.getApplicationContext();
@@ -151,7 +142,7 @@ public final class ViewPagerViewportInstrumentedTest {
                 attach(R.layout.instrumented_view_pager_viewport);
         final AlternatingHeightAdapter adapter =
                 new AlternatingHeightAdapter(
-                        context, ITEM_COUNT, MATCH_PARENT, TALL_CELL_HEIGHT, SHORT_CELL_HEIGHT);
+                        context, ITEM_COUNT, MATCH_PARENT, CELL_HEIGHT, SHORT_CELL_HEIGHT);
         harness.setAdapter(adapter);
 
         flingForward(harness);
@@ -159,7 +150,7 @@ public final class ViewPagerViewportInstrumentedTest {
 
         assertEquals(
                 "the fifth cell should come to the top: " + after,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 after.topOfAdapterPosition(ALTERNATING_CELLS_ON_SCREEN));
         assertEquals(
                 "the page should be the four cells that fit whole: " + after,
@@ -167,10 +158,6 @@ public final class ViewPagerViewportInstrumentedTest {
                 after.topOfAdapterPosition(ALTERNATING_CELLS_ON_SCREEN - 1));
     }
 
-    /**
-     * A cell taller than the viewport is the first cell that does not fit, so the page falls back
-     * to the one cell it always advances at least.
-     */
     @Test
     public void aCellTallerThanTheViewport_advancesExactlyThatOneCell() {
         final ParchmentViewHarness<ListView<BaseAdapter>> harness =
@@ -189,14 +176,10 @@ public final class ViewPagerViewportInstrumentedTest {
 
         assertEquals(
                 "one fling should move by the oversized cell's own height: " + after,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 after.topOfAdapterPosition(SECOND_ITEM));
     }
 
-    /**
-     * The last page is short when the cells left do not fill a viewport: five 200px cells page
-     * three, then the last two, rather than running off the end.
-     */
     @Test
     public void aPartialPageAtTheEnd_advancesOnlyAsFarAsTheLastCell() {
         final ParchmentViewHarness<ListView<BaseAdapter>> harness =
@@ -208,7 +191,7 @@ public final class ViewPagerViewportInstrumentedTest {
         final LaidOutChildren firstPage = harness.settle();
         assertEquals(
                 "the first page should be the three cells that fit: " + firstPage,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 firstPage.topOfAdapterPosition(CELLS_ON_SCREEN));
 
         flingForward(harness);
@@ -216,7 +199,7 @@ public final class ViewPagerViewportInstrumentedTest {
 
         assertEquals(
                 "the last page should stop on the last cell: " + after,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 after.topOfAdapterPosition(LAST_OF_THE_SHORT_LAST_PAGE));
     }
 
@@ -233,7 +216,7 @@ public final class ViewPagerViewportInstrumentedTest {
         final LaidOutChildren atTheEnd = harness.settle();
         assertEquals(
                 "paging to the end should rest the last cell on the snap position: " + atTheEnd,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 atTheEnd.topOfAdapterPosition(LAST_OF_THE_SHORT_LAST_PAGE));
 
         flingForward(harness);
@@ -241,7 +224,7 @@ public final class ViewPagerViewportInstrumentedTest {
 
         assertEquals(
                 "the last cell should still be on the snap position: " + after,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 after.topOfAdapterPosition(LAST_OF_THE_SHORT_LAST_PAGE));
     }
 
@@ -255,7 +238,7 @@ public final class ViewPagerViewportInstrumentedTest {
 
         assertEquals(
                 "there is nothing before the first cell to page to: " + after,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 after.topOfAdapterPosition(FIRST_ITEM));
         assertEquals(
                 "and nothing behind it should have been drawn: " + after,
@@ -263,10 +246,6 @@ public final class ViewPagerViewportInstrumentedTest {
                 after.lowestAdapterPosition());
     }
 
-    /**
-     * The fit is measured against the size inside the padding, so a padded viewport pages fewer
-     * cells than its full height would allow: 500px of content fits two 200px cells, not three.
-     */
     @Test
     public void viewportPagingWithPadding_fitsTheCellsInsideThePaddingOnly() {
         final Context context = ApplicationProvider.getApplicationContext();
@@ -314,10 +293,6 @@ public final class ViewPagerViewportInstrumentedTest {
                 leftOfAdapterPosition(after, CELLS_ACROSS));
     }
 
-    /**
-     * Circular scrolling lifts the cap at the adapter's end, so a viewport page keeps advancing
-     * past the last cell instead of holding still the way the bounded list does.
-     */
     @Test
     public void circularViewportPaging_pastTheLastCell_keepsAdvancing() {
         final ParchmentViewHarness<ListView<BaseAdapter>> harness =
@@ -329,7 +304,7 @@ public final class ViewPagerViewportInstrumentedTest {
         final LaidOutChildren firstPage = harness.settle();
         assertEquals(
                 "the first page should reach the last cell: " + firstPage,
-                SNAP_POSITION_TOP,
+                SNAP_POSITION_START,
                 firstPage.topOfAdapterPosition(LAST_CIRCULAR_ITEM));
 
         flingForward(harness);
@@ -337,10 +312,10 @@ public final class ViewPagerViewportInstrumentedTest {
 
         assertFalse(
                 "a second page should have carried on past the last cell: " + after,
-                after.isAdapterPositionAtTop(LAST_CIRCULAR_ITEM, SNAP_POSITION_TOP));
+                after.isAdapterPositionAtTop(LAST_CIRCULAR_ITEM, SNAP_POSITION_START));
         assertTrue(
                 "and it should have wrapped round rather than stopped: " + after,
-                after.hasChildWithTop(SNAP_POSITION_TOP));
+                after.hasChildWithTop(SNAP_POSITION_START));
     }
 
     private static int leftOfAdapterPosition(
@@ -353,11 +328,11 @@ public final class ViewPagerViewportInstrumentedTest {
         return children.left(index);
     }
 
-    private void flingForward(final ParchmentViewHarness<ListView<BaseAdapter>> harness) {
+    private static void flingForward(final ParchmentViewHarness<ListView<BaseAdapter>> harness) {
         harness.fling(GESTURE_X, GESTURE_START_Y, GESTURE_X, GESTURE_END_Y, GESTURE_STEPS);
     }
 
-    private void flingBack(final ParchmentViewHarness<ListView<BaseAdapter>> harness) {
+    private static void flingBack(final ParchmentViewHarness<ListView<BaseAdapter>> harness) {
         harness.fling(GESTURE_X, GESTURE_END_Y, GESTURE_X, GESTURE_START_Y, GESTURE_STEPS);
     }
 
@@ -376,7 +351,7 @@ public final class ViewPagerViewportInstrumentedTest {
                 mActivityRule.getScenario(), layoutResource, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
     }
 
-    private static final class SetViewportPadding<VIEW extends android.view.View>
+    private static final class SetViewportPadding<VIEW extends View>
             implements ParchmentViewHarness.ViewSetup<VIEW> {
 
         private final int mPadding;

--- a/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerViewportInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/ViewPagerViewportInstrumentedTest.java
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.attributes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import mobi.parchment.harness.AlternatingHeightAdapter;
+import mobi.parchment.harness.FixedSizeAdapter;
+import mobi.parchment.harness.HarnessActivity;
+import mobi.parchment.harness.LaidOutChildren;
+import mobi.parchment.harness.ParchmentViewHarness;
+import mobi.parchment.test.R;
+import mobi.parchment.widget.adapterview.listview.ListView;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Proves on a real framework that a ViewPager gesture with parchment_viewPagerInterval left at
+ * viewport advances by the run of cells that fit the viewport whole, so pages do not overlap and
+ * each cell is shown once per pass. This is the paging Parchment has always done and it is still
+ * the default; an interval of one or more is the carousel that ViewPagerIntervalInstrumentedTest
+ * covers.
+ */
+@RunWith(AndroidJUnit4.class)
+public final class ViewPagerViewportInstrumentedTest {
+
+    private static final int VIEWPORT_WIDTH = 900;
+    private static final int VIEWPORT_HEIGHT = 600;
+    private static final int CELL_HEIGHT = 200;
+    private static final int CELLS_ON_SCREEN = VIEWPORT_HEIGHT / CELL_HEIGHT;
+    private static final int UNEVEN_CELL_HEIGHT = 250;
+    private static final int UNEVEN_CELLS_ON_SCREEN = VIEWPORT_HEIGHT / UNEVEN_CELL_HEIGHT;
+    private static final int TALL_CELL_HEIGHT = 200;
+    private static final int SHORT_CELL_HEIGHT = 100;
+    private static final int ALTERNATING_CELLS_ON_SCREEN = 4;
+    private static final int OVERSIZED_CELL_HEIGHT = 900;
+    private static final int CELL_WIDTH = 300;
+    private static final int CELLS_ACROSS = VIEWPORT_WIDTH / CELL_WIDTH;
+    private static final int VIEWPORT_PADDING = 50;
+    private static final int PADDED_VIEWPORT_HEIGHT = VIEWPORT_HEIGHT - 2 * VIEWPORT_PADDING;
+    private static final int PADDED_CELLS_ON_SCREEN = PADDED_VIEWPORT_HEIGHT / CELL_HEIGHT;
+
+    private static final int ITEM_COUNT = 10;
+    private static final int ITEMS_TO_A_SHORT_LAST_PAGE = 5;
+    private static final int LAST_OF_THE_SHORT_LAST_PAGE = ITEMS_TO_A_SHORT_LAST_PAGE - 1;
+    private static final int CIRCULAR_ITEM_COUNT = 4;
+    private static final int LAST_CIRCULAR_ITEM = CIRCULAR_ITEM_COUNT - 1;
+    private static final int MATCH_PARENT = ViewGroup.LayoutParams.MATCH_PARENT;
+    private static final int SNAP_POSITION_TOP = 0;
+    private static final int SNAP_POSITION_START = 0;
+
+    private static final int GESTURE_X = VIEWPORT_WIDTH / 2;
+    private static final int GESTURE_START_Y = 500;
+    private static final int GESTURE_END_Y = 100;
+    private static final int GESTURE_Y = VIEWPORT_HEIGHT / 2;
+    private static final int GESTURE_START_X = 800;
+    private static final int GESTURE_END_X = 200;
+    private static final int GESTURE_STEPS = 4;
+
+    private static final int FIRST_ITEM = 0;
+    private static final int SECOND_ITEM = 1;
+
+    @Rule
+    public final ActivityScenarioRule<HarnessActivity> mActivityRule =
+            new ActivityScenarioRule<>(HarnessActivity.class);
+
+    @Test
+    public void aFlingWithThreeCellsVisible_advancesAllThreeOfThem() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager_viewport, ITEM_COUNT, CELL_HEIGHT);
+        final LaidOutChildren before = harness.children();
+        assertEquals(
+                "three cells should fill the viewport: " + before,
+                VIEWPORT_HEIGHT - CELL_HEIGHT,
+                before.topOfAdapterPosition(CELLS_ON_SCREEN - 1));
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling should bring the fourth cell to the top: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(CELLS_ON_SCREEN));
+        assertEquals(
+                "the content should have moved by a whole viewport: " + after,
+                -CELL_HEIGHT,
+                after.topOfAdapterPosition(CELLS_ON_SCREEN - 1));
+    }
+
+    @Test
+    public void aFlingBack_returnsTheWholeViewportItCameOver() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager_viewport, ITEM_COUNT, CELL_HEIGHT);
+        flingForward(harness);
+        final LaidOutChildren forward = harness.settle();
+        assertEquals(
+                "the forward fling should have paged a viewport: " + forward,
+                SNAP_POSITION_TOP,
+                forward.topOfAdapterPosition(CELLS_ON_SCREEN));
+
+        flingBack(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling back should return the whole viewport: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(FIRST_ITEM));
+    }
+
+    /**
+     * Cells that do not divide the viewport leave a partial cell behind rather than counting it:
+     * two 250px cells fit a 600px viewport whole and the third does not, so the page is 500px.
+     */
+    @Test
+    public void cellsThatDoNotDivideTheViewport_leaveThePartialCellForTheNextPage() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(
+                        R.layout.instrumented_view_pager_viewport, ITEM_COUNT, UNEVEN_CELL_HEIGHT);
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "the third cell should come to the top: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(UNEVEN_CELLS_ON_SCREEN));
+        assertEquals(
+                "the page should be the two whole cells only: " + after,
+                -UNEVEN_CELL_HEIGHT,
+                after.topOfAdapterPosition(UNEVEN_CELLS_ON_SCREEN - 1));
+    }
+
+    /**
+     * Cells of unequal size are measured, not counted: 200, 100, 200 and 100 fill exactly 600, so
+     * four of them make one page where a fixed cell size would give three or six.
+     */
+    @Test
+    public void cellsOfUnequalSize_advanceByTheCellsThatFitWhole() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attach(R.layout.instrumented_view_pager_viewport);
+        final AlternatingHeightAdapter adapter =
+                new AlternatingHeightAdapter(
+                        context, ITEM_COUNT, MATCH_PARENT, TALL_CELL_HEIGHT, SHORT_CELL_HEIGHT);
+        harness.setAdapter(adapter);
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "the fifth cell should come to the top: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(ALTERNATING_CELLS_ON_SCREEN));
+        assertEquals(
+                "the page should be the four cells that fit whole: " + after,
+                -SHORT_CELL_HEIGHT,
+                after.topOfAdapterPosition(ALTERNATING_CELLS_ON_SCREEN - 1));
+    }
+
+    /**
+     * A cell taller than the viewport is the first cell that does not fit, so the page falls back
+     * to the one cell it always advances at least.
+     */
+    @Test
+    public void aCellTallerThanTheViewport_advancesExactlyThatOneCell() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(
+                        R.layout.instrumented_view_pager_viewport,
+                        ITEM_COUNT,
+                        OVERSIZED_CELL_HEIGHT);
+        final LaidOutChildren before = harness.children();
+        final int firstIndex = before.indexOfAdapterPosition(FIRST_ITEM);
+        assertTrue(
+                "the framework should have measured a cell taller than the viewport: " + before,
+                before.height(firstIndex) > before.viewHeight());
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling should move by the oversized cell's own height: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(SECOND_ITEM));
+    }
+
+    /**
+     * The last page is short when the cells left do not fill a viewport: five 200px cells page
+     * three, then the last two, rather than running off the end.
+     */
+    @Test
+    public void aPartialPageAtTheEnd_advancesOnlyAsFarAsTheLastCell() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(
+                        R.layout.instrumented_view_pager_viewport,
+                        ITEMS_TO_A_SHORT_LAST_PAGE,
+                        CELL_HEIGHT);
+        flingForward(harness);
+        final LaidOutChildren firstPage = harness.settle();
+        assertEquals(
+                "the first page should be the three cells that fit: " + firstPage,
+                SNAP_POSITION_TOP,
+                firstPage.topOfAdapterPosition(CELLS_ON_SCREEN));
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "the last page should stop on the last cell: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(LAST_OF_THE_SHORT_LAST_PAGE));
+    }
+
+    @Test
+    public void pagingForwardAtTheLastCell_holdsTheLastCellOnTheSnapPosition() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(
+                        R.layout.instrumented_view_pager_viewport,
+                        ITEMS_TO_A_SHORT_LAST_PAGE,
+                        CELL_HEIGHT);
+        flingForward(harness);
+        harness.settle();
+        flingForward(harness);
+        final LaidOutChildren atTheEnd = harness.settle();
+        assertEquals(
+                "paging to the end should rest the last cell on the snap position: " + atTheEnd,
+                SNAP_POSITION_TOP,
+                atTheEnd.topOfAdapterPosition(LAST_OF_THE_SHORT_LAST_PAGE));
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "the last cell should still be on the snap position: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(LAST_OF_THE_SHORT_LAST_PAGE));
+    }
+
+    @Test
+    public void pagingBackAtTheFirstCell_holdsTheFirstCellOnTheSnapPosition() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(R.layout.instrumented_view_pager_viewport, ITEM_COUNT, CELL_HEIGHT);
+
+        flingBack(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "there is nothing before the first cell to page to: " + after,
+                SNAP_POSITION_TOP,
+                after.topOfAdapterPosition(FIRST_ITEM));
+        assertEquals(
+                "and nothing behind it should have been drawn: " + after,
+                FIRST_ITEM,
+                after.lowestAdapterPosition());
+    }
+
+    /**
+     * The fit is measured against the size inside the padding, so a padded viewport pages fewer
+     * cells than its full height would allow: 500px of content fits two 200px cells, not three.
+     */
+    @Test
+    public void viewportPagingWithPadding_fitsTheCellsInsideThePaddingOnly() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attach(R.layout.instrumented_view_pager_viewport);
+        harness.apply(new SetViewportPadding<ListView<BaseAdapter>>(VIEWPORT_PADDING));
+        final FixedSizeAdapter adapter =
+                new FixedSizeAdapter(context, ITEM_COUNT, MATCH_PARENT, CELL_HEIGHT);
+        harness.setAdapter(adapter);
+        final LaidOutChildren before = harness.children();
+        assertEquals(
+                "the first cell should rest inside the padding: " + before,
+                VIEWPORT_PADDING,
+                before.topOfAdapterPosition(FIRST_ITEM));
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "only two cells fit inside the padding, so the third comes to the top: " + after,
+                VIEWPORT_PADDING,
+                after.topOfAdapterPosition(PADDED_CELLS_ON_SCREEN));
+    }
+
+    @Test
+    public void viewportPagingInAHorizontalList_advancesAWholeViewport() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attach(R.layout.instrumented_view_pager_viewport_horizontal);
+        final FixedSizeAdapter adapter =
+                new FixedSizeAdapter(context, ITEM_COUNT, CELL_WIDTH, MATCH_PARENT);
+        harness.setAdapter(adapter);
+        final LaidOutChildren before = harness.children();
+        assertEquals(
+                "three cells should fill the viewport across: " + before,
+                VIEWPORT_WIDTH - CELL_WIDTH,
+                leftOfAdapterPosition(before, CELLS_ACROSS - 1));
+
+        harness.fling(GESTURE_START_X, GESTURE_Y, GESTURE_END_X, GESTURE_Y, GESTURE_STEPS);
+        final LaidOutChildren after = harness.settle();
+
+        assertEquals(
+                "one fling should bring the fourth cell to the start: " + after,
+                SNAP_POSITION_START,
+                leftOfAdapterPosition(after, CELLS_ACROSS));
+    }
+
+    /**
+     * Circular scrolling lifts the cap at the adapter's end, so a viewport page keeps advancing
+     * past the last cell instead of holding still the way the bounded list does.
+     */
+    @Test
+    public void circularViewportPaging_pastTheLastCell_keepsAdvancing() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(
+                        R.layout.instrumented_view_pager_viewport_circular,
+                        CIRCULAR_ITEM_COUNT,
+                        CELL_HEIGHT);
+        flingForward(harness);
+        final LaidOutChildren firstPage = harness.settle();
+        assertEquals(
+                "the first page should reach the last cell: " + firstPage,
+                SNAP_POSITION_TOP,
+                firstPage.topOfAdapterPosition(LAST_CIRCULAR_ITEM));
+
+        flingForward(harness);
+        final LaidOutChildren after = harness.settle();
+
+        assertFalse(
+                "a second page should have carried on past the last cell: " + after,
+                after.isAdapterPositionAtTop(LAST_CIRCULAR_ITEM, SNAP_POSITION_TOP));
+        assertTrue(
+                "and it should have wrapped round rather than stopped: " + after,
+                after.hasChildWithTop(SNAP_POSITION_TOP));
+    }
+
+    private static int leftOfAdapterPosition(
+            final LaidOutChildren children, final int adapterPosition) {
+        final int index = children.indexOfAdapterPosition(adapterPosition);
+        if (index < 0) {
+            throw new AssertionError(
+                    "adapter position " + adapterPosition + " is not laid out: " + children);
+        }
+        return children.left(index);
+    }
+
+    private void flingForward(final ParchmentViewHarness<ListView<BaseAdapter>> harness) {
+        harness.fling(GESTURE_X, GESTURE_START_Y, GESTURE_X, GESTURE_END_Y, GESTURE_STEPS);
+    }
+
+    private void flingBack(final ParchmentViewHarness<ListView<BaseAdapter>> harness) {
+        harness.fling(GESTURE_X, GESTURE_END_Y, GESTURE_X, GESTURE_START_Y, GESTURE_STEPS);
+    }
+
+    private ParchmentViewHarness<ListView<BaseAdapter>> attachList(
+            final int layoutResource, final int itemCount, final int itemHeight) {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness = attach(layoutResource);
+        final FixedSizeAdapter adapter =
+                new FixedSizeAdapter(context, itemCount, MATCH_PARENT, itemHeight);
+        harness.setAdapter(adapter);
+        return harness;
+    }
+
+    private ParchmentViewHarness<ListView<BaseAdapter>> attach(final int layoutResource) {
+        return ParchmentViewHarness.attach(
+                mActivityRule.getScenario(), layoutResource, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+    }
+
+    private static final class SetViewportPadding<VIEW extends android.view.View>
+            implements ParchmentViewHarness.ViewSetup<VIEW> {
+
+        private final int mPadding;
+
+        private SetViewportPadding(final int padding) {
+            mPadding = padding;
+        }
+
+        @Override
+        public void setUp(final VIEW view) {
+            view.setPadding(mPadding, mPadding, mPadding, mPadding);
+        }
+    }
+}

--- a/library/src/androidTest/java/mobi/parchment/harness/ParchmentViewHarness.java
+++ b/library/src/androidTest/java/mobi/parchment/harness/ParchmentViewHarness.java
@@ -30,6 +30,7 @@ public final class ParchmentViewHarness<VIEW extends AbstractAdapterView<BaseAda
     private static final int MINIMUM_SETTLE_MILLISECONDS = 250;
     private static final int SLOP_CROSSINGS_IN_THE_FIRST_MOVE = 2;
     private static final int FIRST_STEP = 1;
+    private static final int ONE_STEP = 1;
     private static final float WHOLE_GESTURE = 1f;
     private static final int FRAME_MILLISECONDS = 16;
     private static final int NO_META_STATE = 0;
@@ -123,6 +124,13 @@ public final class ParchmentViewHarness<VIEW extends AbstractAdapterView<BaseAda
      * Dispatches one touch event per main-thread pass, waiting a frame between them. The waiting is
      * the point: Parchment applies a scroll on the animation frame that follows it, so a gesture
      * delivered without frames in between never reaches a layout pass.
+     *
+     * <p>The moves stop one step short of the target and the event that ends the gesture carries
+     * the last of the travel, so the final stretch of the gesture is still moving when the finger
+     * leaves. A move that already sat on the target followed by a lift at the same place gives the
+     * platform detector a stationary frame to end on, and the velocity it derives from that is too
+     * near zero to have a reliable sign: the same upward gesture was read as a fling one way from a
+     * cell boundary and the other way from a resting position part-way through a cell.
      */
     private void performGesture(
             final int fromX,
@@ -132,10 +140,11 @@ public final class ParchmentViewHarness<VIEW extends AbstractAdapterView<BaseAda
             final int steps,
             final int holdSteps) {
         final float firstProgress = firstMoveProgress(fromX, fromY, toX, toY, steps);
+        final int movesBeforeTheLastEvent = Math.max(FIRST_STEP, steps - ONE_STEP);
         final long downTime = SystemClock.uptimeMillis();
         long eventTime = downTime;
         dispatch(downTime, eventTime, MotionEvent.ACTION_DOWN, fromX, fromY);
-        for (int step = FIRST_STEP; step <= steps; step++) {
+        for (int step = FIRST_STEP; step <= movesBeforeTheLastEvent; step++) {
             sleepOneFrame();
             eventTime = eventTime + FRAME_MILLISECONDS;
             final float progress = progressAt(step, steps, firstProgress);
@@ -186,7 +195,12 @@ public final class ParchmentViewHarness<VIEW extends AbstractAdapterView<BaseAda
         return firstProgress + remaining * (stepsTaken / stepsAfterTheFirst);
     }
 
-    private int touchSlop() {
+    /**
+     * The platform touch slop for this view, so a test that depends on a gesture shorter than one
+     * cell can state the premise its numbers rest on rather than failing obscurely on a device with
+     * a different density.
+     */
+    public int touchSlop() {
         final ReadTouchSlop<VIEW> readTouchSlop = new ReadTouchSlop<>(mView);
         InstrumentationRegistry.getInstrumentation().runOnMainSync(readTouchSlop);
         return readTouchSlop.touchSlop();

--- a/library/src/androidTest/res/layout/instrumented_view_pager.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager.xml
@@ -7,4 +7,5 @@
     android:layout_height="match_parent"
     parchment:parchment_orientation="vertical"
     parchment:parchment_snapPosition="start"
-    parchment:parchment_isViewPager="true" />
+    parchment:parchment_isViewPager="true"
+    parchment:parchment_viewPagerInterval="1" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_circular.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_circular.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_isViewPager="true"
+    parchment:parchment_isCircularScroll="true" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_circular.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_circular.xml
@@ -7,4 +7,5 @@
     android:layout_height="match_parent"
     parchment:parchment_orientation="vertical"
     parchment:parchment_isViewPager="true"
-    parchment:parchment_isCircularScroll="true" />
+    parchment:parchment_isCircularScroll="true"
+    parchment:parchment_viewPagerInterval="1" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_grid.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_grid.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.gridview.GridView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_snapPosition="start"
+    parchment:parchment_numberOfViewsPerCell="3"
+    parchment:parchment_isViewPager="true" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_grid_interval_two.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_grid_interval_two.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.gridview.GridView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_snapPosition="start"
+    parchment:parchment_numberOfViewsPerCell="3"
+    parchment:parchment_isViewPager="true"
+    parchment:parchment_viewPagerInterval="2" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_grid_viewport.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_grid_viewport.xml
@@ -9,4 +9,4 @@
     parchment:parchment_snapPosition="start"
     parchment:parchment_numberOfViewsPerCell="3"
     parchment:parchment_isViewPager="true"
-    parchment:parchment_viewPagerInterval="1" />
+    parchment:parchment_viewPagerInterval="viewport" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_interval_beyond_adapter.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_interval_beyond_adapter.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_snapPosition="start"
+    parchment:parchment_isViewPager="true"
+    parchment:parchment_viewPagerInterval="50" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_interval_negative.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_interval_negative.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<mobi.parchment.widget.adapterview.gridview.GridView
+<mobi.parchment.widget.adapterview.listview.ListView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:parchment="http://schemas.android.com/apk/res-auto"
     android:id="@+id/parchment_view"
@@ -7,6 +7,5 @@
     android:layout_height="match_parent"
     parchment:parchment_orientation="vertical"
     parchment:parchment_snapPosition="start"
-    parchment:parchment_numberOfViewsPerCell="3"
     parchment:parchment_isViewPager="true"
-    parchment:parchment_viewPagerInterval="1" />
+    parchment:parchment_viewPagerInterval="-2" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_interval_two.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_interval_two.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_snapPosition="start"
+    parchment:parchment_isViewPager="true"
+    parchment:parchment_viewPagerInterval="2" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_interval_zero.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_interval_zero.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_snapPosition="start"
+    parchment:parchment_isViewPager="true"
+    parchment:parchment_viewPagerInterval="0" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_no_interval.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_no_interval.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<mobi.parchment.widget.adapterview.gridview.GridView
+<mobi.parchment.widget.adapterview.listview.ListView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:parchment="http://schemas.android.com/apk/res-auto"
     android:id="@+id/parchment_view"
@@ -7,6 +7,4 @@
     android:layout_height="match_parent"
     parchment:parchment_orientation="vertical"
     parchment:parchment_snapPosition="start"
-    parchment:parchment_numberOfViewsPerCell="3"
-    parchment:parchment_isViewPager="true"
-    parchment:parchment_viewPagerInterval="1" />
+    parchment:parchment_isViewPager="true" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_pattern.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_pattern.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.gridpatternview.GridPatternView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_snapPosition="start"
+    parchment:parchment_ratio="1.0"
+    parchment:parchment_isViewPager="true" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_pattern.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_pattern.xml
@@ -8,4 +8,5 @@
     parchment:parchment_orientation="vertical"
     parchment:parchment_snapPosition="start"
     parchment:parchment_ratio="1.0"
-    parchment:parchment_isViewPager="true" />
+    parchment:parchment_isViewPager="true"
+    parchment:parchment_viewPagerInterval="1" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_pattern_viewport.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_pattern_viewport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<mobi.parchment.widget.adapterview.gridview.GridView
+<mobi.parchment.widget.adapterview.gridpatternview.GridPatternView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:parchment="http://schemas.android.com/apk/res-auto"
     android:id="@+id/parchment_view"
@@ -7,6 +7,6 @@
     android:layout_height="match_parent"
     parchment:parchment_orientation="vertical"
     parchment:parchment_snapPosition="start"
-    parchment:parchment_numberOfViewsPerCell="3"
+    parchment:parchment_ratio="1.0"
     parchment:parchment_isViewPager="true"
-    parchment:parchment_viewPagerInterval="1" />
+    parchment:parchment_viewPagerInterval="viewport" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_viewport.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_viewport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<mobi.parchment.widget.adapterview.gridview.GridView
+<mobi.parchment.widget.adapterview.listview.ListView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:parchment="http://schemas.android.com/apk/res-auto"
     android:id="@+id/parchment_view"
@@ -7,6 +7,5 @@
     android:layout_height="match_parent"
     parchment:parchment_orientation="vertical"
     parchment:parchment_snapPosition="start"
-    parchment:parchment_numberOfViewsPerCell="3"
     parchment:parchment_isViewPager="true"
-    parchment:parchment_viewPagerInterval="1" />
+    parchment:parchment_viewPagerInterval="viewport" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_viewport_circular.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_viewport_circular.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<mobi.parchment.widget.adapterview.gridview.GridView
+<mobi.parchment.widget.adapterview.listview.ListView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:parchment="http://schemas.android.com/apk/res-auto"
     android:id="@+id/parchment_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     parchment:parchment_orientation="vertical"
-    parchment:parchment_snapPosition="start"
-    parchment:parchment_numberOfViewsPerCell="3"
     parchment:parchment_isViewPager="true"
-    parchment:parchment_viewPagerInterval="1" />
+    parchment:parchment_isCircularScroll="true"
+    parchment:parchment_viewPagerInterval="viewport" />

--- a/library/src/androidTest/res/layout/instrumented_view_pager_viewport_horizontal.xml
+++ b/library/src/androidTest/res/layout/instrumented_view_pager_viewport_horizontal.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<mobi.parchment.widget.adapterview.gridview.GridView
+<mobi.parchment.widget.adapterview.listview.ListView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:parchment="http://schemas.android.com/apk/res-auto"
     android:id="@+id/parchment_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    parchment:parchment_orientation="vertical"
+    parchment:parchment_orientation="horizontal"
     parchment:parchment_snapPosition="start"
-    parchment:parchment_numberOfViewsPerCell="3"
     parchment:parchment_isViewPager="true"
-    parchment:parchment_viewPagerInterval="1" />
+    parchment:parchment_viewPagerInterval="viewport" />

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
@@ -429,7 +429,7 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
     private static final class AnimationFrameRunnable implements Runnable {
         private final AbstractAdapterView<?, ?> mView;
 
-        AnimationFrameRunnable(final AbstractAdapterView<?, ?> view) {
+        private AnimationFrameRunnable(final AbstractAdapterView<?, ?> view) {
             mView = view;
         }
 

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AdapterAnimator.java
@@ -150,7 +150,7 @@ public class AdapterAnimator implements OnGestureListener, AnimationStoppedListe
         return mState;
     }
 
-    void setState(final State state) {
+    private void setState(final State state) {
         if (!mScrollAnimator.isFinished()) mScrollAnimator.forceFinished(true);
 
         final boolean isNotMoving = mState.equals(State.notMoving);

--- a/library/src/main/java/mobi/parchment/widget/adapterview/Animation.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/Animation.java
@@ -8,15 +8,11 @@ public class Animation {
     private int mId;
     private int mDisplacement;
 
-    void setId(final int id) {
-        mId = id;
-    }
-
     public int getId() {
         return mId;
     }
 
-    void setDisplacement(final int displacemente) {
+    protected void setDisplacement(final int displacemente) {
         mDisplacement = displacemente;
     }
 
@@ -24,7 +20,7 @@ public class Animation {
         return mDisplacement;
     }
 
-    void newAnimation() {
+    protected void newAnimation() {
         mId = (mId + 1) % ANIMATION_ID_LIMIT;
         mDisplacement = 0;
     }

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AnimationFrameScheduler.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AnimationFrameScheduler.java
@@ -4,5 +4,5 @@
 package mobi.parchment.widget.adapterview;
 
 public interface AnimationFrameScheduler {
-    void requestAnimationFrame();
+    public void requestAnimationFrame();
 }

--- a/library/src/main/java/mobi/parchment/widget/adapterview/Attributes.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/Attributes.java
@@ -12,7 +12,7 @@ public class Attributes {
 
     private static class DefaultValues {
         private static final int CELL_SPACING = 0;
-        private static final int VIEW_PAGER_INTERVAL = 0;
+        private static final int VIEW_PAGER_INTERVAL = 1;
         private static final Orientation ORIENTATION = Orientation.vertical;
         private static final boolean IS_CIRCULAR_SCROLL = false;
         private static final boolean SNAP_TO_POSITION = false;
@@ -58,6 +58,11 @@ public class Attributes {
                         typedArray.getBoolean(
                                 R.styleable.ListView_parchment_isViewPager,
                                 DefaultValues.IS_VIEW_PAGER);
+                final int viewPagerInterval =
+                        typedArray.getInteger(
+                                R.styleable.ListView_parchment_viewPagerInterval,
+                                DefaultValues.VIEW_PAGER_INTERVAL);
+                mViewPagerInterval = Math.max(viewPagerInterval, DefaultValues.VIEW_PAGER_INTERVAL);
                 mIsCircularScroll =
                         typedArray.getBoolean(
                                 R.styleable.ListView_parchment_isCircularScroll,

--- a/library/src/main/java/mobi/parchment/widget/adapterview/Attributes.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/Attributes.java
@@ -12,7 +12,7 @@ public class Attributes {
 
     private static class DefaultValues {
         private static final int CELL_SPACING = 0;
-        private static final int VIEW_PAGER_INTERVAL = 1;
+        private static final int VIEW_PAGER_INTERVAL = 0;
         private static final Orientation ORIENTATION = Orientation.vertical;
         private static final boolean IS_CIRCULAR_SCROLL = false;
         private static final boolean SNAP_TO_POSITION = false;

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
@@ -11,6 +11,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import mobi.parchment.widget.adapterview.pageinterval.PageIntervalInterface;
+import mobi.parchment.widget.adapterview.pageinterval.PageIntervalSelector;
 import mobi.parchment.widget.adapterview.snapposition.CenterSnapPosition;
 import mobi.parchment.widget.adapterview.snapposition.EndSnapPosition;
 import mobi.parchment.widget.adapterview.snapposition.OnScreenSnapPosition;
@@ -19,9 +21,6 @@ import mobi.parchment.widget.adapterview.snapposition.StartSnapPosition;
 
 public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
     public static final int INVALID_POSITION = -1;
-
-    private static final int VIEWPORT_VIEW_PAGER_INTERVAL = 0;
-    private static final int ONE_CELL = 1;
 
     private final Map<View, Integer> mPositions = new HashMap<View, Integer>();
 
@@ -32,8 +31,8 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
     private int mAnimationId = -1;
     private int mOffset = 0;
     private int mStartCellPosition;
-    int mViewPageDistanceForward;
-    int mViewPageDistanceBack;
+    protected int mViewPageDistanceForward;
+    protected int mViewPageDistanceBack;
     private int mAnimationDisplacement;
     protected final ViewGroup mViewGroup;
     private final ScrollDirectionManager mScrollDirectionManager;
@@ -44,6 +43,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
 
     protected final List<Cell> mCells = new ArrayList<Cell>();
     private final SnapPositionInterface<Cell> mSnapPositionInterface;
+    private final PageIntervalInterface<Cell> mPageIntervalInterface;
     private View mPressedView;
     private int mWidthMeasureSpec;
     private int mHeightMeasureSpec;
@@ -63,6 +63,9 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         final boolean isCircularScroll = mLayoutManagerAttributes.isCircularScroll();
         final SnapPosition snapPosition = getSnapPosition(isCircularScroll);
         mSnapPositionInterface = getSnapPositionInterface(snapPosition);
+
+        final int viewPagerInterval = mLayoutManagerAttributes.getViewPagerInterval();
+        mPageIntervalInterface = PageIntervalSelector.getPageIntervalInterface(viewPagerInterval);
     }
 
     public int getSelectedPosition() {
@@ -91,7 +94,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         }
     }
 
-    protected int getCellSpacing() {
+    public int getCellSpacing() {
         final int cellSpacing = mLayoutManagerAttributes.getCellSpacing();
         return cellSpacing;
     }
@@ -338,7 +341,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         }
     }
 
-    void setViewPageDistances(final int size) {
+    protected void setViewPageDistances(final int size) {
         final boolean isViewPager = mLayoutManagerAttributes.isViewPager();
         if (!isViewPager) return;
 
@@ -349,125 +352,27 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         final int anchorSnappedStart = anchorStart + anchorSnapDisplacement;
         final int viewportEnd = getStartSizePadding() + size;
         final int maximumPageSize = viewportEnd - anchorSnappedStart;
-        final int viewPagerInterval = mLayoutManagerAttributes.getViewPagerInterval();
 
         final long forwardCellIndex =
-                getPageCellIndexForward(
-                        viewPagerInterval, maximumPageSize, anchorIndex, anchorStart);
+                mPageIntervalInterface.getPageCellIndexForward(
+                        this, maximumPageSize, anchorIndex, anchorStart);
         final int forwardCellStart = getCellStartAtIndex(forwardCellIndex);
         mViewPageDistanceForward = forwardCellStart - anchorSnappedStart;
 
         final long backCellIndex =
-                getPageCellIndexBack(viewPagerInterval, maximumPageSize, anchorIndex, anchorStart);
+                mPageIntervalInterface.getPageCellIndexBack(
+                        this, maximumPageSize, anchorIndex, anchorStart);
         final int backCellStart = getCellStartAtIndex(backCellIndex);
         mViewPageDistanceBack = anchorSnappedStart - backCellStart;
     }
 
-    static boolean pagesByCellCount(final int viewPagerInterval) {
-        return viewPagerInterval != VIEWPORT_VIEW_PAGER_INTERVAL;
-    }
-
-    long getPageCellIndexForward(
-            final int viewPagerInterval,
-            final int maximumPageSize,
-            final int anchorIndex,
-            final int anchorStart) {
-        if (pagesByCellCount(viewPagerInterval)) {
-            return getPageCellIndexForwardByCellCount(viewPagerInterval, anchorIndex);
-        }
-        return getPageCellIndexForwardByViewport(maximumPageSize, anchorIndex, anchorStart);
-    }
-
-    static long getPageCellIndexForwardByCellCount(
-            final int viewPagerInterval, final int anchorIndex) {
-        return (long) anchorIndex + viewPagerInterval;
-    }
-
-    long getPageCellIndexForwardByViewport(
-            final int maximumPageSize, final int anchorIndex, final int anchorStart) {
-        long pageCellIndex = anchorIndex + ONE_CELL;
-        int pageCellStart = getCellStartAtIndex(pageCellIndex);
-        long nextCellIndex = pageCellIndex + ONE_CELL;
-        int nextCellStart = getCellStartAtIndex(nextCellIndex);
-
-        while (nextCellJoinsThePage(maximumPageSize, anchorStart, pageCellStart, nextCellStart)) {
-            pageCellIndex = nextCellIndex;
-            pageCellStart = nextCellStart;
-            nextCellIndex = pageCellIndex + ONE_CELL;
-            nextCellStart = getCellStartAtIndex(nextCellIndex);
-        }
-
-        return pageCellIndex;
-    }
-
-    long getPageCellIndexBack(
-            final int viewPagerInterval,
-            final int maximumPageSize,
-            final int anchorIndex,
-            final int anchorStart) {
-        if (pagesByCellCount(viewPagerInterval)) {
-            return getPageCellIndexBackByCellCount(viewPagerInterval, anchorIndex);
-        }
-        return getPageCellIndexBackByViewport(maximumPageSize, anchorIndex, anchorStart);
-    }
-
-    static long getPageCellIndexBackByCellCount(
-            final int viewPagerInterval, final int anchorIndex) {
-        return (long) anchorIndex - viewPagerInterval;
-    }
-
-    long getPageCellIndexBackByViewport(
-            final int maximumPageSize, final int anchorIndex, final int anchorStart) {
-        long pageCellIndex = anchorIndex - ONE_CELL;
-        int pageCellStart = getCellStartAtIndex(pageCellIndex);
-        long previousCellIndex = pageCellIndex - ONE_CELL;
-        int previousCellStart = getCellStartAtIndex(previousCellIndex);
-
-        while (previousCellJoinsThePage(
-                maximumPageSize, anchorStart, pageCellStart, previousCellStart)) {
-            pageCellIndex = previousCellIndex;
-            pageCellStart = previousCellStart;
-            previousCellIndex = pageCellIndex - ONE_CELL;
-            previousCellStart = getCellStartAtIndex(previousCellIndex);
-        }
-
-        return pageCellIndex;
-    }
-
-    boolean nextCellJoinsThePage(
-            final int maximumPageSize,
-            final int pageStart,
-            final int pageCellStart,
-            final int nextCellStart) {
-        final boolean hasAFurtherCell = nextCellStart > pageCellStart;
-        if (!hasAFurtherCell) return false;
-        return pageFits(maximumPageSize, pageStart, nextCellStart);
-    }
-
-    boolean previousCellJoinsThePage(
-            final int maximumPageSize,
-            final int pageLimitStart,
-            final int pageCellStart,
-            final int previousCellStart) {
-        final boolean hasAFurtherCell = previousCellStart < pageCellStart;
-        if (!hasAFurtherCell) return false;
-        return pageFits(maximumPageSize, previousCellStart, pageLimitStart);
-    }
-
-    boolean pageFits(final int maximumPageSize, final long pageStart, final long pageLimitStart) {
-        final int cellSpacing = getCellSpacing();
-        final long pageEnd = pageLimitStart - cellSpacing;
-        final long pageSize = pageEnd - pageStart;
-        return pageSize <= maximumPageSize;
-    }
-
-    int getSnapDisplacement(final int size, final Cell cell) {
+    protected int getSnapDisplacement(final int size, final Cell cell) {
         final View view = getView(cell);
         if (view == null) return 0;
         return getSnapToPixelDistance(size, view);
     }
 
-    int getCellStartAtIndex(final long cellIndex) {
+    public int getCellStartAtIndex(final long cellIndex) {
         final int lastCellIndex = mCells.size() - 1;
 
         final boolean isBeforeTheFirstCell = cellIndex < 0;
@@ -479,7 +384,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         return getCellStart(mCells.get((int) cellIndex));
     }
 
-    int getCellStartExtrapolatedBeforeFirst(final long cellIndex) {
+    protected int getCellStartExtrapolatedBeforeFirst(final long cellIndex) {
         final int cellSpacing = getCellSpacing();
         final Cell firstCell = mCells.get(0);
         final long step = getCellSize(firstCell) + cellSpacing;
@@ -488,7 +393,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         return getDrawableCellStart(cellStart);
     }
 
-    int getCellStartExtrapolatedAfterLast(final long cellIndex) {
+    protected int getCellStartExtrapolatedAfterLast(final long cellIndex) {
         final int cellSpacing = getCellSpacing();
         final int lastCellIndex = mCells.size() - 1;
         final Cell lastCell = mCells.get(lastCellIndex);

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
@@ -227,7 +227,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
 
         final int adjust = setOffset(displacement, newSize);
 
-        if (continuedAnimation) mAnimationDisplacement += adjust;
+        mAnimationDisplacement += adjust;
 
         final int breadth = mScrollDirectionManager.getDrawBreadth(left, top, right, bottom);
         layoutCells(adapterViewHandler, newSize, breadth);

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
@@ -29,7 +29,8 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
     private int mAnimationId = -1;
     private int mOffset = 0;
     private int mStartCellPosition;
-    private int mViewPageDistance;
+    private int mViewPageDistanceForward;
+    private int mViewPageDistanceBack;
     private int mAnimationDisplacement;
     protected final ViewGroup mViewGroup;
     private final ScrollDirectionManager mScrollDirectionManager;
@@ -209,20 +210,21 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         final int animationId = animation.getId();
         final boolean continuedAnimation = animationId == mAnimationId;
 
+        final int startSizePadding = getStartSizePadding();
+        final int endSizePadding = getEndSizePadding();
+
+        final int newSize =
+                size - startSizePadding - endSizePadding; // Todo: consider padding for newSize
+
         if (!continuedAnimation && !mCells.isEmpty()) {
             mAnimationId = animationId;
-            mViewPageDistance = getViewPageDistance(size);
+            setViewPageDistances(newSize);
             mAnimationDisplacement = displacement;
 
         } else if (continuedAnimation) {
             mAnimationDisplacement += displacement;
         }
 
-        final int startSizePadding = getStartSizePadding();
-        final int endSizePadding = getEndSizePadding();
-
-        final int newSize =
-                size - startSizePadding - endSizePadding; // Todo: consider padding for newSize
         final int adjust = setOffset(displacement, newSize);
 
         if (continuedAnimation) mAnimationDisplacement += adjust;
@@ -333,54 +335,89 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         }
     }
 
-    private int getViewPageDistance(final int size) {
-        final int cellSpacing = mLayoutManagerAttributes.getCellSpacing();
-        int viewPageDistance = 0;
-        int numberOfCells = 0;
-        for (final Cell cell : mCells) {
-            final int start = getCellStart(cell);
-            final int end = getCellEnd(cell);
+    private void setViewPageDistances(final int size) {
+        final boolean isViewPager = mLayoutManagerAttributes.isViewPager();
+        if (!isViewPager) return;
 
-            if (start >= 0 && end <= size) {
-                final int cellSize = end - start;
-                viewPageDistance += cellSize;
-                numberOfCells++;
-            } else if (start < 0 && end > size) {
-                final int cellSize = end - start;
-                return cellSize + cellSpacing;
+        final int anchorIndex = getNearestCellIndexToSnapPosition(size);
+        final Cell anchorCell = mCells.get(anchorIndex);
+        final int anchorStart = getCellStart(anchorCell);
+        final int anchorSnapDisplacement = getSnapDisplacement(size, anchorCell);
+        final int anchorSnappedStart = anchorStart + anchorSnapDisplacement;
+        final int viewPagerInterval = mLayoutManagerAttributes.getViewPagerInterval();
+
+        final long forwardCellIndex = (long) anchorIndex + viewPagerInterval;
+        final int forwardCellStart = getCellStartAtIndex(forwardCellIndex);
+        mViewPageDistanceForward = forwardCellStart - anchorSnappedStart;
+
+        final long backCellIndex = (long) anchorIndex - viewPagerInterval;
+        final int backCellStart = getCellStartAtIndex(backCellIndex);
+        mViewPageDistanceBack = anchorSnappedStart - backCellStart;
+    }
+
+    private int getSnapDisplacement(final int size, final Cell cell) {
+        final View view = getView(cell);
+        if (view == null) return 0;
+        return getSnapToPixelDistance(size, view);
+    }
+
+    private int getCellStartAtIndex(final long cellIndex) {
+        final int lastCellIndex = mCells.size() - 1;
+        final int cellSpacing = getCellSpacing();
+
+        if (cellIndex < 0) {
+            final Cell firstCell = mCells.get(0);
+            final long step = getCellSize(firstCell) + cellSpacing;
+            final long steps = Math.min(-cellIndex, getCellsBeforeFirst());
+            final long cellStart = getCellStart(firstCell) - steps * step;
+            return getDrawableCellStart(cellStart);
+        }
+
+        if (cellIndex > lastCellIndex) {
+            final Cell lastCell = mCells.get(lastCellIndex);
+            final long step = getCellSize(lastCell) + cellSpacing;
+            final long steps = Math.min(cellIndex - lastCellIndex, getCellsAfterLast());
+            final long cellStart = getCellStart(lastCell) + steps * step;
+            return getDrawableCellStart(cellStart);
+        }
+
+        return getCellStart(mCells.get((int) cellIndex));
+    }
+
+    private int getDrawableCellStart(final long cellStart) {
+        if (cellStart > MAX) return MAX;
+        if (cellStart < -MAX) return -MAX;
+        return (int) cellStart;
+    }
+
+    private int getNearestCellIndexToSnapPosition(final int size) {
+        final Cell firstCell = mCells.get(0);
+        int nearestCellIndex = 0;
+        int nearestCellDistance =
+                mSnapPositionInterface.getCellDistanceFromSnapPosition(this, size, firstCell);
+
+        for (int cellIndex = 1; cellIndex < mCells.size(); cellIndex++) {
+            final Cell currentCell = mCells.get(cellIndex);
+            final int currentCellDistance =
+                    mSnapPositionInterface.getCellDistanceFromSnapPosition(this, size, currentCell);
+            final boolean currentCellIsCloser = currentCellDistance < nearestCellDistance;
+
+            if (currentCellIsCloser) {
+                nearestCellDistance = currentCellDistance;
+                nearestCellIndex = cellIndex;
             }
         }
-        viewPageDistance += Math.max(0, numberOfCells - 1) * cellSpacing;
 
-        final boolean calculateFirstView = !mCells.isEmpty() && viewPageDistance == 0;
-        if (calculateFirstView) {
-            final Cell cell = mCells.get(0);
-            final int start = getCellStart(cell);
-            final int end = getCellEnd(cell);
-            viewPageDistance = end - start;
-        }
-
-        return viewPageDistance + cellSpacing;
+        return nearestCellIndex;
     }
 
     private View getNearestViewToSnapPosition(final int size) {
-        Cell nearestCell = null;
-        int nearestCellDistance = Integer.MAX_VALUE;
-
-        for (final Cell currentCell : mCells) {
-            final int currentViewDistance =
-                    mSnapPositionInterface.getCellDistanceFromSnapPosition(this, size, currentCell);
-            final boolean currentViewIsCloser = currentViewDistance < nearestCellDistance;
-
-            if (currentViewIsCloser) {
-                nearestCellDistance = currentViewDistance;
-                nearestCell = currentCell;
-            }
-        }
-        if (nearestCell == null) {
+        if (mCells.isEmpty()) {
             return null;
         }
 
+        final int nearestCellIndex = getNearestCellIndexToSnapPosition(size);
+        final Cell nearestCell = mCells.get(nearestCellIndex);
         return getView(nearestCell);
     }
 
@@ -410,8 +447,12 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         if (!viewsBeingDrawn || isCircularScroll) return 0;
 
         final boolean isViewPager = mLayoutManagerAttributes.isViewPager();
-        if (isViewPager && Math.abs(mAnimationDisplacement) > mViewPageDistance)
-            return -displacement;
+        if (isViewPager) {
+            final int viewPageDistance = getViewPageDistanceForAnimation();
+            final int animationDistance = Math.abs(mAnimationDisplacement);
+            final boolean isPastTheViewPage = animationDistance > viewPageDistance;
+            if (isPastTheViewPage) return -displacement;
+        }
 
         final Move move = getMove(displacement);
         switch (move) {
@@ -746,12 +787,18 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
     public int getViewPagerScrollDistance(final Move move) {
         switch (move) {
             case forward:
-                return -mViewPageDistance - mAnimationDisplacement;
+                return -mViewPageDistanceForward - mAnimationDisplacement;
             case back:
             case none:
             default:
-                return mViewPageDistance - mAnimationDisplacement;
+                return mViewPageDistanceBack - mAnimationDisplacement;
         }
+    }
+
+    private int getViewPageDistanceForAnimation() {
+        final boolean isMovingToLaterCells = mAnimationDisplacement < 0;
+        if (isMovingToLaterCells) return mViewPageDistanceForward;
+        return mViewPageDistanceBack;
     }
 
     public int getFlingSnapAdjustment(final ViewGroup viewGroup, final int displacement) {

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
@@ -20,6 +20,9 @@ import mobi.parchment.widget.adapterview.snapposition.StartSnapPosition;
 public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
     public static final int INVALID_POSITION = -1;
 
+    private static final int VIEWPORT_VIEW_PAGER_INTERVAL = 0;
+    private static final int ONE_CELL = 1;
+
     private final Map<View, Integer> mPositions = new HashMap<View, Integer>();
 
     private boolean mIsFirstLayout = true;
@@ -344,15 +347,97 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         final int anchorStart = getCellStart(anchorCell);
         final int anchorSnapDisplacement = getSnapDisplacement(size, anchorCell);
         final int anchorSnappedStart = anchorStart + anchorSnapDisplacement;
+        final int viewportEnd = getStartSizePadding() + size;
+        final int maximumPageSize = viewportEnd - anchorSnappedStart;
         final int viewPagerInterval = mLayoutManagerAttributes.getViewPagerInterval();
 
-        final long forwardCellIndex = (long) anchorIndex + viewPagerInterval;
+        final long forwardCellIndex =
+                getPageCellIndexForward(
+                        viewPagerInterval, maximumPageSize, anchorIndex, anchorStart);
         final int forwardCellStart = getCellStartAtIndex(forwardCellIndex);
         mViewPageDistanceForward = forwardCellStart - anchorSnappedStart;
 
-        final long backCellIndex = (long) anchorIndex - viewPagerInterval;
+        final long backCellIndex =
+                getPageCellIndexBack(viewPagerInterval, maximumPageSize, anchorIndex, anchorStart);
         final int backCellStart = getCellStartAtIndex(backCellIndex);
         mViewPageDistanceBack = anchorSnappedStart - backCellStart;
+    }
+
+    private static boolean pagesByCellCount(final int viewPagerInterval) {
+        return viewPagerInterval != VIEWPORT_VIEW_PAGER_INTERVAL;
+    }
+
+    private long getPageCellIndexForward(
+            final int viewPagerInterval,
+            final int maximumPageSize,
+            final int anchorIndex,
+            final int anchorStart) {
+        if (pagesByCellCount(viewPagerInterval)) return (long) anchorIndex + viewPagerInterval;
+
+        long pageCellIndex = anchorIndex + ONE_CELL;
+        int pageCellStart = getCellStartAtIndex(pageCellIndex);
+        long nextCellIndex = pageCellIndex + ONE_CELL;
+        int nextCellStart = getCellStartAtIndex(nextCellIndex);
+
+        while (nextCellJoinsThePage(maximumPageSize, anchorStart, pageCellStart, nextCellStart)) {
+            pageCellIndex = nextCellIndex;
+            pageCellStart = nextCellStart;
+            nextCellIndex = pageCellIndex + ONE_CELL;
+            nextCellStart = getCellStartAtIndex(nextCellIndex);
+        }
+
+        return pageCellIndex;
+    }
+
+    private long getPageCellIndexBack(
+            final int viewPagerInterval,
+            final int maximumPageSize,
+            final int anchorIndex,
+            final int anchorStart) {
+        if (pagesByCellCount(viewPagerInterval)) return (long) anchorIndex - viewPagerInterval;
+
+        long pageCellIndex = anchorIndex - ONE_CELL;
+        int pageCellStart = getCellStartAtIndex(pageCellIndex);
+        long previousCellIndex = pageCellIndex - ONE_CELL;
+        int previousCellStart = getCellStartAtIndex(previousCellIndex);
+
+        while (previousCellJoinsThePage(
+                maximumPageSize, anchorStart, pageCellStart, previousCellStart)) {
+            pageCellIndex = previousCellIndex;
+            pageCellStart = previousCellStart;
+            previousCellIndex = pageCellIndex - ONE_CELL;
+            previousCellStart = getCellStartAtIndex(previousCellIndex);
+        }
+
+        return pageCellIndex;
+    }
+
+    private boolean nextCellJoinsThePage(
+            final int maximumPageSize,
+            final int pageStart,
+            final int pageCellStart,
+            final int nextCellStart) {
+        final boolean hasAFurtherCell = nextCellStart > pageCellStart;
+        if (!hasAFurtherCell) return false;
+        return pageFits(maximumPageSize, pageStart, nextCellStart);
+    }
+
+    private boolean previousCellJoinsThePage(
+            final int maximumPageSize,
+            final int pageLimitStart,
+            final int pageCellStart,
+            final int previousCellStart) {
+        final boolean hasAFurtherCell = previousCellStart < pageCellStart;
+        if (!hasAFurtherCell) return false;
+        return pageFits(maximumPageSize, previousCellStart, pageLimitStart);
+    }
+
+    private boolean pageFits(
+            final int maximumPageSize, final long pageStart, final long pageLimitStart) {
+        final int cellSpacing = getCellSpacing();
+        final long pageEnd = pageLimitStart - cellSpacing;
+        final long pageSize = pageEnd - pageStart;
+        return pageSize <= maximumPageSize;
     }
 
     private int getSnapDisplacement(final int size, final Cell cell) {

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
@@ -32,8 +32,8 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
     private int mAnimationId = -1;
     private int mOffset = 0;
     private int mStartCellPosition;
-    private int mViewPageDistanceForward;
-    private int mViewPageDistanceBack;
+    int mViewPageDistanceForward;
+    int mViewPageDistanceBack;
     private int mAnimationDisplacement;
     protected final ViewGroup mViewGroup;
     private final ScrollDirectionManager mScrollDirectionManager;
@@ -338,7 +338,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         }
     }
 
-    private void setViewPageDistances(final int size) {
+    void setViewPageDistances(final int size) {
         final boolean isViewPager = mLayoutManagerAttributes.isViewPager();
         if (!isViewPager) return;
 
@@ -363,17 +363,28 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         mViewPageDistanceBack = anchorSnappedStart - backCellStart;
     }
 
-    private static boolean pagesByCellCount(final int viewPagerInterval) {
+    static boolean pagesByCellCount(final int viewPagerInterval) {
         return viewPagerInterval != VIEWPORT_VIEW_PAGER_INTERVAL;
     }
 
-    private long getPageCellIndexForward(
+    long getPageCellIndexForward(
             final int viewPagerInterval,
             final int maximumPageSize,
             final int anchorIndex,
             final int anchorStart) {
-        if (pagesByCellCount(viewPagerInterval)) return (long) anchorIndex + viewPagerInterval;
+        if (pagesByCellCount(viewPagerInterval)) {
+            return getPageCellIndexForwardByCellCount(viewPagerInterval, anchorIndex);
+        }
+        return getPageCellIndexForwardByViewport(maximumPageSize, anchorIndex, anchorStart);
+    }
 
+    static long getPageCellIndexForwardByCellCount(
+            final int viewPagerInterval, final int anchorIndex) {
+        return (long) anchorIndex + viewPagerInterval;
+    }
+
+    long getPageCellIndexForwardByViewport(
+            final int maximumPageSize, final int anchorIndex, final int anchorStart) {
         long pageCellIndex = anchorIndex + ONE_CELL;
         int pageCellStart = getCellStartAtIndex(pageCellIndex);
         long nextCellIndex = pageCellIndex + ONE_CELL;
@@ -389,13 +400,24 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         return pageCellIndex;
     }
 
-    private long getPageCellIndexBack(
+    long getPageCellIndexBack(
             final int viewPagerInterval,
             final int maximumPageSize,
             final int anchorIndex,
             final int anchorStart) {
-        if (pagesByCellCount(viewPagerInterval)) return (long) anchorIndex - viewPagerInterval;
+        if (pagesByCellCount(viewPagerInterval)) {
+            return getPageCellIndexBackByCellCount(viewPagerInterval, anchorIndex);
+        }
+        return getPageCellIndexBackByViewport(maximumPageSize, anchorIndex, anchorStart);
+    }
 
+    static long getPageCellIndexBackByCellCount(
+            final int viewPagerInterval, final int anchorIndex) {
+        return (long) anchorIndex - viewPagerInterval;
+    }
+
+    long getPageCellIndexBackByViewport(
+            final int maximumPageSize, final int anchorIndex, final int anchorStart) {
         long pageCellIndex = anchorIndex - ONE_CELL;
         int pageCellStart = getCellStartAtIndex(pageCellIndex);
         long previousCellIndex = pageCellIndex - ONE_CELL;
@@ -412,7 +434,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         return pageCellIndex;
     }
 
-    private boolean nextCellJoinsThePage(
+    boolean nextCellJoinsThePage(
             final int maximumPageSize,
             final int pageStart,
             final int pageCellStart,
@@ -422,7 +444,7 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         return pageFits(maximumPageSize, pageStart, nextCellStart);
     }
 
-    private boolean previousCellJoinsThePage(
+    boolean previousCellJoinsThePage(
             final int maximumPageSize,
             final int pageLimitStart,
             final int pageCellStart,
@@ -432,41 +454,48 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         return pageFits(maximumPageSize, previousCellStart, pageLimitStart);
     }
 
-    private boolean pageFits(
-            final int maximumPageSize, final long pageStart, final long pageLimitStart) {
+    boolean pageFits(final int maximumPageSize, final long pageStart, final long pageLimitStart) {
         final int cellSpacing = getCellSpacing();
         final long pageEnd = pageLimitStart - cellSpacing;
         final long pageSize = pageEnd - pageStart;
         return pageSize <= maximumPageSize;
     }
 
-    private int getSnapDisplacement(final int size, final Cell cell) {
+    int getSnapDisplacement(final int size, final Cell cell) {
         final View view = getView(cell);
         if (view == null) return 0;
         return getSnapToPixelDistance(size, view);
     }
 
-    private int getCellStartAtIndex(final long cellIndex) {
+    int getCellStartAtIndex(final long cellIndex) {
         final int lastCellIndex = mCells.size() - 1;
-        final int cellSpacing = getCellSpacing();
 
-        if (cellIndex < 0) {
-            final Cell firstCell = mCells.get(0);
-            final long step = getCellSize(firstCell) + cellSpacing;
-            final long steps = Math.min(-cellIndex, getCellsBeforeFirst());
-            final long cellStart = getCellStart(firstCell) - steps * step;
-            return getDrawableCellStart(cellStart);
-        }
+        final boolean isBeforeTheFirstCell = cellIndex < 0;
+        if (isBeforeTheFirstCell) return getCellStartExtrapolatedBeforeFirst(cellIndex);
 
-        if (cellIndex > lastCellIndex) {
-            final Cell lastCell = mCells.get(lastCellIndex);
-            final long step = getCellSize(lastCell) + cellSpacing;
-            final long steps = Math.min(cellIndex - lastCellIndex, getCellsAfterLast());
-            final long cellStart = getCellStart(lastCell) + steps * step;
-            return getDrawableCellStart(cellStart);
-        }
+        final boolean isAfterTheLastCell = cellIndex > lastCellIndex;
+        if (isAfterTheLastCell) return getCellStartExtrapolatedAfterLast(cellIndex);
 
         return getCellStart(mCells.get((int) cellIndex));
+    }
+
+    int getCellStartExtrapolatedBeforeFirst(final long cellIndex) {
+        final int cellSpacing = getCellSpacing();
+        final Cell firstCell = mCells.get(0);
+        final long step = getCellSize(firstCell) + cellSpacing;
+        final long steps = Math.min(-cellIndex, getCellsBeforeFirst());
+        final long cellStart = getCellStart(firstCell) - steps * step;
+        return getDrawableCellStart(cellStart);
+    }
+
+    int getCellStartExtrapolatedAfterLast(final long cellIndex) {
+        final int cellSpacing = getCellSpacing();
+        final int lastCellIndex = mCells.size() - 1;
+        final Cell lastCell = mCells.get(lastCellIndex);
+        final long step = getCellSize(lastCell) + cellSpacing;
+        final long steps = Math.min(cellIndex - lastCellIndex, getCellsAfterLast());
+        final long cellStart = getCellStart(lastCell) + steps * step;
+        return getDrawableCellStart(cellStart);
     }
 
     private int getDrawableCellStart(final long cellStart) {

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerAttributes.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerAttributes.java
@@ -7,6 +7,7 @@ public class LayoutManagerAttributes {
 
     private static class DefaultValues {
         private static final SnapPosition SNAP_POSITION = SnapPosition.center;
+        private static final int VIEW_PAGER_INTERVAL = 1;
     }
 
     private boolean mIsCircularScroll;
@@ -34,7 +35,7 @@ public class LayoutManagerAttributes {
         if (snapPosition != null) mSnapPosition = snapPosition;
         else mSnapPosition = DefaultValues.SNAP_POSITION;
 
-        mViewPagerInterval = viewPagerInterval;
+        mViewPagerInterval = Math.max(viewPagerInterval, DefaultValues.VIEW_PAGER_INTERVAL);
         mIsViewPager = isViewPager;
         mIsCircularScroll = isCircularScroll;
         mSnapToPosition = snapToPosition;

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerAttributes.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerAttributes.java
@@ -7,7 +7,7 @@ public class LayoutManagerAttributes {
 
     private static class DefaultValues {
         private static final SnapPosition SNAP_POSITION = SnapPosition.center;
-        private static final int VIEW_PAGER_INTERVAL = 1;
+        private static final int VIEW_PAGER_INTERVAL = 0;
     }
 
     private boolean mIsCircularScroll;

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerAttributes.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerAttributes.java
@@ -10,15 +10,15 @@ public class LayoutManagerAttributes {
         private static final int VIEW_PAGER_INTERVAL = 0;
     }
 
-    private boolean mIsCircularScroll;
-    private boolean mIsViewPager;
-    private boolean mIsVertical;
-    private int mViewPagerInterval;
-    private boolean mSnapToPosition;
-    private SnapPosition mSnapPosition;
-    private int mCellSpacing;
-    private boolean mSelectOnSnap;
-    private boolean mSelectWhileScrolling;
+    private final boolean mIsCircularScroll;
+    private final boolean mIsViewPager;
+    private final boolean mIsVertical;
+    private final int mViewPagerInterval;
+    private final boolean mSnapToPosition;
+    private final SnapPosition mSnapPosition;
+    private final int mCellSpacing;
+    private final boolean mSelectOnSnap;
+    private final boolean mSelectWhileScrolling;
 
     public LayoutManagerAttributes(
             final boolean isCircularScroll,

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerState.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManagerState.java
@@ -12,7 +12,8 @@ public class LayoutManagerState<Cell> extends View.BaseSavedState {
     private final int mOffset;
     private final int mStartCellPosition;
 
-    LayoutManagerState(final Parcelable superState, final int offset, final int startOffset) {
+    protected LayoutManagerState(
+            final Parcelable superState, final int offset, final int startOffset) {
         super(superState);
         mOffset = offset;
         mStartCellPosition = startOffset;

--- a/library/src/main/java/mobi/parchment/widget/adapterview/pageinterval/CellCountPageInterval.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/pageinterval/CellCountPageInterval.java
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview.pageinterval;
+
+import mobi.parchment.widget.adapterview.LayoutManager;
+
+public final class CellCountPageInterval<Cell> implements PageIntervalInterface<Cell> {
+
+    private final int mViewPagerInterval;
+
+    public CellCountPageInterval(final int viewPagerInterval) {
+        mViewPagerInterval = viewPagerInterval;
+    }
+
+    @Override
+    public long getPageCellIndexForward(
+            final LayoutManager<Cell> layoutManager,
+            final int maximumPageSize,
+            final int anchorIndex,
+            final int anchorStart) {
+        return (long) anchorIndex + mViewPagerInterval;
+    }
+
+    @Override
+    public long getPageCellIndexBack(
+            final LayoutManager<Cell> layoutManager,
+            final int maximumPageSize,
+            final int anchorIndex,
+            final int anchorStart) {
+        return (long) anchorIndex - mViewPagerInterval;
+    }
+}

--- a/library/src/main/java/mobi/parchment/widget/adapterview/pageinterval/PageIntervalInterface.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/pageinterval/PageIntervalInterface.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview.pageinterval;
+
+import mobi.parchment.widget.adapterview.LayoutManager;
+
+public interface PageIntervalInterface<Cell> {
+
+    public long getPageCellIndexForward(
+            final LayoutManager<Cell> layoutManager,
+            final int maximumPageSize,
+            final int anchorIndex,
+            final int anchorStart);
+
+    public long getPageCellIndexBack(
+            final LayoutManager<Cell> layoutManager,
+            final int maximumPageSize,
+            final int anchorIndex,
+            final int anchorStart);
+}

--- a/library/src/main/java/mobi/parchment/widget/adapterview/pageinterval/PageIntervalSelector.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/pageinterval/PageIntervalSelector.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview.pageinterval;
+
+public final class PageIntervalSelector {
+
+    private static final int VIEWPORT_VIEW_PAGER_INTERVAL = 0;
+
+    private PageIntervalSelector() {}
+
+    public static boolean pagesByCellCount(final int viewPagerInterval) {
+        return viewPagerInterval != VIEWPORT_VIEW_PAGER_INTERVAL;
+    }
+
+    public static <Cell> PageIntervalInterface<Cell> getPageIntervalInterface(
+            final int viewPagerInterval) {
+        if (pagesByCellCount(viewPagerInterval)) {
+            return new CellCountPageInterval<Cell>(viewPagerInterval);
+        }
+        return new ViewportPageInterval<Cell>();
+    }
+}

--- a/library/src/main/java/mobi/parchment/widget/adapterview/pageinterval/ViewportPageInterval.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/pageinterval/ViewportPageInterval.java
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview.pageinterval;
+
+import mobi.parchment.widget.adapterview.LayoutManager;
+
+public final class ViewportPageInterval<Cell> implements PageIntervalInterface<Cell> {
+
+    private static final int ONE_CELL = 1;
+
+    @Override
+    public long getPageCellIndexForward(
+            final LayoutManager<Cell> layoutManager,
+            final int maximumPageSize,
+            final int anchorIndex,
+            final int anchorStart) {
+        final int cellSpacing = layoutManager.getCellSpacing();
+        long pageCellIndex = anchorIndex + ONE_CELL;
+        int pageCellStart = layoutManager.getCellStartAtIndex(pageCellIndex);
+        long nextCellIndex = pageCellIndex + ONE_CELL;
+        int nextCellStart = layoutManager.getCellStartAtIndex(nextCellIndex);
+
+        while (nextCellJoinsThePage(
+                maximumPageSize, cellSpacing, anchorStart, pageCellStart, nextCellStart)) {
+            pageCellIndex = nextCellIndex;
+            pageCellStart = nextCellStart;
+            nextCellIndex = pageCellIndex + ONE_CELL;
+            nextCellStart = layoutManager.getCellStartAtIndex(nextCellIndex);
+        }
+
+        return pageCellIndex;
+    }
+
+    @Override
+    public long getPageCellIndexBack(
+            final LayoutManager<Cell> layoutManager,
+            final int maximumPageSize,
+            final int anchorIndex,
+            final int anchorStart) {
+        final int cellSpacing = layoutManager.getCellSpacing();
+        long pageCellIndex = anchorIndex - ONE_CELL;
+        int pageCellStart = layoutManager.getCellStartAtIndex(pageCellIndex);
+        long previousCellIndex = pageCellIndex - ONE_CELL;
+        int previousCellStart = layoutManager.getCellStartAtIndex(previousCellIndex);
+
+        while (previousCellJoinsThePage(
+                maximumPageSize, cellSpacing, anchorStart, pageCellStart, previousCellStart)) {
+            pageCellIndex = previousCellIndex;
+            pageCellStart = previousCellStart;
+            previousCellIndex = pageCellIndex - ONE_CELL;
+            previousCellStart = layoutManager.getCellStartAtIndex(previousCellIndex);
+        }
+
+        return pageCellIndex;
+    }
+
+    public static boolean nextCellJoinsThePage(
+            final int maximumPageSize,
+            final int cellSpacing,
+            final int pageStart,
+            final int pageCellStart,
+            final int nextCellStart) {
+        final boolean hasAFurtherCell = nextCellStart > pageCellStart;
+        if (!hasAFurtherCell) return false;
+        return pageFits(maximumPageSize, cellSpacing, pageStart, nextCellStart);
+    }
+
+    public static boolean previousCellJoinsThePage(
+            final int maximumPageSize,
+            final int cellSpacing,
+            final int pageLimitStart,
+            final int pageCellStart,
+            final int previousCellStart) {
+        final boolean hasAFurtherCell = previousCellStart < pageCellStart;
+        if (!hasAFurtherCell) return false;
+        return pageFits(maximumPageSize, cellSpacing, previousCellStart, pageLimitStart);
+    }
+
+    public static boolean pageFits(
+            final int maximumPageSize,
+            final int cellSpacing,
+            final long pageStart,
+            final long pageLimitStart) {
+        final long pageEnd = pageLimitStart - cellSpacing;
+        final long pageSize = pageEnd - pageStart;
+        return pageSize <= maximumPageSize;
+    }
+}

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -11,7 +11,9 @@
         <attr name="parchment_snapToPosition" format="boolean"/>
         <attr name="parchment_selectOnSnap" format="boolean"/>
         <attr name="parchment_isViewPager" format="boolean"/>
-        <attr name="parchment_viewPagerInterval" format="integer"/>
+        <attr name="parchment_viewPagerInterval" format="integer">
+            <enum name="viewport" value="0"/>
+        </attr>
         <attr name="parchment_snapPosition" format="enum">
             <enum name="center" value="0"/>
             <enum name="start" value="1"/>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -11,6 +11,7 @@
         <attr name="parchment_snapToPosition" format="boolean"/>
         <attr name="parchment_selectOnSnap" format="boolean"/>
         <attr name="parchment_isViewPager" format="boolean"/>
+        <attr name="parchment_viewPagerInterval" format="integer"/>
         <attr name="parchment_snapPosition" format="enum">
             <enum name="center" value="0"/>
             <enum name="start" value="1"/>

--- a/library/src/test/java/mobi/parchment/HorizontalListViewTest.java
+++ b/library/src/test/java/mobi/parchment/HorizontalListViewTest.java
@@ -43,6 +43,10 @@ public class HorizontalListViewTest {
     private static final float TEST_RATIO = 1.5f;
     private static final float DEFAULT_CELL_SPACING = 0f;
     private static final int DEFAULT_VIEWS_PER_CELL = 1;
+    private static final int TEST_VIEW_PAGER_INTERVAL = 3;
+    private static final int DEFAULT_VIEW_PAGER_INTERVAL = 1;
+    private static final int TEST_GRID_VIEW_PAGER_INTERVAL = 4;
+    private static final int TEST_GRID_PATTERN_VIEW_PAGER_INTERVAL = 2;
     private static final float DEFAULT_RATIO = 1.0f;
     private static final int NO_ID_RESOURCE = 0;
     private static final String ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android";
@@ -163,6 +167,7 @@ public class HorizontalListViewTest {
                         "parchment_snapToPosition",
                         "parchment_selectOnSnap",
                         "parchment_isViewPager",
+                        "parchment_viewPagerInterval",
                         "parchment_snapPosition",
                         "parchment_selectWhileScrolling",
                         "parchment_numberOfViewsPerCell",
@@ -184,6 +189,7 @@ public class HorizontalListViewTest {
         assertThat(attributes.isSnapToPosition()).isTrue();
         assertThat(attributes.selectOnSnap()).isTrue();
         assertThat(attributes.isViewPager()).isTrue();
+        assertThat(attributes.getViewPagerInterval()).isEqualTo(TEST_VIEW_PAGER_INTERVAL);
         assertThat(attributes.getSnapPosition()).isEqualTo(SnapPosition.end);
         assertThat(attributes.selectWhileScrolling()).isTrue();
     }
@@ -248,6 +254,47 @@ public class HorizontalListViewTest {
     }
 
     @Test
+    public void viewPagerIntervalOfZeroInXml_fallsBackToOneCellPerGesture() {
+        final Attributes attributes =
+                listViewAttributesFrom(
+                        R.layout.attribute_parsing_view_pager_intervals,
+                        R.id.view_pager_interval_zero);
+
+        assertThat(attributes.getViewPagerInterval()).isEqualTo(DEFAULT_VIEW_PAGER_INTERVAL);
+    }
+
+    @Test
+    public void aNegativeViewPagerIntervalInXml_fallsBackToOneCellPerGesture() {
+        final Attributes attributes =
+                listViewAttributesFrom(
+                        R.layout.attribute_parsing_view_pager_intervals,
+                        R.id.view_pager_interval_negative);
+
+        assertThat(attributes.getViewPagerInterval()).isEqualTo(DEFAULT_VIEW_PAGER_INTERVAL);
+    }
+
+    @Test
+    public void viewPagerIntervalSetInXml_reachesTheGridAttributesGetter() {
+        final GridAttributes gridAttributes =
+                gridAttributesFrom(
+                        R.layout.attribute_parsing_view_pager_intervals,
+                        R.id.view_pager_interval_grid_view);
+
+        assertThat(gridAttributes.getViewPagerInterval()).isEqualTo(TEST_GRID_VIEW_PAGER_INTERVAL);
+    }
+
+    @Test
+    public void viewPagerIntervalSetInXml_reachesTheGridPatternAttributesGetter() {
+        final GridPatternAttributes gridPatternAttributes =
+                gridPatternAttributesFrom(
+                        R.layout.attribute_parsing_view_pager_intervals,
+                        R.id.view_pager_interval_grid_pattern_view);
+
+        assertThat(gridPatternAttributes.getViewPagerInterval())
+                .isEqualTo(TEST_GRID_PATTERN_VIEW_PAGER_INTERVAL);
+    }
+
+    @Test
     public void gridPatternViewRatioSetInXml_reachesTheRatioGetter() {
         final GridPatternAttributes gridPatternAttributes =
                 gridPatternAttributesFrom(
@@ -270,6 +317,7 @@ public class HorizontalListViewTest {
         assertThat(attributes.isSnapToPosition()).isFalse();
         assertThat(attributes.selectOnSnap()).isFalse();
         assertThat(attributes.isViewPager()).isFalse();
+        assertThat(attributes.getViewPagerInterval()).isEqualTo(DEFAULT_VIEW_PAGER_INTERVAL);
         assertThat(attributes.selectWhileScrolling()).isFalse();
         assertThat(attributes.getSnapPosition()).isEqualTo(SnapPosition.onScreen);
     }
@@ -285,6 +333,7 @@ public class HorizontalListViewTest {
         assertThat(attributes.isSnapToPosition()).isFalse();
         assertThat(attributes.selectOnSnap()).isFalse();
         assertThat(attributes.isViewPager()).isFalse();
+        assertThat(attributes.getViewPagerInterval()).isEqualTo(DEFAULT_VIEW_PAGER_INTERVAL);
         assertThat(attributes.selectWhileScrolling()).isFalse();
         assertThat(attributes.getSnapPosition()).isEqualTo(SnapPosition.center);
     }

--- a/library/src/test/java/mobi/parchment/HorizontalListViewTest.java
+++ b/library/src/test/java/mobi/parchment/HorizontalListViewTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.content.res.XmlResourceParser;
 import android.os.Bundle;
 import android.util.AttributeSet;
@@ -44,7 +45,9 @@ public class HorizontalListViewTest {
     private static final float DEFAULT_CELL_SPACING = 0f;
     private static final int DEFAULT_VIEWS_PER_CELL = 1;
     private static final int TEST_VIEW_PAGER_INTERVAL = 3;
-    private static final int DEFAULT_VIEW_PAGER_INTERVAL = 1;
+    private static final int VIEWPORT_VIEW_PAGER_INTERVAL = 0;
+    private static final int ONE_CELL_VIEW_PAGER_INTERVAL = 1;
+    private static final int NO_SUCH_INTERVAL = Integer.MIN_VALUE;
     private static final int TEST_GRID_VIEW_PAGER_INTERVAL = 4;
     private static final int TEST_GRID_PATTERN_VIEW_PAGER_INTERVAL = 2;
     private static final float DEFAULT_RATIO = 1.0f;
@@ -254,23 +257,63 @@ public class HorizontalListViewTest {
     }
 
     @Test
-    public void viewPagerIntervalOfZeroInXml_fallsBackToOneCellPerGesture() {
+    public void viewPagerIntervalOfZeroInXml_isReadAsViewportPaging() {
         final Attributes attributes =
                 listViewAttributesFrom(
                         R.layout.attribute_parsing_view_pager_intervals,
                         R.id.view_pager_interval_zero);
 
-        assertThat(attributes.getViewPagerInterval()).isEqualTo(DEFAULT_VIEW_PAGER_INTERVAL);
+        assertThat(attributes.getViewPagerInterval()).isEqualTo(VIEWPORT_VIEW_PAGER_INTERVAL);
     }
 
     @Test
-    public void aNegativeViewPagerIntervalInXml_fallsBackToOneCellPerGesture() {
+    public void theViewportConstantInXml_resolvesToZeroBeforeAnyClampSeesIt() {
+        final int rawInterval =
+                rawViewPagerIntervalFrom(
+                        R.layout.attribute_parsing_view_pager_intervals,
+                        R.id.view_pager_interval_viewport);
+
+        assertThat(rawInterval).isEqualTo(VIEWPORT_VIEW_PAGER_INTERVAL);
+    }
+
+    @Test
+    public void anAbsentViewPagerIntervalInXml_isNotPresentInTheTypedArrayAtAll() {
+        final int rawInterval =
+                rawViewPagerIntervalFrom(
+                        R.layout.attribute_parsing_view_pager_intervals,
+                        R.id.view_pager_no_interval);
+
+        assertThat(rawInterval).isEqualTo(NO_SUCH_INTERVAL);
+    }
+
+    @Test
+    public void theViewportConstantInXml_readsAsTheSameValueAsALiteralZero() {
+        final Attributes attributes =
+                listViewAttributesFrom(
+                        R.layout.attribute_parsing_view_pager_intervals,
+                        R.id.view_pager_interval_viewport);
+
+        assertThat(attributes.getViewPagerInterval()).isEqualTo(VIEWPORT_VIEW_PAGER_INTERVAL);
+    }
+
+    @Test
+    public void aViewPagerIntervalOfOneInXml_survivesTheClampAsOne() {
+        final Attributes attributes =
+                listViewAttributesFrom(
+                        R.layout.attribute_parsing_view_pager_intervals,
+                        R.id.view_pager_interval_one);
+
+        assertThat(attributes.getViewPagerInterval()).isEqualTo(ONE_CELL_VIEW_PAGER_INTERVAL);
+    }
+
+    @Test
+    public void aNegativeViewPagerIntervalInXml_isReadAsViewportPaging() {
         final Attributes attributes =
                 listViewAttributesFrom(
                         R.layout.attribute_parsing_view_pager_intervals,
                         R.id.view_pager_interval_negative);
 
-        assertThat(attributes.getViewPagerInterval()).isEqualTo(DEFAULT_VIEW_PAGER_INTERVAL);
+        assertThat(attributes.getViewPagerInterval()).isEqualTo(VIEWPORT_VIEW_PAGER_INTERVAL);
     }
 
     @Test
@@ -317,7 +360,7 @@ public class HorizontalListViewTest {
         assertThat(attributes.isSnapToPosition()).isFalse();
         assertThat(attributes.selectOnSnap()).isFalse();
         assertThat(attributes.isViewPager()).isFalse();
-        assertThat(attributes.getViewPagerInterval()).isEqualTo(DEFAULT_VIEW_PAGER_INTERVAL);
+        assertThat(attributes.getViewPagerInterval()).isEqualTo(VIEWPORT_VIEW_PAGER_INTERVAL);
         assertThat(attributes.selectWhileScrolling()).isFalse();
         assertThat(attributes.getSnapPosition()).isEqualTo(SnapPosition.onScreen);
     }
@@ -333,7 +376,7 @@ public class HorizontalListViewTest {
         assertThat(attributes.isSnapToPosition()).isFalse();
         assertThat(attributes.selectOnSnap()).isFalse();
         assertThat(attributes.isViewPager()).isFalse();
-        assertThat(attributes.getViewPagerInterval()).isEqualTo(DEFAULT_VIEW_PAGER_INTERVAL);
+        assertThat(attributes.getViewPagerInterval()).isEqualTo(VIEWPORT_VIEW_PAGER_INTERVAL);
         assertThat(attributes.selectWhileScrolling()).isFalse();
         assertThat(attributes.getSnapPosition()).isEqualTo(SnapPosition.center);
     }
@@ -403,6 +446,27 @@ public class HorizontalListViewTest {
         try {
             final AttributeSet attributeSet = advanceToTagWithId(parser, idResource);
             return new Attributes(context, attributeSet);
+        } finally {
+            parser.close();
+        }
+    }
+
+    private static int rawViewPagerIntervalFrom(final int layoutId, final int idResource) {
+        final Context context = RuntimeEnvironment.getApplication();
+        final XmlResourceParser parser = context.getResources().getLayout(layoutId);
+        try {
+            final AttributeSet attributeSet = advanceToTagWithId(parser, idResource);
+            final TypedArray typedArray =
+                    context.getTheme()
+                            .obtainStyledAttributes(
+                                    attributeSet, mobi.parchment.R.styleable.ListView, 0, 0);
+            try {
+                return typedArray.getInteger(
+                        mobi.parchment.R.styleable.ListView_parchment_viewPagerInterval,
+                        NO_SUCH_INTERVAL);
+            } finally {
+                typedArray.recycle();
+            }
         } finally {
             parser.close();
         }

--- a/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
@@ -174,7 +174,31 @@ public class AdapterAnimatorTest {
         ShadowSystemClock.advanceBy(Duration.ofMillis(MAX_SNAP_DURATION + 1));
 
         assertThat(mFrameScheduler.mRequests).isEqualTo(1);
-        assertThat(nextFrameDisplacement()).isEqualTo(-VIEW_GROUP_SIZE);
+        assertThat(nextFrameDisplacement()).isEqualTo(-VIEW_SIZE);
+    }
+
+    @Test
+    public void onFling_asAViewPagerInTheOtherDirection_movesExactlyOneCellBack() {
+        layOutList(true, SnapPosition.start, true);
+        layout();
+
+        mAdapterAnimator.onFling(down(), up(), FLING_VELOCITY, 0f);
+        mAdapterAnimator.onUp();
+        ShadowSystemClock.advanceBy(Duration.ofMillis(MAX_SNAP_DURATION + 1));
+        layout();
+        mAdapterAnimator.onFrameLaidOut();
+
+        assertThat(mLayoutManager.getViewForPosition(1).getLeft()).isEqualTo(0);
+
+        layout();
+        mFrameScheduler.mRequests = 0;
+
+        mAdapterAnimator.onFling(down(), up(), -FLING_VELOCITY, 0f);
+        mAdapterAnimator.onUp();
+        ShadowSystemClock.advanceBy(Duration.ofMillis(MAX_SNAP_DURATION + 1));
+
+        assertThat(mFrameScheduler.mRequests).isEqualTo(1);
+        assertThat(nextFrameDisplacement()).isEqualTo(VIEW_SIZE);
     }
 
     @Test

--- a/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/AdapterAnimatorTest.java
@@ -31,6 +31,8 @@ public class AdapterAnimatorTest {
     private static final int ADAPTER_SIZE = 10;
     private static final float FLING_VELOCITY = -1000f;
     private static final int FLING_DISTANCE = -194;
+    private static final int VIEWPORT_PAGING = 0;
+    private static final int ONE_CELL_PER_GESTURE = 1;
     private static final long FLING_DURATION = 555;
     private static final long MAX_SNAP_DURATION = 500;
 
@@ -48,19 +50,20 @@ public class AdapterAnimatorTest {
     }
 
     private void setup(final boolean snapToPosition, final SnapPosition snapPosition) {
-        setup(snapToPosition, snapPosition, false);
+        setup(snapToPosition, snapPosition, false, VIEWPORT_PAGING);
     }
 
     private void setup(
             final boolean snapToPosition,
             final SnapPosition snapPosition,
-            final boolean isViewPager) {
+            final boolean isViewPager,
+            final int viewPagerInterval) {
         final LayoutManagerAttributes attributes =
                 new LayoutManagerAttributes(
                         false,
                         snapToPosition,
                         isViewPager,
-                        0,
+                        viewPagerInterval,
                         snapPosition,
                         0,
                         false,
@@ -83,14 +86,15 @@ public class AdapterAnimatorTest {
     }
 
     private void layOutCenterSnappingList() {
-        layOutList(true, SnapPosition.center, false);
+        layOutList(true, SnapPosition.center, false, VIEWPORT_PAGING);
     }
 
     private void layOutList(
             final boolean snapToPosition,
             final SnapPosition snapPosition,
-            final boolean isViewPager) {
-        setup(snapToPosition, snapPosition, isViewPager);
+            final boolean isViewPager,
+            final int viewPagerInterval) {
+        setup(snapToPosition, snapPosition, isViewPager, viewPagerInterval);
         final TestAdapter adapter = new TestAdapter();
         mAdapterViewManager.setAdapter(adapter);
         adapter.setAdapterSize(ADAPTER_SIZE);
@@ -151,7 +155,7 @@ public class AdapterAnimatorTest {
 
     @Test
     public void onFling_withoutSnapping_keepsTheNaturalFlingEnd() {
-        layOutList(false, SnapPosition.onScreen, false);
+        layOutList(false, SnapPosition.onScreen, false, VIEWPORT_PAGING);
         mAdapterAnimator.onFling(down(), up(), FLING_VELOCITY, 0f);
         mAdapterAnimator.onUp();
         ShadowSystemClock.advanceBy(Duration.ofMillis(FLING_DURATION + 1));
@@ -165,7 +169,7 @@ public class AdapterAnimatorTest {
 
     @Test
     public void onFling_asAViewPager_movesExactlyOnePage() {
-        layOutList(true, SnapPosition.start, true);
+        layOutList(true, SnapPosition.start, true, ONE_CELL_PER_GESTURE);
         layout();
         mFrameScheduler.mRequests = 0;
 
@@ -179,7 +183,7 @@ public class AdapterAnimatorTest {
 
     @Test
     public void onFling_asAViewPagerInTheOtherDirection_movesExactlyOneCellBack() {
-        layOutList(true, SnapPosition.start, true);
+        layOutList(true, SnapPosition.start, true, ONE_CELL_PER_GESTURE);
         layout();
 
         mAdapterAnimator.onFling(down(), up(), FLING_VELOCITY, 0f);

--- a/library/src/test/java/mobi/parchment/widget/adapterview/CircularScrollSnapPositionTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/CircularScrollSnapPositionTest.java
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import androidx.test.core.app.ApplicationProvider;
+import java.util.ArrayList;
+import java.util.List;
+import mobi.parchment.widget.adapterview.listview.ListLayoutManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Circular scrolling swaps the snap strategy for onScreen, so parchment_snapPosition does not
+ * decide where a cell comes to rest. It still decides whether the settle snap runs at all, because
+ * getSnapDistanceToNearestView reads the declared position rather than the strategy, so the
+ * attribute is not redundant on a circular view.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class CircularScrollSnapPositionTest {
+
+    private static final int VIEWPORT_SIZE = 300;
+    private static final int CELL_SIZE = VIEWPORT_SIZE;
+    private static final int ADAPTER_SIZE = 10;
+    private static final int DRAG_OFF_THE_BOUNDARY = -50;
+    private static final int NO_CELL_SPACING = 0;
+    private static final boolean CIRCULAR = true;
+    private static final boolean SNAP_TO_POSITION = true;
+    private static final boolean NOT_VIEW_PAGER = false;
+    private static final int VIEWPORT_PAGING = 0;
+    private static final boolean NO_SELECT_ON_SNAP = false;
+    private static final boolean NO_SELECT_WHILE_SCROLLING = false;
+    private static final boolean HORIZONTAL = false;
+
+    private final MyViewGroup mViewGroup =
+            new MyViewGroup(ApplicationProvider.getApplicationContext());
+    private final AdapterViewManager mAdapterViewManager = new AdapterViewManager();
+    private final CellAdapter mAdapter = new CellAdapter();
+    private final Animation mAnimation = new Animation();
+    private ListLayoutManager mListLayoutManager;
+
+    @Test
+    public void circularScroll_withADeclaredSnapPosition_stillSettlesAStraddlingCell() {
+        setup(SnapPosition.start);
+
+        dragBy(DRAG_OFF_THE_BOUNDARY);
+
+        assertThat(mListLayoutManager.snapTo(mViewGroup)).isEqualTo(-DRAG_OFF_THE_BOUNDARY);
+    }
+
+    @Test
+    public void circularScroll_withNoDeclaredSnapPosition_leavesAStraddlingCellWhereItIs() {
+        setup(SnapPosition.onScreen);
+
+        dragBy(DRAG_OFF_THE_BOUNDARY);
+
+        assertThat(mListLayoutManager.snapTo(mViewGroup)).isEqualTo(0);
+    }
+
+    private void setup(final SnapPosition snapPosition) {
+        final LayoutManagerAttributes attributes =
+                new LayoutManagerAttributes(
+                        CIRCULAR,
+                        SNAP_TO_POSITION,
+                        NOT_VIEW_PAGER,
+                        VIEWPORT_PAGING,
+                        snapPosition,
+                        NO_CELL_SPACING,
+                        NO_SELECT_ON_SNAP,
+                        NO_SELECT_WHILE_SCROLLING,
+                        HORIZONTAL);
+        mListLayoutManager =
+                new ListLayoutManager(mViewGroup, null, mAdapterViewManager, attributes);
+        mAdapterViewManager.setAdapter(mAdapter);
+
+        final int measureSpec =
+                View.MeasureSpec.makeMeasureSpec(VIEWPORT_SIZE, View.MeasureSpec.EXACTLY);
+        mViewGroup.measure(measureSpec, measureSpec);
+        mViewGroup.layout(0, 0, VIEWPORT_SIZE, VIEWPORT_SIZE);
+
+        mAnimation.newAnimation();
+        layout();
+    }
+
+    private void layout() {
+        mListLayoutManager.layout(mViewGroup, mAnimation, 0, 0, VIEWPORT_SIZE, VIEWPORT_SIZE);
+    }
+
+    private void dragBy(final int displacement) {
+        mAnimation.setDisplacement(displacement);
+        layout();
+    }
+
+    private static final class MyViewGroup extends LinearLayout implements AdapterViewHandler {
+        private final List<View> mViews = new ArrayList<View>();
+
+        private MyViewGroup(final Context context) {
+            super(context);
+        }
+
+        @Override
+        public boolean addViewInAdapterView(
+                final View view, final int index, final ViewGroup.LayoutParams layoutParams) {
+            mViews.add(index, view);
+            return true;
+        }
+
+        @Override
+        public void removeViewInAdapterView(final View view) {
+            mViews.remove(view);
+        }
+    }
+
+    private static final class CellAdapter extends BaseAdapter {
+        @Override
+        public int getCount() {
+            return ADAPTER_SIZE;
+        }
+
+        @Override
+        public Object getItem(final int position) {
+            return position;
+        }
+
+        @Override
+        public long getItemId(final int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(final int position, final View convertView, final ViewGroup parent) {
+            final FrameLayout view = new FrameLayout(ApplicationProvider.getApplicationContext());
+            view.setTag(position);
+            view.setLayoutParams(new ViewGroup.LayoutParams(CELL_SIZE, CELL_SIZE));
+            return view;
+        }
+    }
+}

--- a/library/src/test/java/mobi/parchment/widget/adapterview/GridLayoutManagerTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/GridLayoutManagerTest.java
@@ -30,6 +30,11 @@ public class GridLayoutManagerTest {
     public static final int VIEW_SIZE = 100;
     public static final int CELL_SPACING = 10;
     public static final int NUMBER_OF_COLUMNS = 2;
+    private static final int ONE_GROUP_PER_GESTURE = 1;
+    private static final int THREE_GROUPS_PER_GESTURE = 3;
+    private static final int PAGER_ADAPTER_SIZE = 10;
+    private static final int NOT_DRAWN = Integer.MIN_VALUE;
+    private static final int ZERO_VIEW_SIZE = 0;
     final MyViewGroup mViewGroup = new MyViewGroup(ApplicationProvider.getApplicationContext());
     final AdapterViewManager adapterViewManager = new AdapterViewManager();
     TestAdapter mTestAdapter;
@@ -400,6 +405,143 @@ public class GridLayoutManagerTest {
         assertThat(secondView.getBottom()).isEqualTo(100);
     }
 
+    @Test
+    public void aGridThatIsNotAViewPager_withZeroSizedViews_laysOutWithoutReadingACellsView() {
+        final MyViewGroup viewGroup = new MyViewGroup(ApplicationProvider.getApplicationContext());
+        final AdapterViewManager zeroSizeAdapterViewManager = new AdapterViewManager();
+        final GridLayoutManagerAttributes notAViewPager =
+                new GridLayoutManagerAttributes(
+                        NUMBER_OF_COLUMNS,
+                        false,
+                        false,
+                        false,
+                        ONE_GROUP_PER_GESTURE,
+                        SnapPosition.start,
+                        CELL_SPACING,
+                        false,
+                        false,
+                        true,
+                        true,
+                        false,
+                        false,
+                        false);
+        final GridLayoutManager zeroSizeLayoutManager =
+                new GridLayoutManager(viewGroup, null, zeroSizeAdapterViewManager, notAViewPager);
+        final TestAdapter zeroSizeAdapter = new TestAdapter(ZERO_VIEW_SIZE);
+        zeroSizeAdapterViewManager.setAdapter(zeroSizeAdapter);
+        zeroSizeAdapter.setAdapterSize(PAGER_ADAPTER_SIZE);
+
+        final int measureSpec =
+                View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
+        viewGroup.measure(measureSpec, measureSpec);
+        viewGroup.layout(0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+
+        final Animation animation = new Animation();
+        animation.newAnimation();
+        zeroSizeLayoutManager.layout(viewGroup, animation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+
+        animation.newAnimation();
+        zeroSizeLayoutManager.layout(viewGroup, animation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+
+        assertThat(zeroSizeLayoutManager.getViewPagerScrollDistance(Move.forward)).isEqualTo(0);
+    }
+
+    @Test
+    public void viewPagerGesture_onAGrid_advancesOneWholeGroup() {
+        final GridPager pager = new GridPager(ONE_GROUP_PER_GESTURE);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-(VIEW_SIZE + CELL_SPACING));
+
+        pager.page(Move.forward);
+
+        assertThat(pager.topOf(2)).isEqualTo(0);
+        assertThat(pager.topOf(3)).isEqualTo(0);
+    }
+
+    @Test
+    public void viewPagerGesture_onAGridWithAnIntervalOfThree_advancesThreeWholeGroups() {
+        final GridPager pager = new GridPager(THREE_GROUPS_PER_GESTURE);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward))
+                .isEqualTo(-THREE_GROUPS_PER_GESTURE * (VIEW_SIZE + CELL_SPACING));
+
+        pager.page(Move.forward);
+
+        assertThat(pager.topOf(6)).isEqualTo(0);
+    }
+
+    private static final class GridPager {
+        private final MyViewGroup mPagerViewGroup;
+        private final GridLayoutManager mPagerLayoutManager;
+        private final Animation mPagerAnimation = new Animation();
+
+        private GridPager(final int viewPagerInterval) {
+            mPagerViewGroup = new MyViewGroup(ApplicationProvider.getApplicationContext());
+            final AdapterViewManager pagerAdapterViewManager = new AdapterViewManager();
+            final GridLayoutManagerAttributes pagerAttributes =
+                    new GridLayoutManagerAttributes(
+                            NUMBER_OF_COLUMNS,
+                            false,
+                            false,
+                            true,
+                            viewPagerInterval,
+                            SnapPosition.start,
+                            CELL_SPACING,
+                            false,
+                            false,
+                            true,
+                            true,
+                            false,
+                            false,
+                            false);
+            mPagerLayoutManager =
+                    new GridLayoutManager(
+                            mPagerViewGroup, null, pagerAdapterViewManager, pagerAttributes);
+            final TestAdapter pagerAdapter = new TestAdapter(VIEW_SIZE);
+            pagerAdapterViewManager.setAdapter(pagerAdapter);
+            pagerAdapter.setAdapterSize(PAGER_ADAPTER_SIZE);
+
+            final int measureSpec =
+                    View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
+            mPagerViewGroup.measure(measureSpec, measureSpec);
+            mPagerViewGroup.layout(0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+
+            layout();
+        }
+
+        private void layout() {
+            mPagerLayoutManager.layout(
+                    mPagerViewGroup, mPagerAnimation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+        }
+
+        private void startGesture() {
+            mPagerAnimation.newAnimation();
+            layout();
+        }
+
+        private int pageDistance(final Move move) {
+            return mPagerLayoutManager.getViewPagerScrollDistance(move);
+        }
+
+        private void page(final Move move) {
+            mPagerAnimation.setDisplacement(pageDistance(move));
+            layout();
+        }
+
+        private int topOf(final int adapterPosition) {
+            for (final View view : mPagerViewGroup.mViews) {
+                final Object tag = view.getTag();
+                final boolean isTheWantedView = tag.equals(Integer.valueOf(adapterPosition));
+                if (isTheWantedView) return view.getTop();
+            }
+            return NOT_DRAWN;
+        }
+    }
+
     private void doLayout() {
         doLayout(new Animation());
     }
@@ -415,7 +557,7 @@ public class GridLayoutManagerTest {
         mViewGroup.layout(0, 0, viewGroupSize, viewGroupSize);
     }
 
-    public class MyViewGroup extends LinearLayout implements AdapterViewHandler {
+    public static class MyViewGroup extends LinearLayout implements AdapterViewHandler {
         public final List<View> mViews = new ArrayList<View>();
 
         public MyViewGroup(Context context) {
@@ -423,14 +565,7 @@ public class GridLayoutManagerTest {
         }
 
         public View forPosition(int position) {
-            Collections.sort(
-                    mViews,
-                    new Comparator<View>() {
-                        @Override
-                        public int compare(View lhs, View rhs) {
-                            return lhs.getLeft() - rhs.getLeft();
-                        }
-                    });
+            Collections.sort(mViews, new LeftToRightComparator());
 
             return mViews.get(position);
         }
@@ -448,9 +583,16 @@ public class GridLayoutManagerTest {
         }
     }
 
-    public class TestAdapter extends BaseAdapter {
+    private static final class LeftToRightComparator implements Comparator<View> {
+        @Override
+        public int compare(final View lhs, final View rhs) {
+            return lhs.getLeft() - rhs.getLeft();
+        }
+    }
+
+    public static class TestAdapter extends BaseAdapter {
+        private final int mViewSize;
         private int mAdapterSize;
-        private int mViewSize;
 
         public TestAdapter(int viewSize) {
             mViewSize = viewSize;

--- a/library/src/test/java/mobi/parchment/widget/adapterview/GridLayoutManagerTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/GridLayoutManagerTest.java
@@ -31,6 +31,10 @@ public class GridLayoutManagerTest {
     public static final int CELL_SPACING = 10;
     public static final int NUMBER_OF_COLUMNS = 2;
     private static final int ONE_GROUP_PER_GESTURE = 1;
+    private static final int VIEWPORT_PAGING = 0;
+    private static final int TWO_GROUPS = 2;
+    private static final int FIRST_VIEW_OF_THE_THIRD_GROUP = 4;
+    private static final int SECOND_VIEW_OF_THE_THIRD_GROUP = 5;
     private static final int THREE_GROUPS_PER_GESTURE = 3;
     private static final int PAGER_ADAPTER_SIZE = 10;
     private static final int NOT_DRAWN = Integer.MIN_VALUE;
@@ -472,6 +476,21 @@ public class GridLayoutManagerTest {
         pager.page(Move.forward);
 
         assertThat(pager.topOf(6)).isEqualTo(0);
+    }
+
+    @Test
+    public void viewportPaging_onAGrid_advancesEveryWholeGroupThatFits() {
+        final GridPager pager = new GridPager(VIEWPORT_PAGING);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward))
+                .isEqualTo(-TWO_GROUPS * (VIEW_SIZE + CELL_SPACING));
+
+        pager.page(Move.forward);
+
+        assertThat(pager.topOf(FIRST_VIEW_OF_THE_THIRD_GROUP)).isEqualTo(0);
+        assertThat(pager.topOf(SECOND_VIEW_OF_THE_THIRD_GROUP)).isEqualTo(0);
     }
 
     private static final class GridPager {

--- a/library/src/test/java/mobi/parchment/widget/adapterview/GridPatternLayoutManagerTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/GridPatternLayoutManagerTest.java
@@ -32,6 +32,15 @@ public class GridPatternLayoutManagerTest {
     public static final int VIEW_SIZE = 145;
     public static final int CELL_SPACING = 10;
     private static final int ONE_GROUP_PER_GESTURE = 1;
+    private static final int VIEWPORT_PAGING = 0;
+    private static final int THREE_GROUPS = 3;
+    private static final int FIRST_ITEM = 0;
+    private static final int FIRST_ITEM_OF_THE_FOURTH_GROUP = 5;
+    private static final int TALL_VIEW_GROUP_SIZE = 500;
+    private static final int GROUP_SPAN = VIEW_SIZE + CELL_SPACING;
+    private static final int THIRD_GROUP_POSITION = 3;
+    private static final int ONE_UNIT_TALL = 1;
+    private static final int TWO_UNITS_TALL = 2;
     private static final int SECOND_GROUP_POSITION = 2;
     private static final int PAGER_ADAPTER_SIZE = 9;
     private static final int NOT_DRAWN = Integer.MIN_VALUE;
@@ -320,12 +329,59 @@ public class GridPatternLayoutManagerTest {
         assertThat(pager.topOf(SECOND_GROUP_POSITION)).isEqualTo(0);
     }
 
+    @Test
+    public void viewportPaging_onAGridPattern_advancesEveryWholePatternGroupThatFits() {
+        final PatternPager pager = new PatternPager(VIEWPORT_PAGING, TALL_VIEW_GROUP_SIZE);
+
+        final int groupSpan = pager.topOf(SECOND_GROUP_POSITION) - pager.topOf(FIRST_ITEM);
+        assertThat(groupSpan).isEqualTo(GROUP_SPAN);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-THREE_GROUPS * groupSpan);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.topOf(FIRST_ITEM_OF_THE_FOURTH_GROUP)).isEqualTo(0);
+    }
+
+    @Test
+    public void viewportPaging_onAPatternWhoseGroupsDifferInHeight_advancesBothOfTheirOwnSpans() {
+        final PatternPager pager =
+                new PatternPager(VIEWPORT_PAGING, TALL_VIEW_GROUP_SIZE, TWO_UNITS_TALL);
+
+        final int firstGroupSpan = pager.topOf(SECOND_GROUP_POSITION) - pager.topOf(FIRST_ITEM);
+        final int secondGroupSpan =
+                pager.topOf(THIRD_GROUP_POSITION) - pager.topOf(SECOND_GROUP_POSITION);
+
+        assertThat(secondGroupSpan).isNotEqualTo(firstGroupSpan);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-(firstGroupSpan + secondGroupSpan));
+
+        pager.page(Move.forward);
+
+        assertThat(pager.topOf(THIRD_GROUP_POSITION)).isEqualTo(0);
+    }
+
     private static final class PatternPager {
         private final MyViewGroup mPagerViewGroup;
         private final GridPatternLayoutManager mPagerLayoutManager;
         private final Animation mPagerAnimation = new Animation();
+        private final int mViewGroupSize;
 
         private PatternPager() {
+            this(ONE_GROUP_PER_GESTURE, VIEW_GROUP_SIZE, ONE_UNIT_TALL);
+        }
+
+        private PatternPager(final int viewPagerInterval, final int viewGroupSize) {
+            this(viewPagerInterval, viewGroupSize, ONE_UNIT_TALL);
+        }
+
+        private PatternPager(
+                final int viewPagerInterval, final int viewGroupSize, final int secondGroupHeight) {
+            mViewGroupSize = viewGroupSize;
             mPagerViewGroup = new MyViewGroup(ApplicationProvider.getApplicationContext());
             final AdapterViewManager pagerAdapterViewManager = new AdapterViewManager();
             final GridPatternLayoutManagerAttributes pagerAttributes =
@@ -333,7 +389,7 @@ public class GridPatternLayoutManagerTest {
                             false,
                             false,
                             true,
-                            ONE_GROUP_PER_GESTURE,
+                            viewPagerInterval,
                             SnapPosition.start,
                             CELL_SPACING,
                             false,
@@ -353,7 +409,7 @@ public class GridPatternLayoutManagerTest {
 
             final List<GridPatternItemDefinition> secondGroupItems =
                     new ArrayList<GridPatternItemDefinition>();
-            secondGroupItems.add(new GridPatternItemDefinition(0, 0, 1, 2));
+            secondGroupItems.add(new GridPatternItemDefinition(0, 0, secondGroupHeight, 2));
             mPagerLayoutManager.addGridPatternGroupDefinition(
                     new GridPatternGroupDefinition(true, secondGroupItems));
 
@@ -361,17 +417,19 @@ public class GridPatternLayoutManagerTest {
             pagerAdapterViewManager.setAdapter(pagerAdapter);
             pagerAdapter.setAdapterSize(PAGER_ADAPTER_SIZE);
 
-            final int measureSpec =
+            final int breadthMeasureSpec =
                     View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
-            mPagerViewGroup.measure(measureSpec, measureSpec);
-            mPagerViewGroup.layout(0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+            final int sizeMeasureSpec =
+                    View.MeasureSpec.makeMeasureSpec(mViewGroupSize, View.MeasureSpec.EXACTLY);
+            mPagerViewGroup.measure(breadthMeasureSpec, sizeMeasureSpec);
+            mPagerViewGroup.layout(0, 0, VIEW_GROUP_SIZE, mViewGroupSize);
 
             layout();
         }
 
         private void layout() {
             mPagerLayoutManager.layout(
-                    mPagerViewGroup, mPagerAnimation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+                    mPagerViewGroup, mPagerAnimation, 0, 0, VIEW_GROUP_SIZE, mViewGroupSize);
         }
 
         private void startGesture() {

--- a/library/src/test/java/mobi/parchment/widget/adapterview/GridPatternLayoutManagerTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/GridPatternLayoutManagerTest.java
@@ -31,6 +31,10 @@ public class GridPatternLayoutManagerTest {
     public static final int VIEW_GROUP_SIZE = 300;
     public static final int VIEW_SIZE = 145;
     public static final int CELL_SPACING = 10;
+    private static final int ONE_GROUP_PER_GESTURE = 1;
+    private static final int SECOND_GROUP_POSITION = 2;
+    private static final int PAGER_ADAPTER_SIZE = 9;
+    private static final int NOT_DRAWN = Integer.MIN_VALUE;
     final MyViewGroup mViewGroup = new MyViewGroup(ApplicationProvider.getApplicationContext());
     final AdapterViewManager adapterViewManager = new AdapterViewManager();
     TestAdapter mTestAdapter;
@@ -300,6 +304,100 @@ public class GridPatternLayoutManagerTest {
         assertThat(thirdView.getBottom()).isEqualTo(300);
     }
 
+    @Test
+    public void viewPagerGesture_onAGridPattern_advancesOneWholePatternGroup() {
+        final PatternPager pager = new PatternPager();
+
+        final int firstGroupSpan = pager.topOf(SECOND_GROUP_POSITION) - pager.topOf(0);
+        assertThat(firstGroupSpan).isGreaterThan(0);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-firstGroupSpan);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.topOf(SECOND_GROUP_POSITION)).isEqualTo(0);
+    }
+
+    private static final class PatternPager {
+        private final MyViewGroup mPagerViewGroup;
+        private final GridPatternLayoutManager mPagerLayoutManager;
+        private final Animation mPagerAnimation = new Animation();
+
+        private PatternPager() {
+            mPagerViewGroup = new MyViewGroup(ApplicationProvider.getApplicationContext());
+            final AdapterViewManager pagerAdapterViewManager = new AdapterViewManager();
+            final GridPatternLayoutManagerAttributes pagerAttributes =
+                    new GridPatternLayoutManagerAttributes(
+                            false,
+                            false,
+                            true,
+                            ONE_GROUP_PER_GESTURE,
+                            SnapPosition.start,
+                            CELL_SPACING,
+                            false,
+                            false,
+                            true,
+                            1f);
+            mPagerLayoutManager =
+                    new GridPatternLayoutManager(
+                            mPagerViewGroup, null, pagerAdapterViewManager, pagerAttributes);
+
+            final List<GridPatternItemDefinition> firstGroupItems =
+                    new ArrayList<GridPatternItemDefinition>();
+            firstGroupItems.add(new GridPatternItemDefinition(0, 0, 1, 1));
+            firstGroupItems.add(new GridPatternItemDefinition(0, 1, 1, 1));
+            mPagerLayoutManager.addGridPatternGroupDefinition(
+                    new GridPatternGroupDefinition(true, firstGroupItems));
+
+            final List<GridPatternItemDefinition> secondGroupItems =
+                    new ArrayList<GridPatternItemDefinition>();
+            secondGroupItems.add(new GridPatternItemDefinition(0, 0, 1, 2));
+            mPagerLayoutManager.addGridPatternGroupDefinition(
+                    new GridPatternGroupDefinition(true, secondGroupItems));
+
+            final TestAdapter pagerAdapter = new TestAdapter(VIEW_SIZE);
+            pagerAdapterViewManager.setAdapter(pagerAdapter);
+            pagerAdapter.setAdapterSize(PAGER_ADAPTER_SIZE);
+
+            final int measureSpec =
+                    View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
+            mPagerViewGroup.measure(measureSpec, measureSpec);
+            mPagerViewGroup.layout(0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+
+            layout();
+        }
+
+        private void layout() {
+            mPagerLayoutManager.layout(
+                    mPagerViewGroup, mPagerAnimation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+        }
+
+        private void startGesture() {
+            mPagerAnimation.newAnimation();
+            layout();
+        }
+
+        private int pageDistance(final Move move) {
+            return mPagerLayoutManager.getViewPagerScrollDistance(move);
+        }
+
+        private void page(final Move move) {
+            mPagerAnimation.setDisplacement(pageDistance(move));
+            layout();
+        }
+
+        private int topOf(final int adapterPosition) {
+            for (final View view : mPagerViewGroup.mViews) {
+                final Object tag = view.getTag();
+                final boolean isTheWantedView = tag.equals(Integer.valueOf(adapterPosition));
+                if (isTheWantedView) return view.getTop();
+            }
+            return NOT_DRAWN;
+        }
+    }
+
     private void doLayout() {
         doLayout(new Animation());
     }
@@ -315,7 +413,7 @@ public class GridPatternLayoutManagerTest {
         mViewGroup.layout(0, 0, viewGroupSize, viewGroupSize);
     }
 
-    public class MyViewGroup extends LinearLayout implements AdapterViewHandler {
+    public static class MyViewGroup extends LinearLayout implements AdapterViewHandler {
         public final List<View> mViews = new ArrayList<View>();
 
         public MyViewGroup(Context context) {
@@ -323,14 +421,7 @@ public class GridPatternLayoutManagerTest {
         }
 
         public View forPosition(int position) {
-            Collections.sort(
-                    mViews,
-                    new Comparator<View>() {
-                        @Override
-                        public int compare(View lhs, View rhs) {
-                            return lhs.getLeft() - rhs.getLeft();
-                        }
-                    });
+            Collections.sort(mViews, new LeftToRightComparator());
 
             return mViews.get(position);
         }
@@ -348,9 +439,16 @@ public class GridPatternLayoutManagerTest {
         }
     }
 
-    public class TestAdapter extends BaseAdapter {
+    private static final class LeftToRightComparator implements Comparator<View> {
+        @Override
+        public int compare(final View lhs, final View rhs) {
+            return lhs.getLeft() - rhs.getLeft();
+        }
+    }
+
+    public static class TestAdapter extends BaseAdapter {
+        private final int mViewSize;
         private int mAdapterSize;
-        private int mViewSize;
 
         public TestAdapter(int viewSize) {
             mViewSize = viewSize;

--- a/library/src/test/java/mobi/parchment/widget/adapterview/LayoutManagerPagingMethodsTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/LayoutManagerPagingMethodsTest.java
@@ -18,6 +18,10 @@ import mobi.parchment.widget.adapterview.gridview.GridLayoutManager;
 import mobi.parchment.widget.adapterview.gridview.GridLayoutManagerAttributes;
 import mobi.parchment.widget.adapterview.gridview.Group;
 import mobi.parchment.widget.adapterview.listview.ListLayoutManager;
+import mobi.parchment.widget.adapterview.pageinterval.CellCountPageInterval;
+import mobi.parchment.widget.adapterview.pageinterval.PageIntervalInterface;
+import mobi.parchment.widget.adapterview.pageinterval.PageIntervalSelector;
+import mobi.parchment.widget.adapterview.pageinterval.ViewportPageInterval;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -58,6 +62,7 @@ public class LayoutManagerPagingMethodsTest {
     private static final int VIEWPORT_PADDING = 20;
     private static final int NO_DISTANCE = 0;
     private static final int NUMBER_OF_VIEWS_PER_CELL = 2;
+    private static final LayoutManager<View> NO_LAYOUT_MANAGER = null;
 
     private static final int FIRST_CELL = 0;
     private static final int SECOND_CELL = 1;
@@ -70,6 +75,8 @@ public class LayoutManagerPagingMethodsTest {
     private static final int A_WHOLE_VIEWPORT = THREE_CELL_VIEWPORT;
 
     private static final int ONE_PIXEL = 1;
+    private static final int SPACED_CELL_STEP = CELL_SIZE + CELL_SPACING;
+    private static final int ROOM_FOR_TWO_SPACED_CELLS = CELL_SIZE + CELL_SPACING + CELL_SIZE;
     private static final int A_PAGE_THAT_MISSES_BY_A_PIXEL = A_WHOLE_VIEWPORT - ONE_PIXEL;
     private static final int NO_PAGE_ROOM = 0;
     private static final int NEGATIVE_PAGE_ROOM = -100;
@@ -105,37 +112,37 @@ public class LayoutManagerPagingMethodsTest {
 
     @Test
     public void pagesByCellCount_withAnIntervalOfZero_choosesTheViewportAlgorithm() {
-        assertThat(LayoutManager.pagesByCellCount(VIEWPORT_PAGING)).isFalse();
+        assertThat(PageIntervalSelector.pagesByCellCount(VIEWPORT_PAGING)).isFalse();
     }
 
     @Test
     public void pagesByCellCount_withAnIntervalOfOne_choosesTheCellCountAlgorithm() {
-        assertThat(LayoutManager.pagesByCellCount(ONE_CELL_PER_GESTURE)).isTrue();
+        assertThat(PageIntervalSelector.pagesByCellCount(ONE_CELL_PER_GESTURE)).isTrue();
     }
 
     @Test
     public void pagesByCellCount_withAnIntervalOfTwo_choosesTheCellCountAlgorithm() {
-        assertThat(LayoutManager.pagesByCellCount(TWO_CELLS_PER_GESTURE)).isTrue();
+        assertThat(PageIntervalSelector.pagesByCellCount(TWO_CELLS_PER_GESTURE)).isTrue();
     }
 
     @Test
     public void pagesByCellCount_withAnIntervalLargerThanTheAdapter_choosesTheCellCountAlgorithm() {
-        assertThat(LayoutManager.pagesByCellCount(MORE_CELLS_THAN_THE_ADAPTER_HAS)).isTrue();
+        assertThat(PageIntervalSelector.pagesByCellCount(MORE_CELLS_THAN_THE_ADAPTER_HAS)).isTrue();
     }
 
     @Test
     public void pagesByCellCount_withTheLargestInterval_choosesTheCellCountAlgorithm() {
-        assertThat(LayoutManager.pagesByCellCount(Integer.MAX_VALUE)).isTrue();
+        assertThat(PageIntervalSelector.pagesByCellCount(Integer.MAX_VALUE)).isTrue();
     }
 
     @Test
     public void pagesByCellCount_withANegativeInterval_choosesTheCellCountAlgorithm() {
-        assertThat(LayoutManager.pagesByCellCount(A_NEGATIVE_INTERVAL)).isTrue();
+        assertThat(PageIntervalSelector.pagesByCellCount(A_NEGATIVE_INTERVAL)).isTrue();
     }
 
     @Test
     public void pagesByCellCount_withTheMostNegativeInterval_choosesTheCellCountAlgorithm() {
-        assertThat(LayoutManager.pagesByCellCount(Integer.MIN_VALUE)).isTrue();
+        assertThat(PageIntervalSelector.pagesByCellCount(Integer.MIN_VALUE)).isTrue();
     }
 
     @Test
@@ -165,7 +172,7 @@ public class LayoutManagerPagingMethodsTest {
         assertThat(intervalAfterAttributeParsing(Integer.MIN_VALUE)).isEqualTo(VIEWPORT_PAGING);
     }
 
-    // ---------------------------------------------------- getPageCellIndexForward dispatch
+    // ------------------------------------------ the selected strategy, paging forward
 
     @Test
     public void getPageCellIndexForward_withAnIntervalOfZero_runsTheViewportWalk() {
@@ -211,7 +218,7 @@ public class LayoutManagerPagingMethodsTest {
         assertThat(forward(manager, VIEWPORT_PAGING + ONE_CELL_PER_GESTURE)).isEqualTo(SECOND_CELL);
     }
 
-    // ------------------------------------------------------- getPageCellIndexBack dispatch
+    // --------------------------------------------- the selected strategy, paging back
 
     @Test
     public void getPageCellIndexBack_withAnIntervalOfZero_runsTheViewportWalk() {
@@ -261,40 +268,30 @@ public class LayoutManagerPagingMethodsTest {
 
     @Test
     public void forwardByCellCount_fromTheFirstCell_addsTheInterval() {
-        assertThat(
-                        LayoutManager.getPageCellIndexForwardByCellCount(
-                                ONE_CELL_PER_GESTURE, FIRST_CELL))
-                .isEqualTo(SECOND_CELL);
+        assertThat(forwardByCellCount(ONE_CELL_PER_GESTURE, FIRST_CELL)).isEqualTo(SECOND_CELL);
     }
 
     @Test
     public void forwardByCellCount_fromACellInTheMiddle_addsTheInterval() {
-        assertThat(
-                        LayoutManager.getPageCellIndexForwardByCellCount(
-                                THREE_CELLS_PER_GESTURE, FOURTH_CELL))
+        assertThat(forwardByCellCount(THREE_CELLS_PER_GESTURE, FOURTH_CELL))
                 .isEqualTo(FOURTH_CELL + THREE_CELLS_PER_GESTURE);
     }
 
     @Test
     public void forwardByCellCount_fromTheLastCell_namesACellBeyondTheAdapterEnd() {
-        assertThat(
-                        LayoutManager.getPageCellIndexForwardByCellCount(
-                                ONE_CELL_PER_GESTURE, LAST_OF_TEN_CELLS))
+        assertThat(forwardByCellCount(ONE_CELL_PER_GESTURE, LAST_OF_TEN_CELLS))
                 .isEqualTo(ONE_PAST_TEN_CELLS);
     }
 
     @Test
     public void forwardByCellCount_withAnIntervalLargerThanTheAdapter_namesACellFarBeyondTheEnd() {
-        assertThat(
-                        LayoutManager.getPageCellIndexForwardByCellCount(
-                                MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL))
+        assertThat(forwardByCellCount(MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL))
                 .isEqualTo(MORE_CELLS_THAN_THE_ADAPTER_HAS);
     }
 
     @Test
     public void forwardByCellCount_withTheLargestInterval_doesNotWrapToANegativeIndex() {
-        final long index =
-                LayoutManager.getPageCellIndexForwardByCellCount(Integer.MAX_VALUE, FOURTH_CELL);
+        final long index = forwardByCellCount(Integer.MAX_VALUE, FOURTH_CELL);
 
         assertThat(index).isEqualTo((long) FOURTH_CELL + Integer.MAX_VALUE);
         assertThat(index).isGreaterThan(Integer.MAX_VALUE);
@@ -302,8 +299,7 @@ public class LayoutManagerPagingMethodsTest {
 
     @Test
     public void forwardByCellCount_withTheMostNegativeInterval_doesNotWrapToAPositiveIndex() {
-        final long index =
-                LayoutManager.getPageCellIndexForwardByCellCount(Integer.MIN_VALUE, FOURTH_CELL);
+        final long index = forwardByCellCount(Integer.MIN_VALUE, FOURTH_CELL);
 
         assertThat(index).isEqualTo((long) FOURTH_CELL + Integer.MIN_VALUE);
         assertThat(index).isLessThan(0L);
@@ -311,30 +307,25 @@ public class LayoutManagerPagingMethodsTest {
 
     @Test
     public void backByCellCount_fromTheFirstCell_namesACellBeforeTheAdapterStart() {
-        assertThat(LayoutManager.getPageCellIndexBackByCellCount(ONE_CELL_PER_GESTURE, FIRST_CELL))
+        assertThat(backByCellCount(ONE_CELL_PER_GESTURE, FIRST_CELL))
                 .isEqualTo(-ONE_CELL_PER_GESTURE);
     }
 
     @Test
     public void backByCellCount_fromACellInTheMiddle_subtractsTheInterval() {
-        assertThat(
-                        LayoutManager.getPageCellIndexBackByCellCount(
-                                THREE_CELLS_PER_GESTURE, FOURTH_CELL))
+        assertThat(backByCellCount(THREE_CELLS_PER_GESTURE, FOURTH_CELL))
                 .isEqualTo(FOURTH_CELL - THREE_CELLS_PER_GESTURE);
     }
 
     @Test
     public void backByCellCount_fromTheLastCell_subtractsTheInterval() {
-        assertThat(
-                        LayoutManager.getPageCellIndexBackByCellCount(
-                                ONE_CELL_PER_GESTURE, LAST_OF_TEN_CELLS))
+        assertThat(backByCellCount(ONE_CELL_PER_GESTURE, LAST_OF_TEN_CELLS))
                 .isEqualTo(LAST_OF_TEN_CELLS - ONE_CELL_PER_GESTURE);
     }
 
     @Test
     public void backByCellCount_withTheLargestInterval_doesNotWrapToAPositiveIndex() {
-        final long index =
-                LayoutManager.getPageCellIndexBackByCellCount(Integer.MAX_VALUE, FOURTH_CELL);
+        final long index = backByCellCount(Integer.MAX_VALUE, FOURTH_CELL);
 
         assertThat(index).isEqualTo((long) FOURTH_CELL - Integer.MAX_VALUE);
         assertThat(index).isLessThan(0L);
@@ -342,8 +333,7 @@ public class LayoutManagerPagingMethodsTest {
 
     @Test
     public void backByCellCount_withTheMostNegativeInterval_doesNotWrapToANegativeIndex() {
-        final long index =
-                LayoutManager.getPageCellIndexBackByCellCount(Integer.MIN_VALUE, FOURTH_CELL);
+        final long index = backByCellCount(Integer.MIN_VALUE, FOURTH_CELL);
 
         assertThat(index).isEqualTo((long) FOURTH_CELL - Integer.MIN_VALUE);
         assertThat(index).isGreaterThan(Integer.MAX_VALUE);
@@ -352,9 +342,7 @@ public class LayoutManagerPagingMethodsTest {
     @Test
     public void cellCountPaging_pastTheAdapterEndWithoutCircularScroll_isCappedAtTheLastCell() {
         final LayoutManager<View> manager = equalCellManager();
-        final long index =
-                LayoutManager.getPageCellIndexForwardByCellCount(
-                        MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
+        final long index = forwardByCellCount(MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
 
         assertThat(manager.getCellStartAtIndex(index)).isEqualTo(LAST_OF_TEN_CELLS * CELL_SIZE);
     }
@@ -362,9 +350,7 @@ public class LayoutManagerPagingMethodsTest {
     @Test
     public void cellCountPaging_pastTheAdapterEndWithCircularScroll_keepsExtrapolating() {
         final LayoutManager<View> manager = circularEqualCellManager();
-        final long index =
-                LayoutManager.getPageCellIndexForwardByCellCount(
-                        MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
+        final long index = forwardByCellCount(MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
 
         assertThat(manager.getCellStartAtIndex(index))
                 .isEqualTo(MORE_CELLS_THAN_THE_ADAPTER_HAS * CELL_SIZE);
@@ -374,9 +360,7 @@ public class LayoutManagerPagingMethodsTest {
     public void
             cellCountPaging_beforeTheAdapterStartWithoutCircularScroll_isCappedAtTheFirstCell() {
         final LayoutManager<View> manager = equalCellManager();
-        final long index =
-                LayoutManager.getPageCellIndexBackByCellCount(
-                        MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
+        final long index = backByCellCount(MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
 
         assertThat(manager.getCellStartAtIndex(index)).isEqualTo(NO_DISTANCE);
     }
@@ -384,9 +368,7 @@ public class LayoutManagerPagingMethodsTest {
     @Test
     public void cellCountPaging_beforeTheAdapterStartWithCircularScroll_keepsExtrapolating() {
         final LayoutManager<View> manager = circularEqualCellManager();
-        final long index =
-                LayoutManager.getPageCellIndexBackByCellCount(
-                        MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
+        final long index = backByCellCount(MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
 
         assertThat(manager.getCellStartAtIndex(index))
                 .isEqualTo(-MORE_CELLS_THAN_THE_ADAPTER_HAS * CELL_SIZE);
@@ -395,8 +377,7 @@ public class LayoutManagerPagingMethodsTest {
     @Test
     public void cellCountPaging_withTheLargestIntervalPastTheEnd_isStillCappedAtTheLastCell() {
         final LayoutManager<View> manager = equalCellManager();
-        final long index =
-                LayoutManager.getPageCellIndexForwardByCellCount(Integer.MAX_VALUE, FIRST_CELL);
+        final long index = forwardByCellCount(Integer.MAX_VALUE, FIRST_CELL);
 
         assertThat(manager.getCellStartAtIndex(index)).isEqualTo(LAST_OF_TEN_CELLS * CELL_SIZE);
     }
@@ -407,9 +388,7 @@ public class LayoutManagerPagingMethodsTest {
     public void forwardByViewport_withAPageThatFitsExactly_takesTheCellThatFits() {
         final LayoutManager<View> manager = equalCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+        assertThat(viewportForward(manager, A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
                 .isEqualTo(FOURTH_CELL);
     }
 
@@ -417,9 +396,7 @@ public class LayoutManagerPagingMethodsTest {
     public void forwardByViewport_withAPageThatMissesByOnePixel_leavesThatCellBehind() {
         final LayoutManager<View> manager = equalCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                A_PAGE_THAT_MISSES_BY_A_PIXEL, FIRST_CELL, NO_DISTANCE))
+        assertThat(viewportForward(manager, A_PAGE_THAT_MISSES_BY_A_PIXEL, FIRST_CELL, NO_DISTANCE))
                 .isEqualTo(THIRD_CELL);
     }
 
@@ -427,9 +404,7 @@ public class LayoutManagerPagingMethodsTest {
     public void forwardByViewport_withASingleCellAdapter_findsNoFurtherCell() {
         final LayoutManager<View> manager = singleCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+        assertThat(viewportForward(manager, A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
                 .isEqualTo(SECOND_CELL);
         assertThat(manager.getCellStartAtIndex(SECOND_CELL)).isEqualTo(NO_DISTANCE);
     }
@@ -438,9 +413,7 @@ public class LayoutManagerPagingMethodsTest {
     public void forwardByViewport_withACellLargerThanTheViewport_advancesExactlyOneCell() {
         final LayoutManager<View> manager = largeCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                SMALL_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+        assertThat(viewportForward(manager, SMALL_VIEWPORT, FIRST_CELL, NO_DISTANCE))
                 .isEqualTo(SECOND_CELL);
     }
 
@@ -448,9 +421,17 @@ public class LayoutManagerPagingMethodsTest {
     public void forwardByViewport_withCellSpacing_countsTheSpacingThatComesWithEachCell() {
         final LayoutManager<View> manager = spacedCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+        assertThat(viewportForward(manager, A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(THIRD_CELL);
+    }
+
+    @Test
+    public void forwardByViewport_withAPageThatOnlyFitsBecauseTheSpacingIsNotPartOfIt_takesIt() {
+        final LayoutManager<View> manager = spacedCellManager();
+
+        assertThat(manager.getCellStartAtIndex(THIRD_CELL))
+                .isEqualTo(ROOM_FOR_TWO_SPACED_CELLS + CELL_SPACING);
+        assertThat(viewportForward(manager, ROOM_FOR_TWO_SPACED_CELLS, FIRST_CELL, NO_DISTANCE))
                 .isEqualTo(THIRD_CELL);
     }
 
@@ -460,9 +441,7 @@ public class LayoutManagerPagingMethodsTest {
 
         assertThat(manager.getCellStartAtIndex(FOURTH_CELL))
                 .isEqualTo(UNEQUAL_CELLS_THAT_FILL_THE_VIEWPORT);
-        assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+        assertThat(viewportForward(manager, A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
                 .isEqualTo(FOURTH_CELL);
     }
 
@@ -472,8 +451,11 @@ public class LayoutManagerPagingMethodsTest {
 
         assertThat(manager.getCellStartAtIndex(FIRST_CELL)).isEqualTo(VIEWPORT_PADDING);
         assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                THE_VIEWPORT_INSIDE_THE_PADDING, FIRST_CELL, VIEWPORT_PADDING))
+                        viewportForward(
+                                manager,
+                                THE_VIEWPORT_INSIDE_THE_PADDING,
+                                FIRST_CELL,
+                                VIEWPORT_PADDING))
                 .isEqualTo(THIRD_CELL);
     }
 
@@ -486,8 +468,11 @@ public class LayoutManagerPagingMethodsTest {
         assertThat(manager.getCellStartAtIndex(FIRST_CELL))
                 .isEqualTo(A_REST_PART_WAY_THROUGH_A_CELL);
         assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                A_WHOLE_VIEWPORT, FIRST_CELL, A_REST_PART_WAY_THROUGH_A_CELL))
+                        viewportForward(
+                                manager,
+                                A_WHOLE_VIEWPORT,
+                                FIRST_CELL,
+                                A_REST_PART_WAY_THROUGH_A_CELL))
                 .isEqualTo(FOURTH_CELL);
     }
 
@@ -495,7 +480,7 @@ public class LayoutManagerPagingMethodsTest {
     public void forwardByViewport_withNoPageRoom_advancesExactlyOneCell() {
         final LayoutManager<View> manager = equalCellManager();
 
-        assertThat(manager.getPageCellIndexForwardByViewport(NO_PAGE_ROOM, FIRST_CELL, NO_DISTANCE))
+        assertThat(viewportForward(manager, NO_PAGE_ROOM, FIRST_CELL, NO_DISTANCE))
                 .isEqualTo(SECOND_CELL);
     }
 
@@ -503,9 +488,7 @@ public class LayoutManagerPagingMethodsTest {
     public void forwardByViewport_withNegativePageRoom_advancesExactlyOneCell() {
         final LayoutManager<View> manager = equalCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                NEGATIVE_PAGE_ROOM, FIRST_CELL, NO_DISTANCE))
+        assertThat(viewportForward(manager, NEGATIVE_PAGE_ROOM, FIRST_CELL, NO_DISTANCE))
                 .isEqualTo(SECOND_CELL);
     }
 
@@ -515,8 +498,7 @@ public class LayoutManagerPagingMethodsTest {
         final int lastCellStart = LAST_OF_TEN_CELLS * CELL_SIZE;
 
         final long index =
-                manager.getPageCellIndexForwardByViewport(
-                        A_WHOLE_VIEWPORT, LAST_OF_TEN_CELLS, lastCellStart);
+                viewportForward(manager, A_WHOLE_VIEWPORT, LAST_OF_TEN_CELLS, lastCellStart);
 
         assertThat(index).isEqualTo(ONE_PAST_TEN_CELLS);
         assertThat(manager.getCellStartAtIndex(index)).isEqualTo(lastCellStart);
@@ -528,9 +510,7 @@ public class LayoutManagerPagingMethodsTest {
         final int anchorIndex = LAST_OF_TEN_CELLS - TWO_CELLS_PER_GESTURE;
         final int anchorStart = anchorIndex * CELL_SIZE;
 
-        final long index =
-                manager.getPageCellIndexForwardByViewport(
-                        A_WHOLE_VIEWPORT, anchorIndex, anchorStart);
+        final long index = viewportForward(manager, A_WHOLE_VIEWPORT, anchorIndex, anchorStart);
 
         assertThat(index).isEqualTo(LAST_OF_TEN_CELLS);
         assertThat(manager.getCellStartAtIndex(index)).isEqualTo(LAST_OF_TEN_CELLS * CELL_SIZE);
@@ -541,9 +521,7 @@ public class LayoutManagerPagingMethodsTest {
         final LayoutManager<View> manager = circularFourCellManager();
         final int anchorStart = FOURTH_CELL * CELL_SIZE;
 
-        assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                A_WHOLE_VIEWPORT, FOURTH_CELL, anchorStart))
+        assertThat(viewportForward(manager, A_WHOLE_VIEWPORT, FOURTH_CELL, anchorStart))
                 .isEqualTo(FOURTH_CELL + THREE_CELLS_PER_GESTURE);
     }
 
@@ -551,9 +529,7 @@ public class LayoutManagerPagingMethodsTest {
     public void forwardByViewport_inAVerticalList_walksTheSameCells() {
         final LayoutManager<View> manager = verticalEqualCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+        assertThat(viewportForward(manager, A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
                 .isEqualTo(FOURTH_CELL);
     }
 
@@ -561,9 +537,7 @@ public class LayoutManagerPagingMethodsTest {
     public void backByViewport_withAPageThatFitsExactly_takesTheCellThatFits() {
         final LayoutManager<View> manager = equalCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexBackByViewport(
-                                A_WHOLE_VIEWPORT, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
+        assertThat(viewportBack(manager, A_WHOLE_VIEWPORT, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
                 .isEqualTo(FIRST_CELL);
     }
 
@@ -572,7 +546,8 @@ public class LayoutManagerPagingMethodsTest {
         final LayoutManager<View> manager = equalCellManager();
 
         assertThat(
-                        manager.getPageCellIndexBackByViewport(
+                        viewportBack(
+                                manager,
                                 A_PAGE_THAT_MISSES_BY_A_PIXEL,
                                 FOURTH_CELL,
                                 FOURTH_CELL * CELL_SIZE))
@@ -583,9 +558,7 @@ public class LayoutManagerPagingMethodsTest {
     public void backByViewport_withASingleCellAdapter_findsNoFurtherCell() {
         final LayoutManager<View> manager = singleCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexBackByViewport(
-                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+        assertThat(viewportBack(manager, A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
                 .isEqualTo(-ONE_CELL_PER_GESTURE);
         assertThat(manager.getCellStartAtIndex(-ONE_CELL_PER_GESTURE)).isEqualTo(NO_DISTANCE);
     }
@@ -594,21 +567,26 @@ public class LayoutManagerPagingMethodsTest {
     public void backByViewport_withACellLargerThanTheViewport_advancesExactlyOneCell() {
         final LayoutManager<View> manager = largeCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexBackByViewport(
-                                SMALL_VIEWPORT, SECOND_CELL, LARGE_CELL_SIZE))
+        assertThat(viewportBack(manager, SMALL_VIEWPORT, SECOND_CELL, LARGE_CELL_SIZE))
                 .isEqualTo(FIRST_CELL);
     }
 
     @Test
     public void backByViewport_withCellSpacing_countsTheSpacingThatComesWithEachCell() {
         final LayoutManager<View> manager = spacedCellManager();
-        final int anchorStart = FOURTH_CELL * (CELL_SIZE + CELL_SPACING);
+        final int anchorStart = FOURTH_CELL * SPACED_CELL_STEP;
 
         assertThat(manager.getCellStartAtIndex(FOURTH_CELL)).isEqualTo(anchorStart);
-        assertThat(
-                        manager.getPageCellIndexBackByViewport(
-                                A_WHOLE_VIEWPORT, FOURTH_CELL, anchorStart))
+        assertThat(viewportBack(manager, A_WHOLE_VIEWPORT, FOURTH_CELL, anchorStart))
+                .isEqualTo(SECOND_CELL);
+    }
+
+    @Test
+    public void backByViewport_withAPageThatOnlyFitsBecauseTheSpacingIsNotPartOfIt_takesIt() {
+        final LayoutManager<View> manager = spacedCellManager();
+        final int anchorStart = FOURTH_CELL * SPACED_CELL_STEP;
+
+        assertThat(viewportBack(manager, ROOM_FOR_TWO_SPACED_CELLS, FOURTH_CELL, anchorStart))
                 .isEqualTo(SECOND_CELL);
     }
 
@@ -617,7 +595,8 @@ public class LayoutManagerPagingMethodsTest {
         final LayoutManager<View> manager = unequalCellManager();
 
         assertThat(
-                        manager.getPageCellIndexBackByViewport(
+                        viewportBack(
+                                manager,
                                 A_WHOLE_VIEWPORT,
                                 FOURTH_CELL,
                                 UNEQUAL_CELLS_THAT_FILL_THE_VIEWPORT))
@@ -629,9 +608,7 @@ public class LayoutManagerPagingMethodsTest {
         final LayoutManager<View> manager = paddedManager();
         final int anchorStart = VIEWPORT_PADDING + FOURTH_CELL * CELL_SIZE;
 
-        assertThat(
-                        manager.getPageCellIndexBackByViewport(
-                                THE_VIEWPORT_INSIDE_THE_PADDING, FOURTH_CELL, anchorStart))
+        assertThat(viewportBack(manager, THE_VIEWPORT_INSIDE_THE_PADDING, FOURTH_CELL, anchorStart))
                 .isEqualTo(SECOND_CELL);
     }
 
@@ -643,9 +620,7 @@ public class LayoutManagerPagingMethodsTest {
         final int anchorStart = FOURTH_CELL * CELL_SIZE + A_REST_PART_WAY_THROUGH_A_CELL;
 
         assertThat(manager.getCellStartAtIndex(FOURTH_CELL)).isEqualTo(anchorStart);
-        assertThat(
-                        manager.getPageCellIndexBackByViewport(
-                                A_WHOLE_VIEWPORT, FOURTH_CELL, anchorStart))
+        assertThat(viewportBack(manager, A_WHOLE_VIEWPORT, FOURTH_CELL, anchorStart))
                 .isEqualTo(FIRST_CELL);
     }
 
@@ -653,9 +628,7 @@ public class LayoutManagerPagingMethodsTest {
     public void backByViewport_withNoPageRoom_advancesExactlyOneCell() {
         final LayoutManager<View> manager = equalCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexBackByViewport(
-                                NO_PAGE_ROOM, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
+        assertThat(viewportBack(manager, NO_PAGE_ROOM, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
                 .isEqualTo(THIRD_CELL);
     }
 
@@ -663,9 +636,7 @@ public class LayoutManagerPagingMethodsTest {
     public void backByViewport_withNegativePageRoom_advancesExactlyOneCell() {
         final LayoutManager<View> manager = equalCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexBackByViewport(
-                                NEGATIVE_PAGE_ROOM, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
+        assertThat(viewportBack(manager, NEGATIVE_PAGE_ROOM, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
                 .isEqualTo(THIRD_CELL);
     }
 
@@ -673,8 +644,7 @@ public class LayoutManagerPagingMethodsTest {
     public void backByViewport_atTheFirstCellWithoutCircularScroll_findsNoFurtherCell() {
         final LayoutManager<View> manager = equalCellManager();
 
-        final long index =
-                manager.getPageCellIndexBackByViewport(A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE);
+        final long index = viewportBack(manager, A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE);
 
         assertThat(index).isEqualTo(-ONE_CELL_PER_GESTURE);
         assertThat(manager.getCellStartAtIndex(index)).isEqualTo(NO_DISTANCE);
@@ -684,9 +654,7 @@ public class LayoutManagerPagingMethodsTest {
     public void backByViewport_withCircularScroll_walksPastTheAdapterStart() {
         final LayoutManager<View> manager = circularFourCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexBackByViewport(
-                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+        assertThat(viewportBack(manager, A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
                 .isEqualTo(-THREE_CELLS_PER_GESTURE);
     }
 
@@ -694,9 +662,7 @@ public class LayoutManagerPagingMethodsTest {
     public void backByViewport_inAVerticalList_walksTheSameCells() {
         final LayoutManager<View> manager = verticalEqualCellManager();
 
-        assertThat(
-                        manager.getPageCellIndexBackByViewport(
-                                A_WHOLE_VIEWPORT, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
+        assertThat(viewportBack(manager, A_WHOLE_VIEWPORT, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
                 .isEqualTo(FIRST_CELL);
     }
 
@@ -704,51 +670,58 @@ public class LayoutManagerPagingMethodsTest {
 
     @Test
     public void nextCellJoinsThePage_whenTheNextStartEqualsTheCurrentOne_hasNoFurtherCell() {
-        final LayoutManager<View> manager = equalCellManager();
-
         assertThat(
-                        manager.nextCellJoinsThePage(
-                                A_WHOLE_VIEWPORT, NO_DISTANCE, CELL_SIZE, CELL_SIZE))
+                        ViewportPageInterval.nextCellJoinsThePage(
+                                A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
+                                NO_DISTANCE,
+                                CELL_SIZE,
+                                CELL_SIZE))
                 .isFalse();
     }
 
     @Test
     public void nextCellJoinsThePage_whenTheNextStartIsOnTheWrongSide_hasNoFurtherCell() {
-        final LayoutManager<View> manager = equalCellManager();
-
         assertThat(
-                        manager.nextCellJoinsThePage(
-                                A_WHOLE_VIEWPORT, NO_DISTANCE, CELL_SIZE, NO_DISTANCE))
+                        ViewportPageInterval.nextCellJoinsThePage(
+                                A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
+                                NO_DISTANCE,
+                                CELL_SIZE,
+                                NO_DISTANCE))
                 .isFalse();
     }
 
     @Test
     public void nextCellJoinsThePage_withAFurtherCellThatFits_joinsThePage() {
-        final LayoutManager<View> manager = equalCellManager();
-
         assertThat(
-                        manager.nextCellJoinsThePage(
-                                A_WHOLE_VIEWPORT, NO_DISTANCE, CELL_SIZE, CELL_SIZE + CELL_SIZE))
+                        ViewportPageInterval.nextCellJoinsThePage(
+                                A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
+                                NO_DISTANCE,
+                                CELL_SIZE,
+                                CELL_SIZE + CELL_SIZE))
                 .isTrue();
     }
 
     @Test
     public void nextCellJoinsThePage_withAFurtherCellThatFitsExactly_joinsThePage() {
-        final LayoutManager<View> manager = equalCellManager();
-
         assertThat(
-                        manager.nextCellJoinsThePage(
-                                A_WHOLE_VIEWPORT, NO_DISTANCE, CELL_SIZE, A_WHOLE_VIEWPORT))
+                        ViewportPageInterval.nextCellJoinsThePage(
+                                A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
+                                NO_DISTANCE,
+                                CELL_SIZE,
+                                A_WHOLE_VIEWPORT))
                 .isTrue();
     }
 
     @Test
     public void nextCellJoinsThePage_withAFurtherCellThatDoesNotFit_doesNotJoinThePage() {
-        final LayoutManager<View> manager = equalCellManager();
-
         assertThat(
-                        manager.nextCellJoinsThePage(
+                        ViewportPageInterval.nextCellJoinsThePage(
                                 A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
                                 NO_DISTANCE,
                                 CELL_SIZE,
                                 A_WHOLE_VIEWPORT + ONE_PIXEL))
@@ -758,21 +731,22 @@ public class LayoutManagerPagingMethodsTest {
     @Test
     public void
             previousCellJoinsThePage_whenThePreviousStartEqualsTheCurrentOne_hasNoFurtherCell() {
-        final LayoutManager<View> manager = equalCellManager();
-
         assertThat(
-                        manager.previousCellJoinsThePage(
-                                A_WHOLE_VIEWPORT, A_WHOLE_VIEWPORT, CELL_SIZE, CELL_SIZE))
+                        ViewportPageInterval.previousCellJoinsThePage(
+                                A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
+                                A_WHOLE_VIEWPORT,
+                                CELL_SIZE,
+                                CELL_SIZE))
                 .isFalse();
     }
 
     @Test
     public void previousCellJoinsThePage_whenThePreviousStartIsOnTheWrongSide_hasNoFurtherCell() {
-        final LayoutManager<View> manager = equalCellManager();
-
         assertThat(
-                        manager.previousCellJoinsThePage(
+                        ViewportPageInterval.previousCellJoinsThePage(
                                 A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
                                 A_WHOLE_VIEWPORT,
                                 CELL_SIZE,
                                 CELL_SIZE + CELL_SIZE))
@@ -781,31 +755,37 @@ public class LayoutManagerPagingMethodsTest {
 
     @Test
     public void previousCellJoinsThePage_withAFurtherCellThatFits_joinsThePage() {
-        final LayoutManager<View> manager = equalCellManager();
-
         assertThat(
-                        manager.previousCellJoinsThePage(
-                                A_WHOLE_VIEWPORT, A_WHOLE_VIEWPORT, CELL_SIZE, CELL_SIZE / 2))
+                        ViewportPageInterval.previousCellJoinsThePage(
+                                A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
+                                A_WHOLE_VIEWPORT,
+                                CELL_SIZE,
+                                CELL_SIZE / 2))
                 .isTrue();
     }
 
     @Test
     public void previousCellJoinsThePage_withAFurtherCellThatFitsExactly_joinsThePage() {
-        final LayoutManager<View> manager = equalCellManager();
-
         assertThat(
-                        manager.previousCellJoinsThePage(
-                                A_WHOLE_VIEWPORT, A_WHOLE_VIEWPORT, CELL_SIZE, NO_DISTANCE))
+                        ViewportPageInterval.previousCellJoinsThePage(
+                                A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
+                                A_WHOLE_VIEWPORT,
+                                CELL_SIZE,
+                                NO_DISTANCE))
                 .isTrue();
     }
 
     @Test
     public void previousCellJoinsThePage_withAFurtherCellThatDoesNotFit_doesNotJoinThePage() {
-        final LayoutManager<View> manager = equalCellManager();
-
         assertThat(
-                        manager.previousCellJoinsThePage(
-                                A_WHOLE_VIEWPORT, A_WHOLE_VIEWPORT, CELL_SIZE, -ONE_PIXEL))
+                        ViewportPageInterval.previousCellJoinsThePage(
+                                A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
+                                A_WHOLE_VIEWPORT,
+                                CELL_SIZE,
+                                -ONE_PIXEL))
                 .isFalse();
     }
 
@@ -813,78 +793,94 @@ public class LayoutManagerPagingMethodsTest {
 
     @Test
     public void pageFits_withAPageExactlyTheMaximumSize_fits() {
-        final LayoutManager<View> manager = equalCellManager();
-
-        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, NO_DISTANCE, A_WHOLE_VIEWPORT)).isTrue();
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                A_WHOLE_VIEWPORT, NO_CELL_SPACING, NO_DISTANCE, A_WHOLE_VIEWPORT))
+                .isTrue();
     }
 
     @Test
     public void pageFits_withAPageOnePixelOverTheMaximum_doesNotFit() {
-        final LayoutManager<View> manager = equalCellManager();
-
-        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, NO_DISTANCE, A_WHOLE_VIEWPORT + ONE_PIXEL))
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
+                                NO_DISTANCE,
+                                A_WHOLE_VIEWPORT + ONE_PIXEL))
                 .isFalse();
     }
 
     @Test
     public void pageFits_withAPageOnePixelUnderTheMaximum_fits() {
-        final LayoutManager<View> manager = equalCellManager();
-
-        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, NO_DISTANCE, A_WHOLE_VIEWPORT - ONE_PIXEL))
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
+                                NO_DISTANCE,
+                                A_WHOLE_VIEWPORT - ONE_PIXEL))
                 .isTrue();
     }
 
     @Test
     public void pageFits_measuringBackwardsAtTheBoundary_fits() {
-        final LayoutManager<View> manager = equalCellManager();
-
-        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, -A_WHOLE_VIEWPORT, NO_DISTANCE)).isTrue();
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                A_WHOLE_VIEWPORT, NO_CELL_SPACING, -A_WHOLE_VIEWPORT, NO_DISTANCE))
+                .isTrue();
     }
 
     @Test
     public void pageFits_measuringBackwardsOnePixelOverTheMaximum_doesNotFit() {
-        final LayoutManager<View> manager = equalCellManager();
-
-        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, -A_WHOLE_VIEWPORT - ONE_PIXEL, NO_DISTANCE))
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                A_WHOLE_VIEWPORT,
+                                NO_CELL_SPACING,
+                                -A_WHOLE_VIEWPORT - ONE_PIXEL,
+                                NO_DISTANCE))
                 .isFalse();
     }
 
     @Test
     public void pageFits_withANegativePageSize_fits() {
-        final LayoutManager<View> manager = equalCellManager();
-
-        assertThat(manager.pageFits(NO_PAGE_ROOM, A_WHOLE_VIEWPORT, NO_DISTANCE)).isTrue();
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                NO_PAGE_ROOM, NO_CELL_SPACING, A_WHOLE_VIEWPORT, NO_DISTANCE))
+                .isTrue();
     }
 
     @Test
     public void pageFits_withANegativeMaximumPageSize_rejectsAPageOfNoSize() {
-        final LayoutManager<View> manager = equalCellManager();
-
-        assertThat(manager.pageFits(-ONE_PIXEL, NO_DISTANCE, NO_DISTANCE)).isFalse();
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                -ONE_PIXEL, NO_CELL_SPACING, NO_DISTANCE, NO_DISTANCE))
+                .isFalse();
     }
 
     @Test
     public void pageFits_withANegativeMaximumPageSize_stillFitsAPageThatMeasuresLessThanIt() {
-        final LayoutManager<View> manager = equalCellManager();
-
-        assertThat(manager.pageFits(NEGATIVE_PAGE_ROOM, A_WHOLE_VIEWPORT, NO_DISTANCE)).isTrue();
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                NEGATIVE_PAGE_ROOM, NO_CELL_SPACING, A_WHOLE_VIEWPORT, NO_DISTANCE))
+                .isTrue();
     }
 
     @Test
     public void pageFits_withCellSpacing_takesTheSpacingOffTheEndOfThePage() {
-        final LayoutManager<View> manager = spacedCellManager();
-
-        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, NO_DISTANCE, A_WHOLE_VIEWPORT + CELL_SPACING))
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                A_WHOLE_VIEWPORT,
+                                CELL_SPACING,
+                                NO_DISTANCE,
+                                A_WHOLE_VIEWPORT + CELL_SPACING))
                 .isTrue();
     }
 
     @Test
     public void pageFits_withCellSpacing_rejectsThePixelPastTheSpacing() {
-        final LayoutManager<View> manager = spacedCellManager();
-
         assertThat(
-                        manager.pageFits(
+                        ViewportPageInterval.pageFits(
                                 A_WHOLE_VIEWPORT,
+                                CELL_SPACING,
                                 NO_DISTANCE,
                                 A_WHOLE_VIEWPORT + CELL_SPACING + ONE_PIXEL))
                 .isFalse();
@@ -892,21 +888,27 @@ public class LayoutManagerPagingMethodsTest {
 
     @Test
     public void pageFits_withCellSpacingWiderThanTheGap_measuresANegativePageAndFits() {
-        final LayoutManager<View> manager = spacedCellManager();
-
-        assertThat(manager.pageFits(NO_PAGE_ROOM, NO_DISTANCE, CELL_SPACING / 2)).isTrue();
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                NO_PAGE_ROOM, CELL_SPACING, NO_DISTANCE, CELL_SPACING / 2))
+                .isTrue();
     }
 
     @Test
     public void pageFits_acrossTheWholeDrawableRange_measuresItWithoutOverflowing() {
-        final LayoutManager<View> manager = equalCellManager();
         final long wholeRange = (long) THE_DRAWABLE_LIMIT + THE_DRAWABLE_LIMIT;
 
-        assertThat(manager.pageFits(Integer.MAX_VALUE, -THE_DRAWABLE_LIMIT, THE_DRAWABLE_LIMIT))
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                Integer.MAX_VALUE,
+                                NO_CELL_SPACING,
+                                -THE_DRAWABLE_LIMIT,
+                                THE_DRAWABLE_LIMIT))
                 .isTrue();
         assertThat(
-                        manager.pageFits(
+                        ViewportPageInterval.pageFits(
                                 (int) wholeRange - ONE_PIXEL,
+                                NO_CELL_SPACING,
                                 -THE_DRAWABLE_LIMIT,
                                 THE_DRAWABLE_LIMIT))
                 .isFalse();
@@ -914,17 +916,23 @@ public class LayoutManagerPagingMethodsTest {
 
     @Test
     public void pageFits_withStartsBeyondTheIntRange_doesNotWrapToASmallPage() {
-        final LayoutManager<View> manager = equalCellManager();
-
-        assertThat(manager.pageFits(Integer.MAX_VALUE, -BEYOND_THE_INT_RANGE, BEYOND_THE_INT_RANGE))
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                Integer.MAX_VALUE,
+                                NO_CELL_SPACING,
+                                -BEYOND_THE_INT_RANGE,
+                                BEYOND_THE_INT_RANGE))
                 .isFalse();
     }
 
     @Test
     public void pageFits_withABackwardsPageBeyondTheIntRange_doesNotWrapToALargePage() {
-        final LayoutManager<View> manager = equalCellManager();
-
-        assertThat(manager.pageFits(NO_PAGE_ROOM, BEYOND_THE_INT_RANGE, -BEYOND_THE_INT_RANGE))
+        assertThat(
+                        ViewportPageInterval.pageFits(
+                                NO_PAGE_ROOM,
+                                NO_CELL_SPACING,
+                                BEYOND_THE_INT_RANGE,
+                                -BEYOND_THE_INT_RANGE))
                 .isTrue();
     }
 
@@ -1297,13 +1305,51 @@ public class LayoutManagerPagingMethodsTest {
     // ------------------------------------------------------------------------- harnesses
 
     private static long forward(final LayoutManager<View> manager, final int viewPagerInterval) {
-        return manager.getPageCellIndexForward(
-                viewPagerInterval, A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE);
+        final PageIntervalInterface<View> pageInterval =
+                PageIntervalSelector.getPageIntervalInterface(viewPagerInterval);
+        return pageInterval.getPageCellIndexForward(
+                manager, A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE);
     }
 
     private static long back(final LayoutManager<View> manager, final int viewPagerInterval) {
-        return manager.getPageCellIndexBack(
-                viewPagerInterval, A_WHOLE_VIEWPORT, FOURTH_CELL, FOURTH_CELL * CELL_SIZE);
+        final PageIntervalInterface<View> pageInterval =
+                PageIntervalSelector.getPageIntervalInterface(viewPagerInterval);
+        return pageInterval.getPageCellIndexBack(
+                manager, A_WHOLE_VIEWPORT, FOURTH_CELL, FOURTH_CELL * CELL_SIZE);
+    }
+
+    private static long viewportForward(
+            final LayoutManager<View> manager,
+            final int maximumPageSize,
+            final int anchorIndex,
+            final int anchorStart) {
+        final ViewportPageInterval<View> pageInterval = new ViewportPageInterval<View>();
+        return pageInterval.getPageCellIndexForward(
+                manager, maximumPageSize, anchorIndex, anchorStart);
+    }
+
+    private static long viewportBack(
+            final LayoutManager<View> manager,
+            final int maximumPageSize,
+            final int anchorIndex,
+            final int anchorStart) {
+        final ViewportPageInterval<View> pageInterval = new ViewportPageInterval<View>();
+        return pageInterval.getPageCellIndexBack(
+                manager, maximumPageSize, anchorIndex, anchorStart);
+    }
+
+    private static long forwardByCellCount(final int viewPagerInterval, final int anchorIndex) {
+        final CellCountPageInterval<View> pageInterval =
+                new CellCountPageInterval<View>(viewPagerInterval);
+        return pageInterval.getPageCellIndexForward(
+                NO_LAYOUT_MANAGER, NO_PAGE_ROOM, anchorIndex, NO_DISTANCE);
+    }
+
+    private static long backByCellCount(final int viewPagerInterval, final int anchorIndex) {
+        final CellCountPageInterval<View> pageInterval =
+                new CellCountPageInterval<View>(viewPagerInterval);
+        return pageInterval.getPageCellIndexBack(
+                NO_LAYOUT_MANAGER, NO_PAGE_ROOM, anchorIndex, NO_DISTANCE);
     }
 
     private static int intervalAfterAttributeParsing(final int viewPagerInterval) {

--- a/library/src/test/java/mobi/parchment/widget/adapterview/LayoutManagerPagingMethodsTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/LayoutManagerPagingMethodsTest.java
@@ -83,6 +83,17 @@ public class LayoutManagerPagingMethodsTest {
     private static final int THE_CENTRE_SNAP_POSITION = (THREE_CELL_VIEWPORT - CELL_SIZE) / 2;
     private static final int THE_END_SNAP_POSITION = THREE_CELL_VIEWPORT - CELL_SIZE;
 
+    private static final int A_DISTANCE_NOTHING_WOULD_MEASURE = 4321;
+    private static final int A_SECOND_DISTANCE_NOTHING_WOULD_MEASURE = 8765;
+
+    /** A cell size that makes two cells plus the padding fill the viewport exactly. */
+    private static final int PADDING_FIT_CELL_SIZE = THE_VIEWPORT_INSIDE_THE_PADDING / 2;
+
+    /** A cell size that puts a cell start between the snapped and the unsnapped page limit. */
+    private static final int OFF_SNAP_CELL_SIZE = 110;
+
+    private static final int CELLS_THAT_FIT_FROM_AN_OFF_SNAP_ANCHOR = 2;
+
     private static final int[] UNEQUAL_CELL_SIZES = {
         100, 50, 150, 100, 100, 100, 100, 100, 100, 100
     };
@@ -434,16 +445,6 @@ public class LayoutManagerPagingMethodsTest {
     }
 
     @Test
-    public void forwardByViewport_withoutCellSpacing_fitsEveryCellTheViewportHolds() {
-        final LayoutManager<View> manager = equalCellManager();
-
-        assertThat(
-                        manager.getPageCellIndexForwardByViewport(
-                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
-                .isEqualTo(FOURTH_CELL);
-    }
-
-    @Test
     public void forwardByViewport_withCellSpacing_countsTheSpacingThatComesWithEachCell() {
         final LayoutManager<View> manager = spacedCellManager();
 
@@ -519,6 +520,20 @@ public class LayoutManagerPagingMethodsTest {
 
         assertThat(index).isEqualTo(ONE_PAST_TEN_CELLS);
         assertThat(manager.getCellStartAtIndex(index)).isEqualTo(lastCellStart);
+    }
+
+    @Test
+    public void forwardByViewport_walkingIntoTheAdapterEnd_stopsWhenTheCapFreezesTheCellStarts() {
+        final LayoutManager<View> manager = equalCellManager();
+        final int anchorIndex = LAST_OF_TEN_CELLS - TWO_CELLS_PER_GESTURE;
+        final int anchorStart = anchorIndex * CELL_SIZE;
+
+        final long index =
+                manager.getPageCellIndexForwardByViewport(
+                        A_WHOLE_VIEWPORT, anchorIndex, anchorStart);
+
+        assertThat(index).isEqualTo(LAST_OF_TEN_CELLS);
+        assertThat(manager.getCellStartAtIndex(index)).isEqualTo(LAST_OF_TEN_CELLS * CELL_SIZE);
     }
 
     @Test
@@ -887,7 +902,6 @@ public class LayoutManagerPagingMethodsTest {
         final LayoutManager<View> manager = equalCellManager();
         final long wholeRange = (long) THE_DRAWABLE_LIMIT + THE_DRAWABLE_LIMIT;
 
-        assertThat(wholeRange).isLessThanOrEqualTo(Integer.MAX_VALUE);
         assertThat(manager.pageFits(Integer.MAX_VALUE, -THE_DRAWABLE_LIMIT, THE_DRAWABLE_LIMIT))
                 .isTrue();
         assertThat(
@@ -931,7 +945,7 @@ public class LayoutManagerPagingMethodsTest {
     }
 
     @Test
-    public void getCellStartAtIndex_pastTheDrawnCells_extrapolatesFromTheLastDrawnCell() {
+    public void getCellStartAtIndex_pastTheDrawnCells_continuesTheCellRun() {
         final LayoutManager<View> manager = equalCellManager();
         final int fifthCell = FOURTH_CELL + ONE_CELL_PER_GESTURE;
 
@@ -939,7 +953,7 @@ public class LayoutManagerPagingMethodsTest {
     }
 
     @Test
-    public void getCellStartAtIndex_atTheLastAdapterCell_extrapolatesToItsStart() {
+    public void getCellStartAtIndex_atTheLastAdapterCell_isThatCellsStart() {
         final LayoutManager<View> manager = equalCellManager();
 
         assertThat(manager.getCellStartAtIndex(LAST_OF_TEN_CELLS))
@@ -1045,7 +1059,7 @@ public class LayoutManagerPagingMethodsTest {
     }
 
     @Test
-    public void getCellStartExtrapolatedBeforeFirst_stepsBackByTheFirstCellSizeAndSpacing() {
+    public void getCellStartExtrapolatedBeforeFirst_stepsBackByTheFirstCellSize() {
         final LayoutManager<View> manager = circularEqualCellManager();
 
         assertThat(manager.getCellStartExtrapolatedBeforeFirst(-ONE_CELL_PER_GESTURE))
@@ -1053,11 +1067,36 @@ public class LayoutManagerPagingMethodsTest {
     }
 
     @Test
-    public void getCellStartExtrapolatedAfterLast_stepsOnByTheLastCellSizeAndSpacing() {
+    public void getCellStartExtrapolatedBeforeFirst_withCellSpacing_stepsBackBySizeAndSpacing() {
+        final LayoutManager<View> manager = circularSpacedCellManager();
+
+        assertThat(manager.getCellStartExtrapolatedBeforeFirst(-ONE_CELL_PER_GESTURE))
+                .isEqualTo(-(CELL_SIZE + CELL_SPACING));
+    }
+
+    @Test
+    public void
+            getCellStartAtIndex_withCellSpacingAndCircularScroll_extrapolatesBackBySizeAndSpacing() {
+        final LayoutManager<View> manager = circularSpacedCellManager();
+
+        assertThat(manager.getCellStartAtIndex(-MORE_CELLS_THAN_THE_ADAPTER_HAS))
+                .isEqualTo(-MORE_CELLS_THAN_THE_ADAPTER_HAS * (CELL_SIZE + CELL_SPACING));
+    }
+
+    @Test
+    public void getCellStartExtrapolatedAfterLast_stepsOnByTheLastCellSize() {
         final LayoutManager<View> manager = circularEqualCellManager();
 
         assertThat(manager.getCellStartExtrapolatedAfterLast(MORE_CELLS_THAN_THE_ADAPTER_HAS))
                 .isEqualTo(MORE_CELLS_THAN_THE_ADAPTER_HAS * CELL_SIZE);
+    }
+
+    @Test
+    public void getCellStartExtrapolatedAfterLast_withCellSpacing_stepsOnBySizeAndSpacing() {
+        final LayoutManager<View> manager = circularSpacedCellManager();
+
+        assertThat(manager.getCellStartExtrapolatedAfterLast(MORE_CELLS_THAN_THE_ADAPTER_HAS))
+                .isEqualTo(MORE_CELLS_THAN_THE_ADAPTER_HAS * (CELL_SIZE + CELL_SPACING));
     }
 
     // ---------------------------------------------------------------- getSnapDisplacement
@@ -1116,7 +1155,7 @@ public class LayoutManagerPagingMethodsTest {
     }
 
     @Test
-    public void getSnapDisplacement_forACellOfZeroSizedViews_isZeroRatherThanACrash() {
+    public void getSnapDisplacement_forAGroupOfZeroSizedViews_findsNoRepresentativeAndIsZero() {
         final LayoutManager<Group> manager = groupManager();
         final Group zeroSizedGroup = new Group(HORIZONTAL);
         zeroSizedGroup.addView(new View(ApplicationProvider.getApplicationContext()));
@@ -1131,11 +1170,14 @@ public class LayoutManagerPagingMethodsTest {
     @Test
     public void setViewPageDistances_whenTheViewIsNotAViewPager_leavesTheDistancesAlone() {
         final LayoutManager<View> manager = notAViewPagerManager();
+        manager.mViewPageDistanceForward = A_DISTANCE_NOTHING_WOULD_MEASURE;
+        manager.mViewPageDistanceBack = A_SECOND_DISTANCE_NOTHING_WOULD_MEASURE;
 
         manager.setViewPageDistances(A_WHOLE_VIEWPORT);
 
-        assertThat(manager.mViewPageDistanceForward).isEqualTo(NO_DISTANCE);
-        assertThat(manager.mViewPageDistanceBack).isEqualTo(NO_DISTANCE);
+        assertThat(manager.mViewPageDistanceForward).isEqualTo(A_DISTANCE_NOTHING_WOULD_MEASURE);
+        assertThat(manager.mViewPageDistanceBack)
+                .isEqualTo(A_SECOND_DISTANCE_NOTHING_WOULD_MEASURE);
     }
 
     @Test
@@ -1205,6 +1247,35 @@ public class LayoutManagerPagingMethodsTest {
     }
 
     @Test
+    public void setViewPageDistances_withViewportPadding_startsTheViewportAtThePaddingNotAtZero() {
+        final LayoutManager<View> manager = paddedCellsThatFillInsideThePaddingManager();
+
+        assertThat(manager.getCellStartAtIndex(FIRST_CELL)).isEqualTo(VIEWPORT_PADDING);
+
+        manager.setViewPageDistances(THE_VIEWPORT_INSIDE_THE_PADDING);
+
+        assertThat(manager.mViewPageDistanceForward)
+                .isEqualTo(TWO_CELLS_PER_GESTURE * PADDING_FIT_CELL_SIZE);
+    }
+
+    @Test
+    public void setViewPageDistances_fromAnAnchorPartWayThroughACell_countsFromWhereItSitsNow() {
+        final PagingHarness harness = offSnapCellHarness();
+        harness.dragBy(A_REST_PART_WAY_THROUGH_A_CELL);
+        final LayoutManager<View> manager = harness.manager();
+
+        assertThat(manager.getCellStartAtIndex(FIRST_CELL))
+                .isEqualTo(A_REST_PART_WAY_THROUGH_A_CELL);
+
+        manager.setViewPageDistances(A_WHOLE_VIEWPORT);
+
+        assertThat(manager.mViewPageDistanceForward)
+                .isEqualTo(
+                        CELLS_THAT_FIT_FROM_AN_OFF_SNAP_ANCHOR * OFF_SNAP_CELL_SIZE
+                                + A_REST_PART_WAY_THROUGH_A_CELL);
+    }
+
+    @Test
     public void setViewPageDistances_withASizeThePaddingHasEatenAway_stillAdvancesOneCell() {
         final LayoutManager<View> manager = equalCellManager();
 
@@ -1215,11 +1286,12 @@ public class LayoutManagerPagingMethodsTest {
     }
 
     @Test
-    public void paddingLargerThanTheViewport_leavesTheLayoutANegativeSizeToPageIn() {
+    public void paddingLargerThanTheViewport_leavesANegativePageRoomAndStillAdvancesOneCell() {
         final LayoutManager<View> manager = paddingLargerThanTheViewportManager();
         final int paddingTotal = manager.getStartSizePadding() + manager.getEndSizePadding();
 
         assertThat(paddingTotal).isGreaterThan(SMALL_VIEWPORT);
+        assertThat(manager.mViewPageDistanceForward).isEqualTo(CELL_SIZE);
     }
 
     // ------------------------------------------------------------------------- harnesses
@@ -1328,6 +1400,41 @@ public class LayoutManagerPagingMethodsTest {
                         CIRCULAR,
                         SnapPosition.start)
                 .manager();
+    }
+
+    private static LayoutManager<View> circularSpacedCellManager() {
+        return new PagingHarness(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(CELL_SIZE, TEN_CELLS),
+                        CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        CIRCULAR,
+                        SnapPosition.start)
+                .manager();
+    }
+
+    private static LayoutManager<View> paddedCellsThatFillInsideThePaddingManager() {
+        return new PagingHarness(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(PADDING_FIT_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start,
+                        VIEWPORT_PADDING,
+                        HORIZONTAL,
+                        IS_A_VIEW_PAGER)
+                .manager();
+    }
+
+    private static PagingHarness offSnapCellHarness() {
+        return new PagingHarness(
+                THREE_CELL_VIEWPORT,
+                equalSizes(OFF_SNAP_CELL_SIZE, TEN_CELLS),
+                NO_CELL_SPACING,
+                VIEWPORT_PAGING,
+                NOT_CIRCULAR,
+                SnapPosition.start);
     }
 
     private static LayoutManager<View> circularFourCellManager() {

--- a/library/src/test/java/mobi/parchment/widget/adapterview/LayoutManagerPagingMethodsTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/LayoutManagerPagingMethodsTest.java
@@ -1,0 +1,1592 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import androidx.test.core.app.ApplicationProvider;
+import java.util.ArrayList;
+import java.util.List;
+import mobi.parchment.widget.adapterview.gridview.GridLayoutManager;
+import mobi.parchment.widget.adapterview.gridview.GridLayoutManagerAttributes;
+import mobi.parchment.widget.adapterview.gridview.Group;
+import mobi.parchment.widget.adapterview.listview.ListLayoutManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Exercises each method the ViewPager page measurement is built from on its own. End to end paging
+ * lives in ViewPagerTest; this pins every method's own contract, including states a whole gesture
+ * cannot easily be driven into.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class LayoutManagerPagingMethodsTest {
+
+    private static final int THREE_CELL_VIEWPORT = 300;
+    private static final int SMALL_VIEWPORT = 100;
+    private static final int CELL_SIZE = 100;
+    private static final int LARGE_CELL_SIZE = 250;
+    private static final int CELL_SPACING = 10;
+    private static final int NO_CELL_SPACING = 0;
+    private static final int TEN_CELLS = 10;
+    private static final int FOUR_CELLS = 4;
+    private static final int VIEWPORT_PAGING = 0;
+    private static final int ONE_CELL_PER_GESTURE = 1;
+    private static final int TWO_CELLS_PER_GESTURE = 2;
+    private static final int THREE_CELLS_PER_GESTURE = 3;
+    private static final int MORE_CELLS_THAN_THE_ADAPTER_HAS = 50;
+    private static final int A_NEGATIVE_INTERVAL = -2;
+    private static final boolean CIRCULAR = true;
+    private static final boolean NOT_CIRCULAR = false;
+    private static final boolean HORIZONTAL = false;
+    private static final boolean VERTICAL = true;
+    private static final boolean IS_A_VIEW_PAGER = true;
+    private static final boolean IS_NOT_A_VIEW_PAGER = false;
+    private static final boolean NOT_SNAP_TO_POSITION = false;
+    private static final boolean NOT_SELECT_ON_SNAP = false;
+    private static final boolean NOT_SELECT_WHILE_SCROLLING = false;
+    private static final boolean NO_GRAVITY_EDGE = false;
+    private static final int NO_VIEWPORT_PADDING = 0;
+    private static final int VIEWPORT_PADDING = 20;
+    private static final int NO_DISTANCE = 0;
+    private static final int NUMBER_OF_VIEWS_PER_CELL = 2;
+
+    private static final int FIRST_CELL = 0;
+    private static final int SECOND_CELL = 1;
+    private static final int THIRD_CELL = 2;
+    private static final int FOURTH_CELL = 3;
+    private static final int LAST_OF_TEN_CELLS = TEN_CELLS - 1;
+    private static final int ONE_PAST_TEN_CELLS = TEN_CELLS;
+
+    /** The room a page has when a start snap puts the anchor at an unpadded viewport's start. */
+    private static final int A_WHOLE_VIEWPORT = THREE_CELL_VIEWPORT;
+
+    private static final int ONE_PIXEL = 1;
+    private static final int A_PAGE_THAT_MISSES_BY_A_PIXEL = A_WHOLE_VIEWPORT - ONE_PIXEL;
+    private static final int NO_PAGE_ROOM = 0;
+    private static final int NEGATIVE_PAGE_ROOM = -100;
+    private static final int A_REST_PART_WAY_THROUGH_A_CELL = -50;
+    private static final int THE_VIEWPORT_INSIDE_THE_PADDING =
+            THREE_CELL_VIEWPORT - VIEWPORT_PADDING - VIEWPORT_PADDING;
+
+    /** LayoutManager clamps an extrapolated cell start to half the int range either way. */
+    private static final int THE_DRAWABLE_LIMIT = Integer.MAX_VALUE / 2;
+
+    private static final int THE_CENTRE_SNAP_POSITION = (THREE_CELL_VIEWPORT - CELL_SIZE) / 2;
+    private static final int THE_END_SNAP_POSITION = THREE_CELL_VIEWPORT - CELL_SIZE;
+
+    private static final int[] UNEQUAL_CELL_SIZES = {
+        100, 50, 150, 100, 100, 100, 100, 100, 100, 100
+    };
+    private static final int UNEQUAL_CELLS_THAT_FILL_THE_VIEWPORT = 300;
+
+    private static final long BEYOND_THE_INT_RANGE = 3000000000L;
+
+    // ------------------------------------------------------------------- pagesByCellCount
+
+    @Test
+    public void pagesByCellCount_withAnIntervalOfZero_choosesTheViewportAlgorithm() {
+        assertThat(LayoutManager.pagesByCellCount(VIEWPORT_PAGING)).isFalse();
+    }
+
+    @Test
+    public void pagesByCellCount_withAnIntervalOfOne_choosesTheCellCountAlgorithm() {
+        assertThat(LayoutManager.pagesByCellCount(ONE_CELL_PER_GESTURE)).isTrue();
+    }
+
+    @Test
+    public void pagesByCellCount_withAnIntervalOfTwo_choosesTheCellCountAlgorithm() {
+        assertThat(LayoutManager.pagesByCellCount(TWO_CELLS_PER_GESTURE)).isTrue();
+    }
+
+    @Test
+    public void pagesByCellCount_withAnIntervalLargerThanTheAdapter_choosesTheCellCountAlgorithm() {
+        assertThat(LayoutManager.pagesByCellCount(MORE_CELLS_THAN_THE_ADAPTER_HAS)).isTrue();
+    }
+
+    @Test
+    public void pagesByCellCount_withTheLargestInterval_choosesTheCellCountAlgorithm() {
+        assertThat(LayoutManager.pagesByCellCount(Integer.MAX_VALUE)).isTrue();
+    }
+
+    @Test
+    public void pagesByCellCount_withANegativeInterval_choosesTheCellCountAlgorithm() {
+        assertThat(LayoutManager.pagesByCellCount(A_NEGATIVE_INTERVAL)).isTrue();
+    }
+
+    @Test
+    public void pagesByCellCount_withTheMostNegativeInterval_choosesTheCellCountAlgorithm() {
+        assertThat(LayoutManager.pagesByCellCount(Integer.MIN_VALUE)).isTrue();
+    }
+
+    @Test
+    public void anAttributeIntervalOfZero_reachesTheDispatchUnchanged() {
+        assertThat(intervalAfterAttributeParsing(VIEWPORT_PAGING)).isEqualTo(VIEWPORT_PAGING);
+    }
+
+    @Test
+    public void anAttributeIntervalOfOne_reachesTheDispatchUnchanged() {
+        assertThat(intervalAfterAttributeParsing(ONE_CELL_PER_GESTURE))
+                .isEqualTo(ONE_CELL_PER_GESTURE);
+    }
+
+    @Test
+    public void theLargestAttributeInterval_reachesTheDispatchUnchanged() {
+        assertThat(intervalAfterAttributeParsing(Integer.MAX_VALUE)).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void aNegativeAttributeInterval_isClampedToViewportPagingBeforeTheDispatchSeesIt() {
+        assertThat(intervalAfterAttributeParsing(A_NEGATIVE_INTERVAL)).isEqualTo(VIEWPORT_PAGING);
+    }
+
+    @Test
+    public void
+            theMostNegativeAttributeInterval_isClampedToViewportPagingBeforeTheDispatchSeesIt() {
+        assertThat(intervalAfterAttributeParsing(Integer.MIN_VALUE)).isEqualTo(VIEWPORT_PAGING);
+    }
+
+    // ---------------------------------------------------- getPageCellIndexForward dispatch
+
+    @Test
+    public void getPageCellIndexForward_withAnIntervalOfZero_runsTheViewportWalk() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(forward(manager, VIEWPORT_PAGING)).isEqualTo(FOURTH_CELL);
+    }
+
+    @Test
+    public void getPageCellIndexForward_withAnIntervalOfOne_countsOneCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(forward(manager, ONE_CELL_PER_GESTURE)).isEqualTo(SECOND_CELL);
+    }
+
+    @Test
+    public void getPageCellIndexForward_withAnIntervalOfTwo_countsTwoCells() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(forward(manager, TWO_CELLS_PER_GESTURE)).isEqualTo(THIRD_CELL);
+    }
+
+    @Test
+    public void getPageCellIndexForward_withALargeInterval_countsThatManyCells() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(forward(manager, MORE_CELLS_THAN_THE_ADAPTER_HAS))
+                .isEqualTo(MORE_CELLS_THAN_THE_ADAPTER_HAS);
+    }
+
+    @Test
+    public void getPageCellIndexForward_withANegativeInterval_countsBackwards() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(forward(manager, A_NEGATIVE_INTERVAL)).isEqualTo(A_NEGATIVE_INTERVAL);
+    }
+
+    @Test
+    public void getPageCellIndexForward_atTheIntervalThatSelectsEachMode_switchesAlgorithms() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(forward(manager, VIEWPORT_PAGING)).isEqualTo(FOURTH_CELL);
+        assertThat(forward(manager, VIEWPORT_PAGING + ONE_CELL_PER_GESTURE)).isEqualTo(SECOND_CELL);
+    }
+
+    // ------------------------------------------------------- getPageCellIndexBack dispatch
+
+    @Test
+    public void getPageCellIndexBack_withAnIntervalOfZero_runsTheViewportWalk() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(back(manager, VIEWPORT_PAGING)).isEqualTo(FIRST_CELL);
+    }
+
+    @Test
+    public void getPageCellIndexBack_withAnIntervalOfOne_countsOneCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(back(manager, ONE_CELL_PER_GESTURE)).isEqualTo(THIRD_CELL);
+    }
+
+    @Test
+    public void getPageCellIndexBack_withAnIntervalOfTwo_countsTwoCells() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(back(manager, TWO_CELLS_PER_GESTURE)).isEqualTo(SECOND_CELL);
+    }
+
+    @Test
+    public void getPageCellIndexBack_withALargeInterval_countsThatManyCells() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(back(manager, MORE_CELLS_THAN_THE_ADAPTER_HAS))
+                .isEqualTo(FOURTH_CELL - MORE_CELLS_THAN_THE_ADAPTER_HAS);
+    }
+
+    @Test
+    public void getPageCellIndexBack_withANegativeInterval_countsForwards() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(back(manager, A_NEGATIVE_INTERVAL)).isEqualTo(FOURTH_CELL - A_NEGATIVE_INTERVAL);
+    }
+
+    @Test
+    public void getPageCellIndexBack_atTheIntervalThatSelectsEachMode_switchesAlgorithms() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(back(manager, VIEWPORT_PAGING)).isEqualTo(FIRST_CELL);
+        assertThat(back(manager, VIEWPORT_PAGING + ONE_CELL_PER_GESTURE)).isEqualTo(THIRD_CELL);
+    }
+
+    // --------------------------------------------------------------- the cell count counts
+
+    @Test
+    public void forwardByCellCount_fromTheFirstCell_addsTheInterval() {
+        assertThat(
+                        LayoutManager.getPageCellIndexForwardByCellCount(
+                                ONE_CELL_PER_GESTURE, FIRST_CELL))
+                .isEqualTo(SECOND_CELL);
+    }
+
+    @Test
+    public void forwardByCellCount_fromACellInTheMiddle_addsTheInterval() {
+        assertThat(
+                        LayoutManager.getPageCellIndexForwardByCellCount(
+                                THREE_CELLS_PER_GESTURE, FOURTH_CELL))
+                .isEqualTo(FOURTH_CELL + THREE_CELLS_PER_GESTURE);
+    }
+
+    @Test
+    public void forwardByCellCount_fromTheLastCell_namesACellBeyondTheAdapterEnd() {
+        assertThat(
+                        LayoutManager.getPageCellIndexForwardByCellCount(
+                                ONE_CELL_PER_GESTURE, LAST_OF_TEN_CELLS))
+                .isEqualTo(ONE_PAST_TEN_CELLS);
+    }
+
+    @Test
+    public void forwardByCellCount_withAnIntervalLargerThanTheAdapter_namesACellFarBeyondTheEnd() {
+        assertThat(
+                        LayoutManager.getPageCellIndexForwardByCellCount(
+                                MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL))
+                .isEqualTo(MORE_CELLS_THAN_THE_ADAPTER_HAS);
+    }
+
+    @Test
+    public void forwardByCellCount_withTheLargestInterval_doesNotWrapToANegativeIndex() {
+        final long index =
+                LayoutManager.getPageCellIndexForwardByCellCount(Integer.MAX_VALUE, FOURTH_CELL);
+
+        assertThat(index).isEqualTo((long) FOURTH_CELL + Integer.MAX_VALUE);
+        assertThat(index).isGreaterThan(Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void forwardByCellCount_withTheMostNegativeInterval_doesNotWrapToAPositiveIndex() {
+        final long index =
+                LayoutManager.getPageCellIndexForwardByCellCount(Integer.MIN_VALUE, FOURTH_CELL);
+
+        assertThat(index).isEqualTo((long) FOURTH_CELL + Integer.MIN_VALUE);
+        assertThat(index).isLessThan(0L);
+    }
+
+    @Test
+    public void backByCellCount_fromTheFirstCell_namesACellBeforeTheAdapterStart() {
+        assertThat(LayoutManager.getPageCellIndexBackByCellCount(ONE_CELL_PER_GESTURE, FIRST_CELL))
+                .isEqualTo(-ONE_CELL_PER_GESTURE);
+    }
+
+    @Test
+    public void backByCellCount_fromACellInTheMiddle_subtractsTheInterval() {
+        assertThat(
+                        LayoutManager.getPageCellIndexBackByCellCount(
+                                THREE_CELLS_PER_GESTURE, FOURTH_CELL))
+                .isEqualTo(FOURTH_CELL - THREE_CELLS_PER_GESTURE);
+    }
+
+    @Test
+    public void backByCellCount_fromTheLastCell_subtractsTheInterval() {
+        assertThat(
+                        LayoutManager.getPageCellIndexBackByCellCount(
+                                ONE_CELL_PER_GESTURE, LAST_OF_TEN_CELLS))
+                .isEqualTo(LAST_OF_TEN_CELLS - ONE_CELL_PER_GESTURE);
+    }
+
+    @Test
+    public void backByCellCount_withTheLargestInterval_doesNotWrapToAPositiveIndex() {
+        final long index =
+                LayoutManager.getPageCellIndexBackByCellCount(Integer.MAX_VALUE, FOURTH_CELL);
+
+        assertThat(index).isEqualTo((long) FOURTH_CELL - Integer.MAX_VALUE);
+        assertThat(index).isLessThan(0L);
+    }
+
+    @Test
+    public void backByCellCount_withTheMostNegativeInterval_doesNotWrapToANegativeIndex() {
+        final long index =
+                LayoutManager.getPageCellIndexBackByCellCount(Integer.MIN_VALUE, FOURTH_CELL);
+
+        assertThat(index).isEqualTo((long) FOURTH_CELL - Integer.MIN_VALUE);
+        assertThat(index).isGreaterThan(Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void cellCountPaging_pastTheAdapterEndWithoutCircularScroll_isCappedAtTheLastCell() {
+        final LayoutManager<View> manager = equalCellManager();
+        final long index =
+                LayoutManager.getPageCellIndexForwardByCellCount(
+                        MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
+
+        assertThat(manager.getCellStartAtIndex(index)).isEqualTo(LAST_OF_TEN_CELLS * CELL_SIZE);
+    }
+
+    @Test
+    public void cellCountPaging_pastTheAdapterEndWithCircularScroll_keepsExtrapolating() {
+        final LayoutManager<View> manager = circularEqualCellManager();
+        final long index =
+                LayoutManager.getPageCellIndexForwardByCellCount(
+                        MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
+
+        assertThat(manager.getCellStartAtIndex(index))
+                .isEqualTo(MORE_CELLS_THAN_THE_ADAPTER_HAS * CELL_SIZE);
+    }
+
+    @Test
+    public void
+            cellCountPaging_beforeTheAdapterStartWithoutCircularScroll_isCappedAtTheFirstCell() {
+        final LayoutManager<View> manager = equalCellManager();
+        final long index =
+                LayoutManager.getPageCellIndexBackByCellCount(
+                        MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
+
+        assertThat(manager.getCellStartAtIndex(index)).isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void cellCountPaging_beforeTheAdapterStartWithCircularScroll_keepsExtrapolating() {
+        final LayoutManager<View> manager = circularEqualCellManager();
+        final long index =
+                LayoutManager.getPageCellIndexBackByCellCount(
+                        MORE_CELLS_THAN_THE_ADAPTER_HAS, FIRST_CELL);
+
+        assertThat(manager.getCellStartAtIndex(index))
+                .isEqualTo(-MORE_CELLS_THAN_THE_ADAPTER_HAS * CELL_SIZE);
+    }
+
+    @Test
+    public void cellCountPaging_withTheLargestIntervalPastTheEnd_isStillCappedAtTheLastCell() {
+        final LayoutManager<View> manager = equalCellManager();
+        final long index =
+                LayoutManager.getPageCellIndexForwardByCellCount(Integer.MAX_VALUE, FIRST_CELL);
+
+        assertThat(manager.getCellStartAtIndex(index)).isEqualTo(LAST_OF_TEN_CELLS * CELL_SIZE);
+    }
+
+    // ----------------------------------------------------------------- the viewport walks
+
+    @Test
+    public void forwardByViewport_withAPageThatFitsExactly_takesTheCellThatFits() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(FOURTH_CELL);
+    }
+
+    @Test
+    public void forwardByViewport_withAPageThatMissesByOnePixel_leavesThatCellBehind() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                A_PAGE_THAT_MISSES_BY_A_PIXEL, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(THIRD_CELL);
+    }
+
+    @Test
+    public void forwardByViewport_withASingleCellAdapter_findsNoFurtherCell() {
+        final LayoutManager<View> manager = singleCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(SECOND_CELL);
+        assertThat(manager.getCellStartAtIndex(SECOND_CELL)).isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void forwardByViewport_withACellLargerThanTheViewport_advancesExactlyOneCell() {
+        final LayoutManager<View> manager = largeCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                SMALL_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(SECOND_CELL);
+    }
+
+    @Test
+    public void forwardByViewport_withoutCellSpacing_fitsEveryCellTheViewportHolds() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(FOURTH_CELL);
+    }
+
+    @Test
+    public void forwardByViewport_withCellSpacing_countsTheSpacingThatComesWithEachCell() {
+        final LayoutManager<View> manager = spacedCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(THIRD_CELL);
+    }
+
+    @Test
+    public void forwardByViewport_withCellsOfUnequalSize_fitsEachCellsOwnSize() {
+        final LayoutManager<View> manager = unequalCellManager();
+
+        assertThat(manager.getCellStartAtIndex(FOURTH_CELL))
+                .isEqualTo(UNEQUAL_CELLS_THAT_FILL_THE_VIEWPORT);
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(FOURTH_CELL);
+    }
+
+    @Test
+    public void forwardByViewport_withViewportPadding_fitsTheCellsInsideThePaddingOnly() {
+        final LayoutManager<View> manager = paddedManager();
+
+        assertThat(manager.getCellStartAtIndex(FIRST_CELL)).isEqualTo(VIEWPORT_PADDING);
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                THE_VIEWPORT_INSIDE_THE_PADDING, FIRST_CELL, VIEWPORT_PADDING))
+                .isEqualTo(THIRD_CELL);
+    }
+
+    @Test
+    public void forwardByViewport_fromAnAnchorPartWayThroughACell_measuresFromItsCurrentStart() {
+        final PagingHarness harness = equalCellHarness();
+        harness.dragBy(A_REST_PART_WAY_THROUGH_A_CELL);
+        final LayoutManager<View> manager = harness.manager();
+
+        assertThat(manager.getCellStartAtIndex(FIRST_CELL))
+                .isEqualTo(A_REST_PART_WAY_THROUGH_A_CELL);
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                A_WHOLE_VIEWPORT, FIRST_CELL, A_REST_PART_WAY_THROUGH_A_CELL))
+                .isEqualTo(FOURTH_CELL);
+    }
+
+    @Test
+    public void forwardByViewport_withNoPageRoom_advancesExactlyOneCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.getPageCellIndexForwardByViewport(NO_PAGE_ROOM, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(SECOND_CELL);
+    }
+
+    @Test
+    public void forwardByViewport_withNegativePageRoom_advancesExactlyOneCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                NEGATIVE_PAGE_ROOM, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(SECOND_CELL);
+    }
+
+    @Test
+    public void forwardByViewport_atTheLastCellWithoutCircularScroll_findsNoFurtherCell() {
+        final LayoutManager<View> manager = equalCellManager();
+        final int lastCellStart = LAST_OF_TEN_CELLS * CELL_SIZE;
+
+        final long index =
+                manager.getPageCellIndexForwardByViewport(
+                        A_WHOLE_VIEWPORT, LAST_OF_TEN_CELLS, lastCellStart);
+
+        assertThat(index).isEqualTo(ONE_PAST_TEN_CELLS);
+        assertThat(manager.getCellStartAtIndex(index)).isEqualTo(lastCellStart);
+    }
+
+    @Test
+    public void forwardByViewport_withCircularScroll_walksPastTheAdapterEnd() {
+        final LayoutManager<View> manager = circularFourCellManager();
+        final int anchorStart = FOURTH_CELL * CELL_SIZE;
+
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                A_WHOLE_VIEWPORT, FOURTH_CELL, anchorStart))
+                .isEqualTo(FOURTH_CELL + THREE_CELLS_PER_GESTURE);
+    }
+
+    @Test
+    public void forwardByViewport_inAVerticalList_walksTheSameCells() {
+        final LayoutManager<View> manager = verticalEqualCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexForwardByViewport(
+                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(FOURTH_CELL);
+    }
+
+    @Test
+    public void backByViewport_withAPageThatFitsExactly_takesTheCellThatFits() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                A_WHOLE_VIEWPORT, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
+                .isEqualTo(FIRST_CELL);
+    }
+
+    @Test
+    public void backByViewport_withAPageThatMissesByOnePixel_leavesThatCellBehind() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                A_PAGE_THAT_MISSES_BY_A_PIXEL,
+                                FOURTH_CELL,
+                                FOURTH_CELL * CELL_SIZE))
+                .isEqualTo(SECOND_CELL);
+    }
+
+    @Test
+    public void backByViewport_withASingleCellAdapter_findsNoFurtherCell() {
+        final LayoutManager<View> manager = singleCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(-ONE_CELL_PER_GESTURE);
+        assertThat(manager.getCellStartAtIndex(-ONE_CELL_PER_GESTURE)).isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void backByViewport_withACellLargerThanTheViewport_advancesExactlyOneCell() {
+        final LayoutManager<View> manager = largeCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                SMALL_VIEWPORT, SECOND_CELL, LARGE_CELL_SIZE))
+                .isEqualTo(FIRST_CELL);
+    }
+
+    @Test
+    public void backByViewport_withCellSpacing_countsTheSpacingThatComesWithEachCell() {
+        final LayoutManager<View> manager = spacedCellManager();
+        final int anchorStart = FOURTH_CELL * (CELL_SIZE + CELL_SPACING);
+
+        assertThat(manager.getCellStartAtIndex(FOURTH_CELL)).isEqualTo(anchorStart);
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                A_WHOLE_VIEWPORT, FOURTH_CELL, anchorStart))
+                .isEqualTo(SECOND_CELL);
+    }
+
+    @Test
+    public void backByViewport_withCellsOfUnequalSize_fitsEachCellsOwnSize() {
+        final LayoutManager<View> manager = unequalCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                A_WHOLE_VIEWPORT,
+                                FOURTH_CELL,
+                                UNEQUAL_CELLS_THAT_FILL_THE_VIEWPORT))
+                .isEqualTo(FIRST_CELL);
+    }
+
+    @Test
+    public void backByViewport_withViewportPadding_fitsTheCellsInsideThePaddingOnly() {
+        final LayoutManager<View> manager = paddedManager();
+        final int anchorStart = VIEWPORT_PADDING + FOURTH_CELL * CELL_SIZE;
+
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                THE_VIEWPORT_INSIDE_THE_PADDING, FOURTH_CELL, anchorStart))
+                .isEqualTo(SECOND_CELL);
+    }
+
+    @Test
+    public void backByViewport_fromAnAnchorPartWayThroughACell_measuresToItsCurrentStart() {
+        final PagingHarness harness = equalCellHarness();
+        harness.dragBy(A_REST_PART_WAY_THROUGH_A_CELL);
+        final LayoutManager<View> manager = harness.manager();
+        final int anchorStart = FOURTH_CELL * CELL_SIZE + A_REST_PART_WAY_THROUGH_A_CELL;
+
+        assertThat(manager.getCellStartAtIndex(FOURTH_CELL)).isEqualTo(anchorStart);
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                A_WHOLE_VIEWPORT, FOURTH_CELL, anchorStart))
+                .isEqualTo(FIRST_CELL);
+    }
+
+    @Test
+    public void backByViewport_withNoPageRoom_advancesExactlyOneCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                NO_PAGE_ROOM, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
+                .isEqualTo(THIRD_CELL);
+    }
+
+    @Test
+    public void backByViewport_withNegativePageRoom_advancesExactlyOneCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                NEGATIVE_PAGE_ROOM, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
+                .isEqualTo(THIRD_CELL);
+    }
+
+    @Test
+    public void backByViewport_atTheFirstCellWithoutCircularScroll_findsNoFurtherCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        final long index =
+                manager.getPageCellIndexBackByViewport(A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE);
+
+        assertThat(index).isEqualTo(-ONE_CELL_PER_GESTURE);
+        assertThat(manager.getCellStartAtIndex(index)).isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void backByViewport_withCircularScroll_walksPastTheAdapterStart() {
+        final LayoutManager<View> manager = circularFourCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE))
+                .isEqualTo(-THREE_CELLS_PER_GESTURE);
+    }
+
+    @Test
+    public void backByViewport_inAVerticalList_walksTheSameCells() {
+        final LayoutManager<View> manager = verticalEqualCellManager();
+
+        assertThat(
+                        manager.getPageCellIndexBackByViewport(
+                                A_WHOLE_VIEWPORT, FOURTH_CELL, FOURTH_CELL * CELL_SIZE))
+                .isEqualTo(FIRST_CELL);
+    }
+
+    // --------------------------------------------------------------- the join predicates
+
+    @Test
+    public void nextCellJoinsThePage_whenTheNextStartEqualsTheCurrentOne_hasNoFurtherCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.nextCellJoinsThePage(
+                                A_WHOLE_VIEWPORT, NO_DISTANCE, CELL_SIZE, CELL_SIZE))
+                .isFalse();
+    }
+
+    @Test
+    public void nextCellJoinsThePage_whenTheNextStartIsOnTheWrongSide_hasNoFurtherCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.nextCellJoinsThePage(
+                                A_WHOLE_VIEWPORT, NO_DISTANCE, CELL_SIZE, NO_DISTANCE))
+                .isFalse();
+    }
+
+    @Test
+    public void nextCellJoinsThePage_withAFurtherCellThatFits_joinsThePage() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.nextCellJoinsThePage(
+                                A_WHOLE_VIEWPORT, NO_DISTANCE, CELL_SIZE, CELL_SIZE + CELL_SIZE))
+                .isTrue();
+    }
+
+    @Test
+    public void nextCellJoinsThePage_withAFurtherCellThatFitsExactly_joinsThePage() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.nextCellJoinsThePage(
+                                A_WHOLE_VIEWPORT, NO_DISTANCE, CELL_SIZE, A_WHOLE_VIEWPORT))
+                .isTrue();
+    }
+
+    @Test
+    public void nextCellJoinsThePage_withAFurtherCellThatDoesNotFit_doesNotJoinThePage() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.nextCellJoinsThePage(
+                                A_WHOLE_VIEWPORT,
+                                NO_DISTANCE,
+                                CELL_SIZE,
+                                A_WHOLE_VIEWPORT + ONE_PIXEL))
+                .isFalse();
+    }
+
+    @Test
+    public void
+            previousCellJoinsThePage_whenThePreviousStartEqualsTheCurrentOne_hasNoFurtherCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.previousCellJoinsThePage(
+                                A_WHOLE_VIEWPORT, A_WHOLE_VIEWPORT, CELL_SIZE, CELL_SIZE))
+                .isFalse();
+    }
+
+    @Test
+    public void previousCellJoinsThePage_whenThePreviousStartIsOnTheWrongSide_hasNoFurtherCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.previousCellJoinsThePage(
+                                A_WHOLE_VIEWPORT,
+                                A_WHOLE_VIEWPORT,
+                                CELL_SIZE,
+                                CELL_SIZE + CELL_SIZE))
+                .isFalse();
+    }
+
+    @Test
+    public void previousCellJoinsThePage_withAFurtherCellThatFits_joinsThePage() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.previousCellJoinsThePage(
+                                A_WHOLE_VIEWPORT, A_WHOLE_VIEWPORT, CELL_SIZE, CELL_SIZE / 2))
+                .isTrue();
+    }
+
+    @Test
+    public void previousCellJoinsThePage_withAFurtherCellThatFitsExactly_joinsThePage() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.previousCellJoinsThePage(
+                                A_WHOLE_VIEWPORT, A_WHOLE_VIEWPORT, CELL_SIZE, NO_DISTANCE))
+                .isTrue();
+    }
+
+    @Test
+    public void previousCellJoinsThePage_withAFurtherCellThatDoesNotFit_doesNotJoinThePage() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(
+                        manager.previousCellJoinsThePage(
+                                A_WHOLE_VIEWPORT, A_WHOLE_VIEWPORT, CELL_SIZE, -ONE_PIXEL))
+                .isFalse();
+    }
+
+    // -------------------------------------------------------------------------- pageFits
+
+    @Test
+    public void pageFits_withAPageExactlyTheMaximumSize_fits() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, NO_DISTANCE, A_WHOLE_VIEWPORT)).isTrue();
+    }
+
+    @Test
+    public void pageFits_withAPageOnePixelOverTheMaximum_doesNotFit() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, NO_DISTANCE, A_WHOLE_VIEWPORT + ONE_PIXEL))
+                .isFalse();
+    }
+
+    @Test
+    public void pageFits_withAPageOnePixelUnderTheMaximum_fits() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, NO_DISTANCE, A_WHOLE_VIEWPORT - ONE_PIXEL))
+                .isTrue();
+    }
+
+    @Test
+    public void pageFits_measuringBackwardsAtTheBoundary_fits() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, -A_WHOLE_VIEWPORT, NO_DISTANCE)).isTrue();
+    }
+
+    @Test
+    public void pageFits_measuringBackwardsOnePixelOverTheMaximum_doesNotFit() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, -A_WHOLE_VIEWPORT - ONE_PIXEL, NO_DISTANCE))
+                .isFalse();
+    }
+
+    @Test
+    public void pageFits_withANegativePageSize_fits() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.pageFits(NO_PAGE_ROOM, A_WHOLE_VIEWPORT, NO_DISTANCE)).isTrue();
+    }
+
+    @Test
+    public void pageFits_withANegativeMaximumPageSize_rejectsAPageOfNoSize() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.pageFits(-ONE_PIXEL, NO_DISTANCE, NO_DISTANCE)).isFalse();
+    }
+
+    @Test
+    public void pageFits_withANegativeMaximumPageSize_stillFitsAPageThatMeasuresLessThanIt() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.pageFits(NEGATIVE_PAGE_ROOM, A_WHOLE_VIEWPORT, NO_DISTANCE)).isTrue();
+    }
+
+    @Test
+    public void pageFits_withCellSpacing_takesTheSpacingOffTheEndOfThePage() {
+        final LayoutManager<View> manager = spacedCellManager();
+
+        assertThat(manager.pageFits(A_WHOLE_VIEWPORT, NO_DISTANCE, A_WHOLE_VIEWPORT + CELL_SPACING))
+                .isTrue();
+    }
+
+    @Test
+    public void pageFits_withCellSpacing_rejectsThePixelPastTheSpacing() {
+        final LayoutManager<View> manager = spacedCellManager();
+
+        assertThat(
+                        manager.pageFits(
+                                A_WHOLE_VIEWPORT,
+                                NO_DISTANCE,
+                                A_WHOLE_VIEWPORT + CELL_SPACING + ONE_PIXEL))
+                .isFalse();
+    }
+
+    @Test
+    public void pageFits_withCellSpacingWiderThanTheGap_measuresANegativePageAndFits() {
+        final LayoutManager<View> manager = spacedCellManager();
+
+        assertThat(manager.pageFits(NO_PAGE_ROOM, NO_DISTANCE, CELL_SPACING / 2)).isTrue();
+    }
+
+    @Test
+    public void pageFits_acrossTheWholeDrawableRange_measuresItWithoutOverflowing() {
+        final LayoutManager<View> manager = equalCellManager();
+        final long wholeRange = (long) THE_DRAWABLE_LIMIT + THE_DRAWABLE_LIMIT;
+
+        assertThat(wholeRange).isLessThanOrEqualTo(Integer.MAX_VALUE);
+        assertThat(manager.pageFits(Integer.MAX_VALUE, -THE_DRAWABLE_LIMIT, THE_DRAWABLE_LIMIT))
+                .isTrue();
+        assertThat(
+                        manager.pageFits(
+                                (int) wholeRange - ONE_PIXEL,
+                                -THE_DRAWABLE_LIMIT,
+                                THE_DRAWABLE_LIMIT))
+                .isFalse();
+    }
+
+    @Test
+    public void pageFits_withStartsBeyondTheIntRange_doesNotWrapToASmallPage() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.pageFits(Integer.MAX_VALUE, -BEYOND_THE_INT_RANGE, BEYOND_THE_INT_RANGE))
+                .isFalse();
+    }
+
+    @Test
+    public void pageFits_withABackwardsPageBeyondTheIntRange_doesNotWrapToALargePage() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.pageFits(NO_PAGE_ROOM, BEYOND_THE_INT_RANGE, -BEYOND_THE_INT_RANGE))
+                .isTrue();
+    }
+
+    // ------------------------------------------------------------------ getCellStartAtIndex
+
+    @Test
+    public void getCellStartAtIndex_atTheFirstDrawnCell_returnsThatCellsStart() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.getCellStartAtIndex(FIRST_CELL)).isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_atADrawnCellInTheMiddle_returnsThatCellsStart() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.getCellStartAtIndex(THIRD_CELL)).isEqualTo(THIRD_CELL * CELL_SIZE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_pastTheDrawnCells_extrapolatesFromTheLastDrawnCell() {
+        final LayoutManager<View> manager = equalCellManager();
+        final int fifthCell = FOURTH_CELL + ONE_CELL_PER_GESTURE;
+
+        assertThat(manager.getCellStartAtIndex(fifthCell)).isEqualTo(fifthCell * CELL_SIZE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_atTheLastAdapterCell_extrapolatesToItsStart() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.getCellStartAtIndex(LAST_OF_TEN_CELLS))
+                .isEqualTo(LAST_OF_TEN_CELLS * CELL_SIZE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_oneCellPastTheAdapterEnd_isCappedAtTheLastCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.getCellStartAtIndex(ONE_PAST_TEN_CELLS))
+                .isEqualTo(LAST_OF_TEN_CELLS * CELL_SIZE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_farPastTheAdapterEnd_isCappedAtTheLastCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.getCellStartAtIndex(MORE_CELLS_THAN_THE_ADAPTER_HAS))
+                .isEqualTo(LAST_OF_TEN_CELLS * CELL_SIZE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_oneCellBeforeTheAdapterStart_isCappedAtTheFirstCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.getCellStartAtIndex(-ONE_CELL_PER_GESTURE)).isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_farBeforeTheAdapterStart_isCappedAtTheFirstCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        assertThat(manager.getCellStartAtIndex(-MORE_CELLS_THAN_THE_ADAPTER_HAS))
+                .isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_withCellSpacing_stepsByTheCellSizeAndTheSpacing() {
+        final LayoutManager<View> manager = spacedCellManager();
+
+        assertThat(manager.getCellStartAtIndex(LAST_OF_TEN_CELLS))
+                .isEqualTo(LAST_OF_TEN_CELLS * (CELL_SIZE + CELL_SPACING));
+    }
+
+    @Test
+    public void getCellStartAtIndex_withCircularScroll_extrapolatesPastTheAdapterEnd() {
+        final LayoutManager<View> manager = circularEqualCellManager();
+
+        assertThat(manager.getCellStartAtIndex(MORE_CELLS_THAN_THE_ADAPTER_HAS))
+                .isEqualTo(MORE_CELLS_THAN_THE_ADAPTER_HAS * CELL_SIZE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_withCircularScroll_extrapolatesBeforeTheAdapterStart() {
+        final LayoutManager<View> manager = circularEqualCellManager();
+
+        assertThat(manager.getCellStartAtIndex(-MORE_CELLS_THAN_THE_ADAPTER_HAS))
+                .isEqualTo(-MORE_CELLS_THAN_THE_ADAPTER_HAS * CELL_SIZE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_withCircularScroll_keepsCountingRatherThanWrappingTheIndex() {
+        final LayoutManager<View> manager = circularFourCellManager();
+        final int oncePastTheAdapter = FOUR_CELLS + THREE_CELLS_PER_GESTURE;
+
+        assertThat(manager.getCellStartAtIndex(oncePastTheAdapter))
+                .isEqualTo(oncePastTheAdapter * CELL_SIZE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_farPastTheEndWithCircularScroll_isClampedToTheDrawableLimit() {
+        final LayoutManager<View> manager = circularEqualCellManager();
+
+        assertThat(manager.getCellStartAtIndex(Integer.MAX_VALUE)).isEqualTo(THE_DRAWABLE_LIMIT);
+    }
+
+    @Test
+    public void getCellStartAtIndex_farBeforeTheStartWithCircularScroll_isClampedToTheLimit() {
+        final LayoutManager<View> manager = circularEqualCellManager();
+
+        assertThat(manager.getCellStartAtIndex(-(long) Integer.MAX_VALUE))
+                .isEqualTo(-THE_DRAWABLE_LIMIT);
+    }
+
+    @Test
+    public void getCellStartAtIndex_inAVerticalList_returnsTheTopOfTheCell() {
+        final LayoutManager<View> manager = verticalEqualCellManager();
+
+        assertThat(manager.getCellStartAtIndex(THIRD_CELL)).isEqualTo(THIRD_CELL * CELL_SIZE);
+    }
+
+    @Test
+    public void getCellStartAtIndex_afterADrag_returnsTheMovedCellStarts() {
+        final PagingHarness harness = equalCellHarness();
+        harness.dragBy(A_REST_PART_WAY_THROUGH_A_CELL);
+        final LayoutManager<View> manager = harness.manager();
+
+        assertThat(manager.getCellStartAtIndex(FIRST_CELL))
+                .isEqualTo(A_REST_PART_WAY_THROUGH_A_CELL);
+        assertThat(manager.getCellStartAtIndex(FOURTH_CELL))
+                .isEqualTo(FOURTH_CELL * CELL_SIZE + A_REST_PART_WAY_THROUGH_A_CELL);
+    }
+
+    @Test
+    public void getCellStartExtrapolatedBeforeFirst_stepsBackByTheFirstCellSizeAndSpacing() {
+        final LayoutManager<View> manager = circularEqualCellManager();
+
+        assertThat(manager.getCellStartExtrapolatedBeforeFirst(-ONE_CELL_PER_GESTURE))
+                .isEqualTo(-CELL_SIZE);
+    }
+
+    @Test
+    public void getCellStartExtrapolatedAfterLast_stepsOnByTheLastCellSizeAndSpacing() {
+        final LayoutManager<View> manager = circularEqualCellManager();
+
+        assertThat(manager.getCellStartExtrapolatedAfterLast(MORE_CELLS_THAN_THE_ADAPTER_HAS))
+                .isEqualTo(MORE_CELLS_THAN_THE_ADAPTER_HAS * CELL_SIZE);
+    }
+
+    // ---------------------------------------------------------------- getSnapDisplacement
+
+    @Test
+    public void getSnapDisplacement_forACellAlreadyAtTheSnapPosition_isZero() {
+        final PagingHarness harness = equalCellHarness();
+        final LayoutManager<View> manager = harness.manager();
+
+        assertThat(manager.getSnapDisplacement(A_WHOLE_VIEWPORT, harness.cell(FIRST_CELL)))
+                .isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void getSnapDisplacement_forACellRestingPartWayThrough_isTheDistanceBackToTheSnap() {
+        final PagingHarness harness = equalCellHarness();
+        harness.dragBy(A_REST_PART_WAY_THROUGH_A_CELL);
+        final LayoutManager<View> manager = harness.manager();
+
+        assertThat(manager.getSnapDisplacement(A_WHOLE_VIEWPORT, harness.cell(FIRST_CELL)))
+                .isEqualTo(-A_REST_PART_WAY_THROUGH_A_CELL);
+    }
+
+    @Test
+    public void getSnapDisplacement_withAnEndSnapPosition_measuresToTheEndOfTheViewport() {
+        final PagingHarness harness = endSnapHarness();
+        harness.dragBy(A_REST_PART_WAY_THROUGH_A_CELL);
+        final LayoutManager<View> manager = harness.manager();
+
+        assertThat(manager.getCellStartAtIndex(FIRST_CELL))
+                .isEqualTo(THE_END_SNAP_POSITION + A_REST_PART_WAY_THROUGH_A_CELL);
+        assertThat(manager.getSnapDisplacement(A_WHOLE_VIEWPORT, harness.cell(FIRST_CELL)))
+                .isEqualTo(-A_REST_PART_WAY_THROUGH_A_CELL);
+    }
+
+    @Test
+    public void getSnapDisplacement_withACentreSnapPosition_measuresToTheCentreOfTheViewport() {
+        final PagingHarness harness = centreSnapHarness();
+        harness.dragBy(A_REST_PART_WAY_THROUGH_A_CELL);
+        final LayoutManager<View> manager = harness.manager();
+
+        assertThat(manager.getCellStartAtIndex(FIRST_CELL))
+                .isEqualTo(THE_CENTRE_SNAP_POSITION + A_REST_PART_WAY_THROUGH_A_CELL);
+        assertThat(manager.getSnapDisplacement(A_WHOLE_VIEWPORT, harness.cell(FIRST_CELL)))
+                .isEqualTo(-A_REST_PART_WAY_THROUGH_A_CELL);
+    }
+
+    @Test
+    public void getSnapDisplacement_forACellWithNoViews_isZeroRatherThanACrash() {
+        final LayoutManager<Group> manager = groupManager();
+        final Group emptyGroup = new Group(HORIZONTAL);
+
+        assertThat(manager.getView(emptyGroup)).isNull();
+        assertThat(manager.getSnapDisplacement(A_WHOLE_VIEWPORT, emptyGroup))
+                .isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void getSnapDisplacement_forACellOfZeroSizedViews_isZeroRatherThanACrash() {
+        final LayoutManager<Group> manager = groupManager();
+        final Group zeroSizedGroup = new Group(HORIZONTAL);
+        zeroSizedGroup.addView(new View(ApplicationProvider.getApplicationContext()));
+
+        assertThat(manager.getView(zeroSizedGroup)).isNull();
+        assertThat(manager.getSnapDisplacement(A_WHOLE_VIEWPORT, zeroSizedGroup))
+                .isEqualTo(NO_DISTANCE);
+    }
+
+    // --------------------------------------------------------------- setViewPageDistances
+
+    @Test
+    public void setViewPageDistances_whenTheViewIsNotAViewPager_leavesTheDistancesAlone() {
+        final LayoutManager<View> manager = notAViewPagerManager();
+
+        manager.setViewPageDistances(A_WHOLE_VIEWPORT);
+
+        assertThat(manager.mViewPageDistanceForward).isEqualTo(NO_DISTANCE);
+        assertThat(manager.mViewPageDistanceBack).isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void setViewPageDistances_withViewportPaging_measuresAWholeViewportForward() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        manager.setViewPageDistances(A_WHOLE_VIEWPORT);
+
+        assertThat(manager.mViewPageDistanceForward).isEqualTo(A_WHOLE_VIEWPORT);
+        assertThat(manager.mViewPageDistanceBack).isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void setViewPageDistances_withCellCountPaging_measuresThatManyCells() {
+        final LayoutManager<View> manager = intervalManager(TWO_CELLS_PER_GESTURE);
+
+        manager.setViewPageDistances(A_WHOLE_VIEWPORT);
+
+        assertThat(manager.mViewPageDistanceForward).isEqualTo(TWO_CELLS_PER_GESTURE * CELL_SIZE);
+        assertThat(manager.mViewPageDistanceBack).isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void setViewPageDistances_withViewportPadding_measuresThePageInsideThePadding() {
+        final LayoutManager<View> manager = paddedManager();
+
+        manager.setViewPageDistances(THE_VIEWPORT_INSIDE_THE_PADDING);
+
+        assertThat(manager.mViewPageDistanceForward).isEqualTo(TWO_CELLS_PER_GESTURE * CELL_SIZE);
+    }
+
+    @Test
+    public void setViewPageDistances_fromAnAnchorPartWayThroughACell_measuresFromTheSnappedStart() {
+        final PagingHarness harness = equalCellHarness();
+        harness.dragBy(A_REST_PART_WAY_THROUGH_A_CELL);
+        final LayoutManager<View> manager = harness.manager();
+
+        manager.setViewPageDistances(A_WHOLE_VIEWPORT);
+
+        assertThat(manager.mViewPageDistanceForward)
+                .isEqualTo(A_WHOLE_VIEWPORT + A_REST_PART_WAY_THROUGH_A_CELL);
+        assertThat(manager.mViewPageDistanceBack).isEqualTo(-A_REST_PART_WAY_THROUGH_A_CELL);
+    }
+
+    @Test
+    public void
+            setViewPageDistances_withACentreSnapPosition_leavesThePageOnlyTheRoomAfterTheAnchor() {
+        final LayoutManager<View> manager = centreSnapHarness().manager();
+
+        assertThat(manager.getCellStartAtIndex(FIRST_CELL)).isEqualTo(THE_CENTRE_SNAP_POSITION);
+
+        manager.setViewPageDistances(A_WHOLE_VIEWPORT);
+
+        assertThat(manager.mViewPageDistanceForward).isEqualTo(TWO_CELLS_PER_GESTURE * CELL_SIZE);
+    }
+
+    @Test
+    public void
+            setViewPageDistances_withAnEndSnapPosition_leavesThePageOnlyTheRoomAfterTheAnchor() {
+        final LayoutManager<View> manager = endSnapHarness().manager();
+
+        assertThat(manager.getCellStartAtIndex(FIRST_CELL)).isEqualTo(THE_END_SNAP_POSITION);
+
+        manager.setViewPageDistances(A_WHOLE_VIEWPORT);
+
+        assertThat(manager.mViewPageDistanceForward).isEqualTo(ONE_CELL_PER_GESTURE * CELL_SIZE);
+    }
+
+    @Test
+    public void setViewPageDistances_withASizeThePaddingHasEatenAway_stillAdvancesOneCell() {
+        final LayoutManager<View> manager = equalCellManager();
+
+        manager.setViewPageDistances(NEGATIVE_PAGE_ROOM);
+
+        assertThat(manager.mViewPageDistanceForward).isEqualTo(CELL_SIZE);
+        assertThat(manager.mViewPageDistanceBack).isEqualTo(NO_DISTANCE);
+    }
+
+    @Test
+    public void paddingLargerThanTheViewport_leavesTheLayoutANegativeSizeToPageIn() {
+        final LayoutManager<View> manager = paddingLargerThanTheViewportManager();
+        final int paddingTotal = manager.getStartSizePadding() + manager.getEndSizePadding();
+
+        assertThat(paddingTotal).isGreaterThan(SMALL_VIEWPORT);
+    }
+
+    // ------------------------------------------------------------------------- harnesses
+
+    private static long forward(final LayoutManager<View> manager, final int viewPagerInterval) {
+        return manager.getPageCellIndexForward(
+                viewPagerInterval, A_WHOLE_VIEWPORT, FIRST_CELL, NO_DISTANCE);
+    }
+
+    private static long back(final LayoutManager<View> manager, final int viewPagerInterval) {
+        return manager.getPageCellIndexBack(
+                viewPagerInterval, A_WHOLE_VIEWPORT, FOURTH_CELL, FOURTH_CELL * CELL_SIZE);
+    }
+
+    private static int intervalAfterAttributeParsing(final int viewPagerInterval) {
+        final LayoutManagerAttributes attributes =
+                new LayoutManagerAttributes(
+                        NOT_CIRCULAR,
+                        NOT_SNAP_TO_POSITION,
+                        IS_A_VIEW_PAGER,
+                        viewPagerInterval,
+                        SnapPosition.start,
+                        NO_CELL_SPACING,
+                        NOT_SELECT_ON_SNAP,
+                        NOT_SELECT_WHILE_SCROLLING,
+                        HORIZONTAL);
+        return attributes.getViewPagerInterval();
+    }
+
+    private static PagingHarness equalCellHarness() {
+        return new PagingHarness(
+                THREE_CELL_VIEWPORT,
+                equalSizes(CELL_SIZE, TEN_CELLS),
+                NO_CELL_SPACING,
+                VIEWPORT_PAGING,
+                NOT_CIRCULAR,
+                SnapPosition.start);
+    }
+
+    private static LayoutManager<View> equalCellManager() {
+        return equalCellHarness().manager();
+    }
+
+    private static LayoutManager<View> intervalManager(final int viewPagerInterval) {
+        return new PagingHarness(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        viewPagerInterval,
+                        NOT_CIRCULAR,
+                        SnapPosition.start)
+                .manager();
+    }
+
+    private static LayoutManager<View> spacedCellManager() {
+        return new PagingHarness(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(CELL_SIZE, TEN_CELLS),
+                        CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start)
+                .manager();
+    }
+
+    private static LayoutManager<View> unequalCellManager() {
+        return new PagingHarness(
+                        THREE_CELL_VIEWPORT,
+                        UNEQUAL_CELL_SIZES,
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start)
+                .manager();
+    }
+
+    private static LayoutManager<View> singleCellManager() {
+        final int[] oneCell = {CELL_SIZE};
+        return new PagingHarness(
+                        THREE_CELL_VIEWPORT,
+                        oneCell,
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start)
+                .manager();
+    }
+
+    private static LayoutManager<View> largeCellManager() {
+        return new PagingHarness(
+                        SMALL_VIEWPORT,
+                        equalSizes(LARGE_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start)
+                .manager();
+    }
+
+    private static LayoutManager<View> circularEqualCellManager() {
+        return new PagingHarness(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        CIRCULAR,
+                        SnapPosition.start)
+                .manager();
+    }
+
+    private static LayoutManager<View> circularFourCellManager() {
+        return new PagingHarness(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(CELL_SIZE, FOUR_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        CIRCULAR,
+                        SnapPosition.start)
+                .manager();
+    }
+
+    private static LayoutManager<View> verticalEqualCellManager() {
+        return new PagingHarness(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start,
+                        NO_VIEWPORT_PADDING,
+                        VERTICAL,
+                        IS_A_VIEW_PAGER)
+                .manager();
+    }
+
+    private static LayoutManager<View> paddedManager() {
+        return new PagingHarness(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start,
+                        VIEWPORT_PADDING,
+                        HORIZONTAL,
+                        IS_A_VIEW_PAGER)
+                .manager();
+    }
+
+    private static LayoutManager<View> notAViewPagerManager() {
+        return new PagingHarness(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start,
+                        NO_VIEWPORT_PADDING,
+                        HORIZONTAL,
+                        IS_NOT_A_VIEW_PAGER)
+                .manager();
+    }
+
+    private static LayoutManager<View> paddingLargerThanTheViewportManager() {
+        return new PagingHarness(
+                        SMALL_VIEWPORT,
+                        equalSizes(CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start,
+                        SMALL_VIEWPORT,
+                        HORIZONTAL,
+                        IS_A_VIEW_PAGER)
+                .manager();
+    }
+
+    private static PagingHarness endSnapHarness() {
+        return new PagingHarness(
+                THREE_CELL_VIEWPORT,
+                equalSizes(CELL_SIZE, TEN_CELLS),
+                NO_CELL_SPACING,
+                VIEWPORT_PAGING,
+                NOT_CIRCULAR,
+                SnapPosition.end);
+    }
+
+    private static PagingHarness centreSnapHarness() {
+        return new PagingHarness(
+                THREE_CELL_VIEWPORT,
+                equalSizes(CELL_SIZE, TEN_CELLS),
+                NO_CELL_SPACING,
+                VIEWPORT_PAGING,
+                NOT_CIRCULAR,
+                SnapPosition.center);
+    }
+
+    private static LayoutManager<Group> groupManager() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final PagingViewGroup gridViewGroup = new PagingViewGroup(context);
+        final AdapterViewManager gridAdapterViewManager = new AdapterViewManager();
+        final GridLayoutManagerAttributes gridAttributes =
+                new GridLayoutManagerAttributes(
+                        NUMBER_OF_VIEWS_PER_CELL,
+                        NOT_CIRCULAR,
+                        NOT_SNAP_TO_POSITION,
+                        IS_A_VIEW_PAGER,
+                        VIEWPORT_PAGING,
+                        SnapPosition.start,
+                        NO_CELL_SPACING,
+                        NOT_SELECT_ON_SNAP,
+                        NOT_SELECT_WHILE_SCROLLING,
+                        HORIZONTAL,
+                        NO_GRAVITY_EDGE,
+                        NO_GRAVITY_EDGE,
+                        NO_GRAVITY_EDGE,
+                        NO_GRAVITY_EDGE);
+        return new GridLayoutManager(gridViewGroup, null, gridAdapterViewManager, gridAttributes);
+    }
+
+    private static int[] equalSizes(final int cellSize, final int cellCount) {
+        final int[] sizes = new int[cellCount];
+        for (int index = 0; index < cellCount; index++) {
+            sizes[index] = cellSize;
+        }
+        return sizes;
+    }
+
+    private static final class PagingHarness {
+        private final PagingViewGroup mHarnessViewGroup;
+        private final LayoutManager<View> mHarnessLayoutManager;
+        private final Animation mHarnessAnimation = new Animation();
+        private final int mHarnessViewportSize;
+
+        private PagingHarness(
+                final int viewportSize,
+                final int[] cellSizes,
+                final int cellSpacing,
+                final int viewPagerInterval,
+                final boolean isCircularScroll,
+                final SnapPosition snapPosition) {
+            this(
+                    viewportSize,
+                    cellSizes,
+                    cellSpacing,
+                    viewPagerInterval,
+                    isCircularScroll,
+                    snapPosition,
+                    NO_VIEWPORT_PADDING,
+                    HORIZONTAL,
+                    IS_A_VIEW_PAGER);
+        }
+
+        private PagingHarness(
+                final int viewportSize,
+                final int[] cellSizes,
+                final int cellSpacing,
+                final int viewPagerInterval,
+                final boolean isCircularScroll,
+                final SnapPosition snapPosition,
+                final int viewportPadding,
+                final boolean isVertical,
+                final boolean isViewPager) {
+            mHarnessViewportSize = viewportSize;
+            mHarnessViewGroup = new PagingViewGroup(ApplicationProvider.getApplicationContext());
+            final AdapterViewManager harnessAdapterViewManager = new AdapterViewManager();
+            final LayoutManagerAttributes harnessAttributes =
+                    new LayoutManagerAttributes(
+                            isCircularScroll,
+                            NOT_SNAP_TO_POSITION,
+                            isViewPager,
+                            viewPagerInterval,
+                            snapPosition,
+                            cellSpacing,
+                            NOT_SELECT_ON_SNAP,
+                            NOT_SELECT_WHILE_SCROLLING,
+                            isVertical);
+            mHarnessLayoutManager =
+                    new ListLayoutManager(
+                            mHarnessViewGroup, null, harnessAdapterViewManager, harnessAttributes);
+            harnessAdapterViewManager.setAdapter(new SizedCellAdapter(cellSizes));
+
+            mHarnessViewGroup.setPadding(
+                    viewportPadding, viewportPadding, viewportPadding, viewportPadding);
+            final int measureSpec =
+                    View.MeasureSpec.makeMeasureSpec(viewportSize, View.MeasureSpec.EXACTLY);
+            mHarnessViewGroup.measure(measureSpec, measureSpec);
+            mHarnessViewGroup.layout(0, 0, viewportSize, viewportSize);
+
+            layout();
+            mHarnessAnimation.newAnimation();
+            layout();
+        }
+
+        private void layout() {
+            mHarnessLayoutManager.layout(
+                    mHarnessViewGroup,
+                    mHarnessAnimation,
+                    0,
+                    0,
+                    mHarnessViewportSize,
+                    mHarnessViewportSize);
+        }
+
+        private LayoutManager<View> manager() {
+            return mHarnessLayoutManager;
+        }
+
+        private View cell(final int cellIndex) {
+            return mHarnessLayoutManager.mCells.get(cellIndex);
+        }
+
+        private void dragBy(final int displacement) {
+            mHarnessAnimation.setDisplacement(displacement);
+            layout();
+        }
+    }
+
+    private static final class PagingViewGroup extends LinearLayout implements AdapterViewHandler {
+        private final List<View> mChildren = new ArrayList<View>();
+
+        private PagingViewGroup(final Context context) {
+            super(context);
+        }
+
+        @Override
+        public boolean addViewInAdapterView(
+                final View view, final int index, final ViewGroup.LayoutParams layoutParams) {
+            mChildren.add(index, view);
+            return true;
+        }
+
+        @Override
+        public void removeViewInAdapterView(final View view) {
+            mChildren.remove(view);
+        }
+    }
+
+    private static final class SizedCellAdapter extends BaseAdapter {
+        private final int[] mAdapterCellSizes;
+
+        private SizedCellAdapter(final int[] cellSizes) {
+            mAdapterCellSizes = cellSizes;
+        }
+
+        @Override
+        public int getCount() {
+            return mAdapterCellSizes.length;
+        }
+
+        @Override
+        public Object getItem(final int position) {
+            return position;
+        }
+
+        @Override
+        public long getItemId(final int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(final int position, final View convertView, final ViewGroup parent) {
+            final int cellSize = mAdapterCellSizes[position];
+            final FrameLayout view = new FrameLayout(ApplicationProvider.getApplicationContext());
+            view.setTag(position);
+            view.setLayoutParams(new ViewGroup.LayoutParams(cellSize, cellSize));
+            return view;
+        }
+    }
+}

--- a/library/src/test/java/mobi/parchment/widget/adapterview/ListViewViewPagerIntervalTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/ListViewViewPagerIntervalTest.java
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import android.content.res.XmlResourceParser;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.FrameLayout;
+import androidx.test.core.app.ApplicationProvider;
+import java.io.IOException;
+import mobi.parchment.test.R;
+import mobi.parchment.widget.adapterview.listview.ListView;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+/**
+ * ListView reads parchment_viewPagerInterval and hands it to LayoutManagerAttributes through a
+ * nine-argument positional constructor, so these drive the value from real inflated XML rather than
+ * from a hand-built LayoutManagerAttributes.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ListViewViewPagerIntervalTest {
+
+    private static final int VIEWPORT_SIZE = 300;
+    private static final int CELL_SIZE = 100;
+    private static final int ADAPTER_SIZE = 10;
+    private static final int TWO_CELLS_PER_GESTURE = 2;
+    private static final int START_OF_THE_VIEWPORT = 0;
+    private static final int NOT_DRAWN = Integer.MIN_VALUE;
+    private static final int NO_ID_RESOURCE = 0;
+    private static final String ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android";
+    private static final String ID_ATTRIBUTE = "id";
+
+    @Test
+    public void anIntervalOfTwoInXml_makesOneGestureAdvanceTwoCells() {
+        final PagingListView listView = pagingListViewFrom(R.id.view_pager_interval_two);
+
+        assertThat(listView.pageDistance(Move.forward))
+                .isEqualTo(-TWO_CELLS_PER_GESTURE * CELL_SIZE);
+
+        listView.page(Move.forward);
+
+        assertThat(listView.startOf(2)).isEqualTo(START_OF_THE_VIEWPORT);
+        assertThat(listView.startOf(0)).isEqualTo(NOT_DRAWN);
+    }
+
+    @Test
+    public void noIntervalInXml_makesOneGestureAdvanceOneCell() {
+        final PagingListView listView = pagingListViewFrom(R.id.view_pager_no_interval);
+
+        assertThat(listView.pageDistance(Move.forward)).isEqualTo(-CELL_SIZE);
+
+        listView.page(Move.forward);
+
+        assertThat(listView.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    private static PagingListView pagingListViewFrom(final int idResource) {
+        final Context context = RuntimeEnvironment.getApplication();
+        final XmlResourceParser parser =
+                context.getResources().getLayout(R.layout.attribute_parsing_view_pager_intervals);
+        try {
+            final AttributeSet attributeSet = advanceToTagWithId(parser, idResource);
+            final PagingListView listView = new PagingListView(context, attributeSet);
+            listView.start(context, attributeSet);
+            return listView;
+        } finally {
+            parser.close();
+        }
+    }
+
+    private static AttributeSet advanceToTagWithId(
+            final XmlResourceParser parser, final int idResource) {
+        try {
+            int event = parser.next();
+            while (event != XmlPullParser.END_DOCUMENT) {
+                if (event == XmlPullParser.START_TAG) {
+                    final int tagId =
+                            parser.getAttributeResourceValue(
+                                    ANDROID_NAMESPACE, ID_ATTRIBUTE, NO_ID_RESOURCE);
+                    if (tagId == idResource) {
+                        return parser;
+                    }
+                }
+                event = parser.next();
+            }
+        } catch (final XmlPullParserException | IOException exception) {
+            throw new IllegalStateException("could not read the layout", exception);
+        }
+        throw new IllegalStateException("the layout has no tag with the requested id");
+    }
+
+    private static final class PagingListView extends ListView<BaseAdapter> {
+        private final Animation mAnimation = new Animation();
+        private LayoutManager<View> mPagingLayoutManager;
+
+        private PagingListView(final Context context, final AttributeSet attributeSet) {
+            super(context, attributeSet);
+        }
+
+        private void start(final Context context, final AttributeSet attributeSet) {
+            final AdapterViewInitializer<View> initializer =
+                    getAdapterViewInitializer(context, attributeSet);
+            mPagingLayoutManager = initializer.getLayoutManager();
+            initializer.getAdapterViewManager().setAdapter(new CellAdapter());
+
+            final int measureSpec =
+                    View.MeasureSpec.makeMeasureSpec(VIEWPORT_SIZE, View.MeasureSpec.EXACTLY);
+            measure(measureSpec, measureSpec);
+            layout(0, 0, VIEWPORT_SIZE, VIEWPORT_SIZE);
+
+            layoutOnce();
+            mAnimation.newAnimation();
+            layoutOnce();
+        }
+
+        private void layoutOnce() {
+            mPagingLayoutManager.layout(this, mAnimation, 0, 0, VIEWPORT_SIZE, VIEWPORT_SIZE);
+        }
+
+        private int pageDistance(final Move move) {
+            return mPagingLayoutManager.getViewPagerScrollDistance(move);
+        }
+
+        private void page(final Move move) {
+            mAnimation.setDisplacement(pageDistance(move));
+            layoutOnce();
+        }
+
+        private int startOf(final int adapterPosition) {
+            for (int index = 0; index < getChildCount(); index++) {
+                final View view = getChildAt(index);
+                final Object tag = view.getTag();
+                final boolean isTheWantedView = tag.equals(Integer.valueOf(adapterPosition));
+                if (isTheWantedView) return view.getLeft();
+            }
+            return NOT_DRAWN;
+        }
+    }
+
+    private static final class CellAdapter extends BaseAdapter {
+        @Override
+        public int getCount() {
+            return ADAPTER_SIZE;
+        }
+
+        @Override
+        public Object getItem(final int position) {
+            return position;
+        }
+
+        @Override
+        public long getItemId(final int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(final int position, final View convertView, final ViewGroup parent) {
+            final FrameLayout view = new FrameLayout(ApplicationProvider.getApplicationContext());
+            view.setTag(position);
+            view.setLayoutParams(new ViewGroup.LayoutParams(CELL_SIZE, CELL_SIZE));
+            return view;
+        }
+    }
+}

--- a/library/src/test/java/mobi/parchment/widget/adapterview/ListViewViewPagerIntervalTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/ListViewViewPagerIntervalTest.java
@@ -35,6 +35,8 @@ public class ListViewViewPagerIntervalTest {
     private static final int CELL_SIZE = 100;
     private static final int ADAPTER_SIZE = 10;
     private static final int TWO_CELLS_PER_GESTURE = 2;
+    private static final int ONE_CELL_PER_GESTURE = 1;
+    private static final int CELLS_THAT_FIT_THE_VIEWPORT = VIEWPORT_SIZE / CELL_SIZE;
     private static final int START_OF_THE_VIEWPORT = 0;
     private static final int NOT_DRAWN = Integer.MIN_VALUE;
     private static final int NO_ID_RESOURCE = 0;
@@ -55,14 +57,44 @@ public class ListViewViewPagerIntervalTest {
     }
 
     @Test
-    public void noIntervalInXml_makesOneGestureAdvanceOneCell() {
-        final PagingListView listView = pagingListViewFrom(R.id.view_pager_no_interval);
+    public void anIntervalOfOneInXml_makesOneGestureAdvanceOneCell() {
+        final PagingListView listView = pagingListViewFrom(R.id.view_pager_interval_one);
 
         assertThat(listView.pageDistance(Move.forward)).isEqualTo(-CELL_SIZE);
 
         listView.page(Move.forward);
 
         assertThat(listView.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void noIntervalInXml_makesOneGestureAdvanceAWholeViewport() {
+        assertAdvancesAWholeViewport(R.id.view_pager_no_interval);
+    }
+
+    @Test
+    public void anIntervalOfZeroInXml_makesOneGestureAdvanceAWholeViewport() {
+        assertAdvancesAWholeViewport(R.id.view_pager_interval_zero);
+    }
+
+    @Test
+    public void theViewportConstantInXml_makesOneGestureAdvanceAWholeViewport() {
+        assertAdvancesAWholeViewport(R.id.view_pager_interval_viewport);
+    }
+
+    @Test
+    public void aNegativeIntervalInXml_makesOneGestureAdvanceAWholeViewport() {
+        assertAdvancesAWholeViewport(R.id.view_pager_interval_negative);
+    }
+
+    private static void assertAdvancesAWholeViewport(final int idResource) {
+        final PagingListView listView = pagingListViewFrom(idResource);
+
+        assertThat(listView.pageDistance(Move.forward)).isEqualTo(-VIEWPORT_SIZE);
+
+        listView.page(Move.forward);
+
+        assertThat(listView.startOf(CELLS_THAT_FIT_THE_VIEWPORT)).isEqualTo(START_OF_THE_VIEWPORT);
     }
 
     private static PagingListView pagingListViewFrom(final int idResource) {

--- a/library/src/test/java/mobi/parchment/widget/adapterview/ViewPagerTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/ViewPagerTest.java
@@ -28,6 +28,29 @@ public class ViewPagerTest {
     public static final int VIEW_GROUP_SIZE = 100;
     public static final int VIEW_SIZE = 100;
     public static final int CELL_SPACING = 10;
+
+    private static final int THREE_CELL_VIEWPORT = 300;
+    private static final int TWO_AND_A_HALF_CELL_VIEWPORT = 250;
+    private static final int SMALL_CELL_SIZE = 100;
+    private static final int LARGE_CELL_SIZE = 250;
+    private static final int SMALL_VIEWPORT = 100;
+    private static final int NO_CELL_SPACING = 0;
+    private static final int ONE_CELL_PER_GESTURE = 1;
+    private static final int THREE_CELLS_PER_GESTURE = 3;
+    private static final int MORE_CELLS_THAN_THE_ADAPTER_HAS = 10;
+    private static final int NO_INTERVAL = 0;
+    private static final int NEGATIVE_INTERVAL = -2;
+    private static final boolean CIRCULAR = true;
+    private static final boolean NOT_CIRCULAR = false;
+    private static final int TEN_CELLS = 10;
+    private static final int FOUR_CELLS = 4;
+    private static final int START_OF_THE_VIEWPORT = 0;
+    private static final int NOT_DRAWN = Integer.MIN_VALUE;
+    private static final int NO_VIEWPORT_PADDING = 0;
+    private static final int ENORMOUS_INTERVAL = Integer.MAX_VALUE;
+    private static final int HUGE_INTERVAL = 30000000;
+    private static final int VIEWPORT_PADDING = 20;
+
     final MyViewGroup mViewGroup = new MyViewGroup(ApplicationProvider.getApplicationContext());
     final AdapterViewManager adapterViewManager = new AdapterViewManager();
     TestAdapter mTestAdapter;
@@ -106,6 +129,416 @@ public class ViewPagerTest {
         assertThat(currentView.getBottom()).isEqualTo(100);
     }
 
+    @Test
+    public void viewPagerGesture_withThreeCellsOnScreen_advancesOneCellForward() {
+        final Pager pager = equalCellPager(ONE_CELL_PER_GESTURE, NOT_CIRCULAR);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_withThreeCellsOnScreen_advancesOneCellBack() {
+        final Pager pager = equalCellPager(ONE_CELL_PER_GESTURE, NOT_CIRCULAR);
+
+        pager.startGesture();
+        pager.page(Move.forward);
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(2)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.back)).isEqualTo(SMALL_CELL_SIZE);
+
+        pager.page(Move.back);
+
+        assertThat(pager.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_withAnIntervalOfThree_advancesThreeCells() {
+        final Pager pager =
+                new Pager(
+                        TWO_AND_A_HALF_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        THREE_CELLS_PER_GESTURE,
+                        NOT_CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward))
+                .isEqualTo(-THREE_CELLS_PER_GESTURE * SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_withCellsOfUnequalSize_advancesByEachCellsOwnSize() {
+        final int[] cellSizes = new int[] {50, 75, 100, 125, 150, 175, 200, 225, 250, 275};
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        cellSizes,
+                        NO_CELL_SPACING,
+                        ONE_CELL_PER_GESTURE,
+                        NOT_CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-50);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-75);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(2)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_withACellLargerThanTheViewport_advancesOneCell() {
+        final Pager pager =
+                new Pager(
+                        SMALL_VIEWPORT,
+                        equalSizes(LARGE_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        ONE_CELL_PER_GESTURE,
+                        NOT_CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-LARGE_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_withCellSpacing_advancesOneCellAndOneSpacing() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        CELL_SPACING,
+                        ONE_CELL_PER_GESTURE,
+                        NOT_CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-(SMALL_CELL_SIZE + CELL_SPACING));
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_startingPartWayThroughACell_landsOnACellBoundary() {
+        final Pager pager = equalCellPager(ONE_CELL_PER_GESTURE, NOT_CIRCULAR);
+
+        pager.startGesture();
+        pager.page(Move.forward);
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        pager.startGesture();
+        pager.dragBy(-40);
+
+        assertThat(pager.startOf(2)).isEqualTo(-40);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-60);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_atTheFirstCellWithoutCircularScroll_staysOnTheFirstCell() {
+        final Pager pager = equalCellPager(ONE_CELL_PER_GESTURE, NOT_CIRCULAR);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.back)).isEqualTo(0);
+
+        pager.page(Move.back);
+
+        assertThat(pager.startOf(0)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_atTheLastCellWithoutCircularScroll_stopsAtTheLastCell() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, FOUR_CELLS),
+                        NO_CELL_SPACING,
+                        ONE_CELL_PER_GESTURE,
+                        NOT_CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGesture();
+        pager.page(Move.forward);
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+        assertThat(pager.startOf(0)).isEqualTo(NOT_DRAWN);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(0);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_pastTheLastCellWithCircularScroll_wrapsToTheFirstCell() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, FOUR_CELLS),
+                        NO_CELL_SPACING,
+                        ONE_CELL_PER_GESTURE,
+                        CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGesture();
+        pager.page(Move.forward);
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(0)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_withAnIntervalLargerThanTheAdapter_stopsAtTheLastCell() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, FOUR_CELLS),
+                        NO_CELL_SPACING,
+                        MORE_CELLS_THAN_THE_ADAPTER_HAS,
+                        NOT_CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(0);
+    }
+
+    @Test
+    public void viewPagerGesture_withAnIntervalOfZero_advancesOneCell() {
+        final Pager pager = equalCellPager(NO_INTERVAL, NOT_CIRCULAR);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_withANegativeInterval_advancesOneCell() {
+        final Pager pager = equalCellPager(NEGATIVE_INTERVAL, NOT_CIRCULAR);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_withACentreSnapPosition_advancesOneCell() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        ONE_CELL_PER_GESTURE,
+                        NOT_CIRCULAR,
+                        SnapPosition.center);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(SMALL_CELL_SIZE);
+    }
+
+    @Test
+    public void viewPagerGesture_withAnOnScreenSnapPosition_advancesOneCell() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        ONE_CELL_PER_GESTURE,
+                        NOT_CIRCULAR,
+                        SnapPosition.onScreen);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.back)).isEqualTo(SMALL_CELL_SIZE);
+
+        pager.page(Move.back);
+
+        assertThat(pager.startOf(0)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewPagerGesture_withAnEnormousIntervalAtTheLastCell_asksForNoMovement() {
+        final Pager pager = equalCellPager(ENORMOUS_INTERVAL, NOT_CIRCULAR);
+
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(TEN_CELLS - 1)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(0);
+    }
+
+    @Test
+    public void viewPagerGesture_withAHugeIntervalAndCircularScroll_stillPagesForward() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        CELL_SPACING,
+                        HUGE_INTERVAL,
+                        CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isLessThan(0);
+        assertThat(pager.pageDistance(Move.back)).isGreaterThan(0);
+    }
+
+    @Test
+    public void
+            viewPagerGesture_withViewportPaddingAndAStartSnap_advancesOneCellInsideThePadding() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        ONE_CELL_PER_GESTURE,
+                        NOT_CIRCULAR,
+                        SnapPosition.start,
+                        VIEWPORT_PADDING);
+
+        assertThat(pager.startOf(0)).isEqualTo(VIEWPORT_PADDING);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(VIEWPORT_PADDING);
+    }
+
+    @Test
+    public void viewPagerGesture_withViewportPaddingAndACentreSnap_centresInsideThePadding() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        ONE_CELL_PER_GESTURE,
+                        NOT_CIRCULAR,
+                        SnapPosition.center,
+                        VIEWPORT_PADDING);
+
+        final int sizeInsidePadding = THREE_CELL_VIEWPORT - VIEWPORT_PADDING - VIEWPORT_PADDING;
+        final int centredStart = VIEWPORT_PADDING + (sizeInsidePadding - SMALL_CELL_SIZE) / 2;
+
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(1)).isEqualTo(centredStart);
+    }
+
+    private static Pager equalCellPager(final int viewPagerInterval, final boolean isCircular) {
+        return new Pager(
+                THREE_CELL_VIEWPORT,
+                equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                NO_CELL_SPACING,
+                viewPagerInterval,
+                isCircular,
+                SnapPosition.start);
+    }
+
+    private static int[] equalSizes(final int cellSize, final int cellCount) {
+        final int[] sizes = new int[cellCount];
+        for (int index = 0; index < cellCount; index++) {
+            sizes[index] = cellSize;
+        }
+        return sizes;
+    }
+
     private void doLayout() {
         doLayout(new Animation());
     }
@@ -121,7 +554,100 @@ public class ViewPagerTest {
         mViewGroup.layout(0, 0, viewGroupSize, viewGroupSize);
     }
 
-    public class MyViewGroup extends LinearLayout implements AdapterViewHandler {
+    private static final class Pager {
+        private final MyViewGroup mPagerViewGroup;
+        private final ListLayoutManager mPagerLayoutManager;
+        private final Animation mPagerAnimation = new Animation();
+        private final int mViewportSize;
+
+        private Pager(
+                final int viewportSize,
+                final int[] cellSizes,
+                final int cellSpacing,
+                final int viewPagerInterval,
+                final boolean isCircularScroll,
+                final SnapPosition snapPosition) {
+            this(
+                    viewportSize,
+                    cellSizes,
+                    cellSpacing,
+                    viewPagerInterval,
+                    isCircularScroll,
+                    snapPosition,
+                    NO_VIEWPORT_PADDING);
+        }
+
+        private Pager(
+                final int viewportSize,
+                final int[] cellSizes,
+                final int cellSpacing,
+                final int viewPagerInterval,
+                final boolean isCircularScroll,
+                final SnapPosition snapPosition,
+                final int viewportPadding) {
+            mViewportSize = viewportSize;
+            mPagerViewGroup = new MyViewGroup(ApplicationProvider.getApplicationContext());
+            final AdapterViewManager pagerAdapterViewManager = new AdapterViewManager();
+            final LayoutManagerAttributes pagerAttributes =
+                    new LayoutManagerAttributes(
+                            isCircularScroll,
+                            false,
+                            true,
+                            viewPagerInterval,
+                            snapPosition,
+                            cellSpacing,
+                            false,
+                            false,
+                            false);
+            mPagerLayoutManager =
+                    new ListLayoutManager(
+                            mPagerViewGroup, null, pagerAdapterViewManager, pagerAttributes);
+            pagerAdapterViewManager.setAdapter(new TestAdapter(cellSizes));
+
+            mPagerViewGroup.setPadding(
+                    viewportPadding, viewportPadding, viewportPadding, viewportPadding);
+            final int measureSpec =
+                    View.MeasureSpec.makeMeasureSpec(viewportSize, View.MeasureSpec.EXACTLY);
+            mPagerViewGroup.measure(measureSpec, measureSpec);
+            mPagerViewGroup.layout(0, 0, viewportSize, viewportSize);
+
+            layout();
+        }
+
+        private void layout() {
+            mPagerLayoutManager.layout(
+                    mPagerViewGroup, mPagerAnimation, 0, 0, mViewportSize, mViewportSize);
+        }
+
+        private void startGesture() {
+            mPagerAnimation.newAnimation();
+            layout();
+        }
+
+        private void dragBy(final int displacement) {
+            mPagerAnimation.setDisplacement(displacement);
+            layout();
+        }
+
+        private int pageDistance(final Move move) {
+            return mPagerLayoutManager.getViewPagerScrollDistance(move);
+        }
+
+        private void page(final Move move) {
+            dragBy(pageDistance(move));
+        }
+
+        private int startOf(final int adapterPosition) {
+            for (final View view : mPagerViewGroup.mViews) {
+                final Object tag = view.getTag();
+                final boolean isTheWantedView = tag.equals(Integer.valueOf(adapterPosition));
+                if (isTheWantedView) return view.getLeft();
+            }
+            return NOT_DRAWN;
+        }
+    }
+
+    public static class MyViewGroup extends LinearLayout implements AdapterViewHandler {
         public final List<View> mViews = new ArrayList<View>();
 
         public MyViewGroup(Context context) {
@@ -129,14 +655,7 @@ public class ViewPagerTest {
         }
 
         public View forPosition(int position) {
-            Collections.sort(
-                    mViews,
-                    new Comparator<View>() {
-                        @Override
-                        public int compare(View lhs, View rhs) {
-                            return lhs.getLeft() - rhs.getLeft();
-                        }
-                    });
+            Collections.sort(mViews, new LeftToRightComparator());
 
             return mViews.get(position);
         }
@@ -154,12 +673,27 @@ public class ViewPagerTest {
         }
     }
 
-    public class TestAdapter extends BaseAdapter {
+    private static final class LeftToRightComparator implements Comparator<View> {
+        @Override
+        public int compare(final View lhs, final View rhs) {
+            return lhs.getLeft() - rhs.getLeft();
+        }
+    }
+
+    public static class TestAdapter extends BaseAdapter {
+        private final int[] mCellSizes;
+        private final int mViewSize;
         private int mAdapterSize;
-        private int mViewSize;
 
         public TestAdapter(int viewSize) {
             mViewSize = viewSize;
+            mCellSizes = null;
+        }
+
+        private TestAdapter(final int[] cellSizes) {
+            mCellSizes = cellSizes;
+            mViewSize = 0;
+            mAdapterSize = cellSizes.length;
         }
 
         public void setAdapterSize(final int adapterSize) {
@@ -182,15 +716,21 @@ public class ViewPagerTest {
             return position;
         }
 
+        private int getViewSize(final int position) {
+            if (mCellSizes == null) return mViewSize;
+            return mCellSizes[position];
+        }
+
         @Override
         public View getView(int position, View convertView, ViewGroup parent) {
+            final int viewSize = getViewSize(position);
             FrameLayout outer = new FrameLayout(ApplicationProvider.getApplicationContext());
             outer.setTag(position);
-            outer.setLayoutParams(new android.view.ViewGroup.LayoutParams(mViewSize, mViewSize));
+            outer.setLayoutParams(new android.view.ViewGroup.LayoutParams(viewSize, viewSize));
 
             // TODO: necessary to have an outer and an inner?
             final FrameLayout inner = new FrameLayout(ApplicationProvider.getApplicationContext());
-            inner.setLayoutParams(new android.view.ViewGroup.LayoutParams(mViewSize, mViewSize));
+            inner.setLayoutParams(new android.view.ViewGroup.LayoutParams(viewSize, viewSize));
             outer.addView(inner);
             return outer;
         }

--- a/library/src/test/java/mobi/parchment/widget/adapterview/ViewPagerTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/ViewPagerTest.java
@@ -38,19 +38,32 @@ public class ViewPagerTest {
     private static final int ONE_CELL_PER_GESTURE = 1;
     private static final int THREE_CELLS_PER_GESTURE = 3;
     private static final int MORE_CELLS_THAN_THE_ADAPTER_HAS = 10;
-    private static final int NO_INTERVAL = 0;
+    private static final int VIEWPORT_PAGING = 0;
     private static final int NEGATIVE_INTERVAL = -2;
     private static final boolean CIRCULAR = true;
     private static final boolean NOT_CIRCULAR = false;
     private static final int TEN_CELLS = 10;
     private static final int LAST_OF_TEN_CELLS = TEN_CELLS - 1;
     private static final int FOUR_CELLS = 4;
+    private static final int LAST_OF_FOUR_CELLS = FOUR_CELLS - 1;
+    private static final int FIVE_CELLS = 5;
+    private static final int LAST_OF_FIVE_CELLS = FIVE_CELLS - 1;
+    private static final int TWO_CELLS = 2;
+    private static final int UNEQUAL_CELLS_THAT_FIT = 225;
+    private static final boolean HORIZONTAL = false;
+    private static final boolean VERTICAL = true;
     private static final int START_OF_THE_VIEWPORT = 0;
     private static final int NOT_DRAWN = Integer.MIN_VALUE;
     private static final int NO_VIEWPORT_PADDING = 0;
     private static final int ENORMOUS_INTERVAL = Integer.MAX_VALUE;
     private static final int HUGE_INTERVAL = 30000000;
     private static final int VIEWPORT_PADDING = 20;
+    private static final int A_REST_PART_WAY_THROUGH_A_CELL = -50;
+    private static final int CELLS_FULLY_VISIBLE_FROM_A_CENTRED_ANCHOR = 2;
+    private static final int CELLS_FULLY_VISIBLE_FROM_AN_END_ANCHOR = 1;
+    private static final int THE_END_SNAP_POSITION = THREE_CELL_VIEWPORT - SMALL_CELL_SIZE;
+    private static final int THE_CENTRE_SNAP_POSITION = (THREE_CELL_VIEWPORT - SMALL_CELL_SIZE) / 2;
+    private static final int UNEQUAL_CELLS_EXTRAPOLATED_BACK = 300;
 
     final MyViewGroup mViewGroup = new MyViewGroup(ApplicationProvider.getApplicationContext());
     final AdapterViewManager adapterViewManager = new AdapterViewManager();
@@ -65,7 +78,7 @@ public class ViewPagerTest {
                         true,
                         true,
                         true,
-                        0,
+                        VIEWPORT_PAGING,
                         SnapPosition.onScreen,
                         CELL_SPACING,
                         true,
@@ -373,12 +386,88 @@ public class ViewPagerTest {
     }
 
     @Test
-    public void viewPagerGesture_withAnIntervalOfZero_advancesOneCell() {
-        final Pager pager = equalCellPager(NO_INTERVAL, NOT_CIRCULAR);
+    public void viewPagerGesture_withAnIntervalOfZero_advancesAWholeViewport() {
+        final Pager pager = equalCellPager(VIEWPORT_PAGING, NOT_CIRCULAR);
 
         pager.startGesture();
 
-        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-SMALL_CELL_SIZE);
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-THREE_CELL_VIEWPORT);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+        assertThat(pager.startOf(2)).isEqualTo(-SMALL_CELL_SIZE);
+    }
+
+    @Test
+    public void viewPagerGesture_withANegativeInterval_advancesAWholeViewport() {
+        final Pager pager = equalCellPager(NEGATIVE_INTERVAL, NOT_CIRCULAR);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-THREE_CELL_VIEWPORT);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewportPaging_withCellsThatDoNotDivideTheViewport_leavesThePartialCellBehind() {
+        final Pager pager =
+                new Pager(
+                        TWO_AND_A_HALF_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-TWO_CELLS * SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(2)).isEqualTo(START_OF_THE_VIEWPORT);
+        assertThat(pager.startOf(1)).isEqualTo(-SMALL_CELL_SIZE);
+    }
+
+    @Test
+    public void viewportPaging_withCellsOfUnequalSize_advancesEveryCellThatFitsWhole() {
+        final int[] cellSizes = new int[] {50, 75, 100, 125, 150, 175, 200, 225, 250, 275};
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        cellSizes,
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-UNEQUAL_CELLS_THAT_FIT);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewportPaging_withACellLargerThanTheViewport_advancesThatOneCell() {
+        final Pager pager =
+                new Pager(
+                        SMALL_VIEWPORT,
+                        equalSizes(LARGE_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-LARGE_CELL_SIZE);
 
         pager.page(Move.forward);
 
@@ -386,8 +475,48 @@ public class ViewPagerTest {
     }
 
     @Test
-    public void viewPagerGesture_withANegativeInterval_advancesOneCell() {
-        final Pager pager = equalCellPager(NEGATIVE_INTERVAL, NOT_CIRCULAR);
+    public void viewportPaging_withCellSpacing_countsTheSpacingThatComesWithEachCell() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward))
+                .isEqualTo(-TWO_CELLS * (SMALL_CELL_SIZE + CELL_SPACING));
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(2)).isEqualTo(START_OF_THE_VIEWPORT);
+        assertThat(pager.startOf(3)).isEqualTo(SMALL_CELL_SIZE + CELL_SPACING);
+    }
+
+    @Test
+    public void viewportPaging_atTheFirstCellWithoutCircularScroll_staysOnTheFirstCell() {
+        final Pager pager = equalCellPager(VIEWPORT_PAGING, NOT_CIRCULAR);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.back)).isEqualTo(0);
+
+        pager.page(Move.back);
+
+        assertThat(pager.startOf(0)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewportPaging_withAPartialPageLeftAtTheEnd_advancesOnlyAsFarAsTheLastCell() {
+        final Pager pager = fiveCellPager();
+
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
 
         pager.startGesture();
 
@@ -395,7 +524,235 @@ public class ViewPagerTest {
 
         pager.page(Move.forward);
 
+        assertThat(pager.startOf(LAST_OF_FIVE_CELLS)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewportPaging_atTheLastCellWithoutCircularScroll_asksForNoMovement() {
+        final Pager pager = fiveCellPager();
+
+        pager.startGesture();
+        pager.page(Move.forward);
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(LAST_OF_FIVE_CELLS)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(0);
+    }
+
+    @Test
+    public void viewportPaging_back_returnsTheViewportItCameForwardOver() {
+        final Pager pager = equalCellPager(VIEWPORT_PAGING, NOT_CIRCULAR);
+
+        pager.startGesture();
+        pager.page(Move.forward);
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(6)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.back)).isEqualTo(THREE_CELL_VIEWPORT);
+
+        pager.page(Move.back);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewportPaging_pastTheAdapterEndWithCircularScroll_stillAdvancesAWholeViewport() {
+        final Pager pager = fourCellCircularPager();
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-THREE_CELL_VIEWPORT);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(LAST_OF_FOUR_CELLS)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-THREE_CELL_VIEWPORT);
+    }
+
+    @Test
+    public void viewportPaging_backFromTheFirstCellWithCircularScroll_wrapsRoundToTheLastCells() {
+        final Pager pager = fourCellCircularPager();
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.back)).isEqualTo(THREE_CELL_VIEWPORT);
+
+        pager.page(Move.back);
+
         assertThat(pager.startOf(1)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewportPaging_withViewportPadding_fitsTheCellsInsideThePaddingOnly() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start,
+                        VIEWPORT_PADDING,
+                        HORIZONTAL);
+
+        assertThat(pager.startOf(0)).isEqualTo(VIEWPORT_PADDING);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-TWO_CELLS * SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(2)).isEqualTo(VIEWPORT_PADDING);
+    }
+
+    @Test
+    public void viewportPaging_inAVerticalList_advancesAWholeViewport() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start,
+                        NO_VIEWPORT_PADDING,
+                        VERTICAL);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-THREE_CELL_VIEWPORT);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+    }
+
+    @Test
+    public void viewportPaging_withACentreSnapPosition_advancesOnlyTheCellsFullyVisible() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.center);
+
+        assertThat(pager.startOf(0)).isEqualTo(THE_CENTRE_SNAP_POSITION);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward))
+                .isEqualTo(-CELLS_FULLY_VISIBLE_FROM_A_CENTRED_ANCHOR * SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(CELLS_FULLY_VISIBLE_FROM_A_CENTRED_ANCHOR))
+                .isEqualTo(THE_CENTRE_SNAP_POSITION);
+    }
+
+    @Test
+    public void viewportPaging_withAnEndSnapPosition_advancesOnlyTheCellsFullyVisible() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.end);
+
+        assertThat(pager.startOf(0)).isEqualTo(THE_END_SNAP_POSITION);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward))
+                .isEqualTo(-CELLS_FULLY_VISIBLE_FROM_AN_END_ANCHOR * SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(CELLS_FULLY_VISIBLE_FROM_AN_END_ANCHOR))
+                .isEqualTo(THE_END_SNAP_POSITION);
+    }
+
+    @Test
+    public void viewportPaging_fromARestPartWayThroughACell_leavesNoCellUnshown() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.onScreen);
+
+        pager.startGesture();
+        pager.dragBy(A_REST_PART_WAY_THROUGH_A_CELL);
+
+        assertThat(pager.startOf(0)).isEqualTo(A_REST_PART_WAY_THROUGH_A_CELL);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-TWO_CELLS * SMALL_CELL_SIZE);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(SMALL_CELL_SIZE + A_REST_PART_WAY_THROUGH_A_CELL);
+    }
+
+    @Test
+    public void viewportPaging_backOverCellsNoLongerDrawn_extrapolatesTheFirstDrawnCellSize() {
+        final int[] cellSizes = new int[] {50, 75, 100, 125, 150, 175, 200, 225, 250, 275};
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        cellSizes,
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.start);
+
+        pager.startGesture();
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
+        assertThat(pager.startOf(0)).isEqualTo(NOT_DRAWN);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.back)).isEqualTo(UNEQUAL_CELLS_EXTRAPOLATED_BACK);
+    }
+
+    @Test
+    public void viewportPaging_withAnOnScreenSnapPosition_advancesAWholeViewport() {
+        final Pager pager =
+                new Pager(
+                        THREE_CELL_VIEWPORT,
+                        equalSizes(SMALL_CELL_SIZE, TEN_CELLS),
+                        NO_CELL_SPACING,
+                        VIEWPORT_PAGING,
+                        NOT_CIRCULAR,
+                        SnapPosition.onScreen);
+
+        pager.startGesture();
+
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-THREE_CELL_VIEWPORT);
+
+        pager.page(Move.forward);
+
+        assertThat(pager.startOf(3)).isEqualTo(START_OF_THE_VIEWPORT);
     }
 
     @Test
@@ -488,7 +845,8 @@ public class ViewPagerTest {
                         ONE_CELL_PER_GESTURE,
                         NOT_CIRCULAR,
                         SnapPosition.start,
-                        VIEWPORT_PADDING);
+                        VIEWPORT_PADDING,
+                        HORIZONTAL);
 
         assertThat(pager.startOf(0)).isEqualTo(VIEWPORT_PADDING);
 
@@ -511,7 +869,8 @@ public class ViewPagerTest {
                         ONE_CELL_PER_GESTURE,
                         NOT_CIRCULAR,
                         SnapPosition.center,
-                        VIEWPORT_PADDING);
+                        VIEWPORT_PADDING,
+                        HORIZONTAL);
 
         final int sizeInsidePadding = THREE_CELL_VIEWPORT - VIEWPORT_PADDING - VIEWPORT_PADDING;
         final int centredStart = VIEWPORT_PADDING + (sizeInsidePadding - SMALL_CELL_SIZE) / 2;
@@ -573,6 +932,26 @@ public class ViewPagerTest {
                 SnapPosition.start);
     }
 
+    private static Pager fiveCellPager() {
+        return new Pager(
+                THREE_CELL_VIEWPORT,
+                equalSizes(SMALL_CELL_SIZE, FIVE_CELLS),
+                NO_CELL_SPACING,
+                VIEWPORT_PAGING,
+                NOT_CIRCULAR,
+                SnapPosition.start);
+    }
+
+    private static Pager fourCellCircularPager() {
+        return new Pager(
+                THREE_CELL_VIEWPORT,
+                equalSizes(SMALL_CELL_SIZE, FOUR_CELLS),
+                NO_CELL_SPACING,
+                VIEWPORT_PAGING,
+                CIRCULAR,
+                SnapPosition.start);
+    }
+
     private static int[] equalSizes(final int cellSize, final int cellCount) {
         final int[] sizes = new int[cellCount];
         for (int index = 0; index < cellCount; index++) {
@@ -601,6 +980,7 @@ public class ViewPagerTest {
         private final ListLayoutManager mPagerLayoutManager;
         private final Animation mPagerAnimation = new Animation();
         private final int mViewportSize;
+        private final boolean mIsVertical;
 
         private Pager(
                 final int viewportSize,
@@ -616,7 +996,8 @@ public class ViewPagerTest {
                     viewPagerInterval,
                     isCircularScroll,
                     snapPosition,
-                    NO_VIEWPORT_PADDING);
+                    NO_VIEWPORT_PADDING,
+                    HORIZONTAL);
         }
 
         private Pager(
@@ -626,8 +1007,10 @@ public class ViewPagerTest {
                 final int viewPagerInterval,
                 final boolean isCircularScroll,
                 final SnapPosition snapPosition,
-                final int viewportPadding) {
+                final int viewportPadding,
+                final boolean isVertical) {
             mViewportSize = viewportSize;
+            mIsVertical = isVertical;
             mPagerViewGroup = new MyViewGroup(ApplicationProvider.getApplicationContext());
             final AdapterViewManager pagerAdapterViewManager = new AdapterViewManager();
             final LayoutManagerAttributes pagerAttributes =
@@ -640,7 +1023,7 @@ public class ViewPagerTest {
                             cellSpacing,
                             false,
                             false,
-                            false);
+                            isVertical);
             mPagerLayoutManager =
                     new ListLayoutManager(
                             mPagerViewGroup, null, pagerAdapterViewManager, pagerAttributes);
@@ -690,9 +1073,14 @@ public class ViewPagerTest {
             for (final View view : mPagerViewGroup.mViews) {
                 final Object tag = view.getTag();
                 final boolean isTheWantedView = tag.equals(Integer.valueOf(adapterPosition));
-                if (isTheWantedView) return view.getLeft();
+                if (isTheWantedView) return startOfView(view);
             }
             return NOT_DRAWN;
+        }
+
+        private int startOfView(final View view) {
+            if (mIsVertical) return view.getTop();
+            return view.getLeft();
         }
     }
 

--- a/library/src/test/java/mobi/parchment/widget/adapterview/ViewPagerTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/ViewPagerTest.java
@@ -43,6 +43,7 @@ public class ViewPagerTest {
     private static final boolean CIRCULAR = true;
     private static final boolean NOT_CIRCULAR = false;
     private static final int TEN_CELLS = 10;
+    private static final int LAST_OF_TEN_CELLS = TEN_CELLS - 1;
     private static final int FOUR_CELLS = 4;
     private static final int START_OF_THE_VIEWPORT = 0;
     private static final int NOT_DRAWN = Integer.MIN_VALUE;
@@ -521,6 +522,47 @@ public class ViewPagerTest {
         assertThat(pager.startOf(1)).isEqualTo(centredStart);
     }
 
+    /**
+     * A gesture whose very first frame is held by the bounds must not count the movement it was
+     * denied. The distance a page asks for is measured from where the gesture started, so a first
+     * frame that carried a drag the start of the list refused used to leave that drag in the
+     * running total, and the page that followed was short by it in one direction and long by it in
+     * the other. Whether a gesture's first frame carries a drag at all depends on whether a touch
+     * move and an animation frame land in the same pass, which is why this only ever showed up on a
+     * device.
+     */
+    @Test
+    public void aGestureWhoseFirstFrameIsHeldAtTheStart_doesNotCountTheHeldMovementAsTravelled() {
+        final Pager pager = equalCellPager(ONE_CELL_PER_GESTURE, NOT_CIRCULAR);
+
+        pager.startGestureWith(SMALL_CELL_SIZE);
+
+        assertThat(pager.startOf(0)).isEqualTo(START_OF_THE_VIEWPORT);
+        assertThat(pager.pageDistance(Move.back)).isEqualTo(0);
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(-SMALL_CELL_SIZE);
+    }
+
+    /**
+     * The other end of the same clamp. The end of the list is held by a different method with a
+     * different limit than the start, so it needs its own case: a forward gesture there answered
+     * with the negative of the drag it was denied, moving the content backwards.
+     */
+    @Test
+    public void aGestureWhoseFirstFrameIsHeldAtTheEnd_doesNotCountTheHeldMovementAsTravelled() {
+        final Pager pager = equalCellPager(ONE_CELL_PER_GESTURE, NOT_CIRCULAR);
+        for (int page = 0; page < LAST_OF_TEN_CELLS; page++) {
+            pager.startGesture();
+            pager.page(Move.forward);
+        }
+        assertThat(pager.startOf(LAST_OF_TEN_CELLS)).isEqualTo(START_OF_THE_VIEWPORT);
+
+        pager.startGestureWith(-SMALL_CELL_SIZE);
+
+        assertThat(pager.startOf(LAST_OF_TEN_CELLS)).isEqualTo(START_OF_THE_VIEWPORT);
+        assertThat(pager.pageDistance(Move.forward)).isEqualTo(0);
+        assertThat(pager.pageDistance(Move.back)).isEqualTo(SMALL_CELL_SIZE);
+    }
+
     private static Pager equalCellPager(final int viewPagerInterval, final boolean isCircular) {
         return new Pager(
                 THREE_CELL_VIEWPORT,
@@ -621,6 +663,13 @@ public class ViewPagerTest {
 
         private void startGesture() {
             mPagerAnimation.newAnimation();
+            layout();
+        }
+
+        /** Starts a gesture whose first frame already carries a drag, as one on a device can. */
+        private void startGestureWith(final int displacement) {
+            mPagerAnimation.newAnimation();
+            mPagerAnimation.setDisplacement(displacement);
             layout();
         }
 

--- a/library/src/test/res/layout/attribute_parsing_list_view.xml
+++ b/library/src/test/res/layout/attribute_parsing_list_view.xml
@@ -11,5 +11,6 @@
         parchment:parchment_snapToPosition="true"
         parchment:parchment_selectOnSnap="true"
         parchment:parchment_isViewPager="true"
+        parchment:parchment_viewPagerInterval="3"
         parchment:parchment_snapPosition="end"
         parchment:parchment_selectWhileScrolling="true"/>

--- a/library/src/test/res/layout/attribute_parsing_view_pager_intervals.xml
+++ b/library/src/test/res/layout/attribute_parsing_view_pager_intervals.xml
@@ -9,15 +9,37 @@
             android:id="@+id/view_pager_interval_zero"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            parchment:parchment_orientation="horizontal"
+            parchment:parchment_snapPosition="start"
             parchment:parchment_isViewPager="true"
             parchment:parchment_viewPagerInterval="0"/>
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/view_pager_interval_viewport"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            parchment:parchment_orientation="horizontal"
+            parchment:parchment_snapPosition="start"
+            parchment:parchment_isViewPager="true"
+            parchment:parchment_viewPagerInterval="viewport"/>
 
     <mobi.parchment.widget.adapterview.listview.ListView
             android:id="@+id/view_pager_interval_negative"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            parchment:parchment_orientation="horizontal"
+            parchment:parchment_snapPosition="start"
             parchment:parchment_isViewPager="true"
             parchment:parchment_viewPagerInterval="-2"/>
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/view_pager_interval_one"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            parchment:parchment_orientation="horizontal"
+            parchment:parchment_snapPosition="start"
+            parchment:parchment_isViewPager="true"
+            parchment:parchment_viewPagerInterval="1"/>
 
     <mobi.parchment.widget.adapterview.listview.ListView
             android:id="@+id/view_pager_interval_two"

--- a/library/src/test/res/layout/attribute_parsing_view_pager_intervals.xml
+++ b/library/src/test/res/layout/attribute_parsing_view_pager_intervals.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:parchment="http://schemas.android.com/apk/res-auto"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/view_pager_interval_zero"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            parchment:parchment_isViewPager="true"
+            parchment:parchment_viewPagerInterval="0"/>
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/view_pager_interval_negative"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            parchment:parchment_isViewPager="true"
+            parchment:parchment_viewPagerInterval="-2"/>
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/view_pager_interval_two"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            parchment:parchment_orientation="horizontal"
+            parchment:parchment_snapPosition="start"
+            parchment:parchment_isViewPager="true"
+            parchment:parchment_viewPagerInterval="2"/>
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/view_pager_no_interval"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            parchment:parchment_orientation="horizontal"
+            parchment:parchment_snapPosition="start"
+            parchment:parchment_isViewPager="true"/>
+
+    <mobi.parchment.widget.adapterview.gridview.GridView
+            android:id="@+id/view_pager_interval_grid_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            parchment:parchment_isViewPager="true"
+            parchment:parchment_viewPagerInterval="4"/>
+
+    <mobi.parchment.widget.adapterview.gridpatternview.GridPatternView
+            android:id="@+id/view_pager_interval_grid_pattern_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            parchment:parchment_isViewPager="true"
+            parchment:parchment_viewPagerInterval="2"/>
+</LinearLayout>


### PR DESCRIPTION
## Description

Parchment has always paged by the viewport: a ViewPager gesture advanced the
run of cells fully visible, so a magazine-style `GridPatternView` spread turned
a page at a time and adapted to the screen for free — three cells on a tablet,
one on a phone, no configuration. Issue #26 wants the other model, the
carousel: advance exactly one cell whatever else is on screen.

This PR carries both, selected by one attribute, with viewport as the default
so nothing changes for anyone who does not set it.

```xml
<attr name="parchment_viewPagerInterval" format="integer">
    <enum name="viewport" value="0"/>
</attr>
```

An integer plus a named constant, the way `layout_width` carries a dimension
plus `match_parent`. `viewport`, the literal `0`, and leaving the attribute out
are one state, because zero is already the value an absent attribute yields —
so "unset" needs no special case and upgrading changes nothing by default. `N`
advances exactly N cells.

An earlier revision of this branch made the carousel the only behaviour and
clamped zero up to one cell. That was too narrow. This revision restores
viewport paging, makes it the default again, and keeps the carousel behind the
attribute.

### A negative interval is read as `viewport`

A negative interval is not a number of cells. Left alone it would put the
forward landing cell *behind* the anchor, so a forward swipe would move the
content backwards and a backward swipe forwards. Two other answers were
possible — take its absolute value, or clamp to one cell — and both invent a
meaning the writer did not express. Falling back to the default keeps exactly
one degenerate state: anything that is not a positive cell count is viewport
paging, the same as unset. It is the same one-line `Math.max` clamp that was
already at both attribute boundaries, now with zero as the floor, and it is
pinned by `aNegativeViewPagerIntervalInXml_isReadAsViewportPaging`,
`viewPagerGesture_withANegativeInterval_advancesAWholeViewport` and
`aNegativeIntervalInXml_pagesByTheWholeViewport` on a device.

### Consequence for #26, stated plainly

**With viewport as the default, issue #26's complaint is no longer fixed by
default.** Its reporter had three cells on screen and one swipe jumped all
three; after this PR that is still what happens unless they add
`parchment_viewPagerInterval="1"`, which is the fix they want and is one line.

So `Closes #26` is **not** the right claim any more and this PR does not make
it. #26 is a bug report against a behaviour that this PR keeps as the default
and now documents as deliberate; auto-closing it on merge would mark the
reported behaviour fixed when it is unchanged. The capability exists and is
reachable in one line, so the issue may well be closable — but as "working as
intended, set the attribute", and that is the repo owner's call, not this PR's.
Marked `Refs #26`.

### Rebuilt on the anchor machinery, not restored

The old `getViewPageDistance` is not coming back. It summed the fully visible
cells, then added an unconditional `+ cellSpacing`, with a fallback for when no
cell was fully visible and a separate case for a cell straddling the whole
viewport. It also produced a single distance used in both directions.

Viewport paging is now expressed on the same anchor machinery the interval mode
uses. Both modes take the cell nearest the snap position as the anchor and both
end at `getCellStartAtIndex`, so one place decides where a page lands and the
distance is always the gap between the anchor's snapped start and the landing
cell's start. Only the choice of landing index differs:

- interval mode takes `anchorIndex ± N`;
- viewport mode walks out from the anchor while the next cell still fits
  entirely inside the viewport, and lands on the first one that does not.

The walk starts one cell out, so a page always advances at least one cell. That
is what removes the old special case: **a cell larger than the viewport is
simply the first cell that does not fit**, and advancing exactly one cell falls
out of the walk rather than being written down. It mirrors backwards, so a page
back covers the run of cells that would fill one viewport ending at the anchor,
instead of reusing the forward number the way the old single `mViewPageDistance`
did.

The room a page has is `maximumPageSize`: the distance from **where the anchor
will sit once snapped** to the end of the size inside the padding — not the
whole of that size. The two are equal only when the anchor snaps to the start
edge, which is why the first version of this branch got away with measuring
from the anchor's own start and why the independent review caught it (see
below). With `center`, with `end`, or with the XML-default `onScreen` resting
part-way through a cell, the anchor sits further into the viewport and less
room is left; measuring against the whole size counted a cell that was only
partly visible into the page and skipped it for good.

Extrapolation past the drawn cells and the cap at the adapter's ends come free
from `getCellStartAtIndex`, which already lifts the cap under
`parchment_isCircularScroll`. The cap is therefore *not* what ends the walk —
under circular scroll there is no cap. The walk ends when the page stops
fitting; the separate guard that the next index names a further cell is what
stops it when the cap, a zero cell size, or a negative `parchment_cellSpacing`
leaves the start where it was. Because the extrapolation knows only the edge
cell's size, a page **back** over cells that are no longer drawn is exact only
while those cells match it — pinned, as a limitation, by
`viewportPaging_backOverCellsNoLongerDrawn_extrapolatesTheFirstDrawnCellSize`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

Not breaking. The previous revision of this branch *was* breaking; making
viewport the default removes that. A view with no `parchment_viewPagerInterval`
pages exactly as it does on `main` today.

## How Has This Been Tested?

- [x] Unit tests
- [x] Instrumented tests
- [x] Manual testing on device/emulator — the instrumented suite is the device
      testing; no by-hand run beyond it.

Baseline on this branch before the change: **177** unit tests green. After:
**207** unit tests green and **78** instrumented tests green on
`emulator-5554` (API 36, Android 16). Counts parsed out of
`library/build/test-results/**/*.xml` and
`library/build/outputs/androidTest-results/connected/**/*.xml`, not read off the
console — `connectedDebugAndroidTest` can report BUILD SUCCESSFUL having run
zero tests.

### Tests that failed before the change

**Unit — `ViewPagerTest`, 14 failures, each showing the old one-cell answer**

```
viewPagerGesture_withAnIntervalOfZero_advancesAWholeViewport      expected:<-[3]00> but was:<-[1]00>
viewPagerGesture_withANegativeInterval_advancesAWholeViewport     expected:<-[3]00> but was:<-[1]00>
viewportPaging_withCellsThatDoNotDivideTheViewport_
        leavesThePartialCellBehind                                expected:<-[2]00> but was:<-[1]00>
viewportPaging_withCellsOfUnequalSize_advancesEveryCellThatFitsWhole
                                                                  expected:<-[225]> but was:<-[50]>
viewportPaging_withCellSpacing_countsTheSpacingThatComesWithEachCell
                                                                  expected:<-[22]0> but was:<-[11]0>
viewportPaging_withAPartialPageLeftAtTheEnd_
        advancesOnlyAsFarAsTheLastCell                            expected:<[]0> but was:<[20]0>
viewportPaging_atTheLastCellWithoutCircularScroll_asksForNoMovement
                                                                  expected:<[]0> but was:<[20]0>
viewportPaging_back_returnsTheViewportItCameForwardOver           expected:<[0]> but was:<[-2147483648]>
viewportPaging_pastTheAdapterEndWithCircularScroll_
        stillAdvancesAWholeViewport                               expected:<-[3]00> but was:<-[1]00>
viewportPaging_backFromTheFirstCellWithCircularScroll_
        wrapsRoundToTheLastCells                                  expected:<[3]00> but was:<[1]00>
viewportPaging_withViewportPadding_fitsTheCellsInsideThePaddingOnly
                                                                  expected:<-[2]00> but was:<-[1]00>
viewportPaging_inAVerticalList_advancesAWholeViewport             expected:<-[3]00> but was:<-[1]00>
viewportPaging_withACentreSnapPosition_
        advancesOnlyTheCellsFullyVisible                          expected:<-[2]00> but was:<-[1]00>
viewportPaging_withAnOnScreenSnapPosition_advancesAWholeViewport  expected:<-[3]00> but was:<-[1]00>
```

`-2147483648` is the harness's "not drawn": after two viewport pages the sixth
cell was nowhere near the snap position, because each page had only moved one
cell.

Two of the new `ViewPagerTest` cases passed with the old code and are reported
rather than hidden: `viewportPaging_withACellLargerThanTheViewport_
advancesThatOneCell` and `viewportPaging_atTheFirstCellWithoutCircularScroll_
staysOnTheFirstCell`. Both modes agree in those two situations by construction
— an oversized cell is one page either way, and there is nothing before the
first cell to page to — so they pin behaviour that must not regress rather than
behaviour this PR introduces. They are the same two situations as the
instrumented pair below.

**Unit — attribute selection, 9 failures**

```
HorizontalListViewTest.viewPagerIntervalOfZeroInXml_isReadAsViewportPaging          expected:<[0]> but was:<[1]>
HorizontalListViewTest.theViewportConstantInXml_readsAsTheSameValueAsALiteralZero   expected:<[0]> but was:<[1]>
HorizontalListViewTest.aNegativeViewPagerIntervalInXml_isReadAsViewportPaging       expected:<[0]> but was:<[1]>
HorizontalListViewTest.listViewAttributesAbsentFromAnAttributeSet_
        fallBackToTheDefaultsWithOnScreenSnap                                       expected:<[0]> but was:<[1]>
HorizontalListViewTest.listViewAttributesWithoutAnAttributeSet_
        fallBackToTheDefaultsWithCenterSnap                                         expected:<[0]> but was:<[1]>
ListViewViewPagerIntervalTest.noIntervalInXml_makesOneGestureAdvanceAWholeViewport
                                                                                    expected:<-[3]00> but was:<-[1]00>
ListViewViewPagerIntervalTest.anIntervalOfZeroInXml_makesOneGestureAdvanceAWholeViewport
                                                                                    expected:<-[3]00> but was:<-[1]00>
ListViewViewPagerIntervalTest.theViewportConstantInXml_makesOneGestureAdvanceAWholeViewport
                                                                                    expected:<-[3]00> but was:<-[1]00>
ListViewViewPagerIntervalTest.aNegativeIntervalInXml_makesOneGestureAdvanceAWholeViewport
                                                                                    expected:<-[3]00> but was:<-[1]00>
```

**Unit — group cells, 2 failures**

```
GridLayoutManagerTest.viewportPaging_onAGrid_advancesEveryWholeGroupThatFits
                                                                  expected:<-[22]0> but was:<-[11]0>
GridPatternLayoutManagerTest.viewportPaging_onAGridPattern_
        advancesEveryWholePatternGroupThatFits                    expected:<-[46]5> but was:<-[15]5>
```

**Instrumented — production change reverted on the working tree, tests left
alone, run on `emulator-5554`**

9 of the 11 then-new `ViewPagerViewportInstrumentedTest` cases failed:

```
aFlingWithThreeCellsVisible_advancesAllThreeOfThem
        AssertionError: one fling should bring the fourth cell to the top
aFlingBack_returnsTheWholeViewportItCameOver
        AssertionError: the forward fling should have paged a viewport
cellsThatDoNotDivideTheViewport_leaveThePartialCellForTheNextPage
        AssertionError: the third cell should come to the top
cellsOfUnequalSize_advanceByTheCellsThatFitWhole
        AssertionError: the fifth cell should come to the top
aPartialPageAtTheEnd_advancesOnlyAsFarAsTheLastCell
        AssertionError: the first page should be the three cells that fit
pagingForwardAtTheLastCell_holdsTheLastCellOnTheSnapPosition
        AssertionError: paging to the end should rest the last cell on the snap position
viewportPagingWithPadding_fitsTheCellsInsideThePaddingOnly
        AssertionError: only two cells fit inside the padding, so the third comes to the top
viewportPagingInAHorizontalList_advancesAWholeViewport
        AssertionError: one fling should bring the fourth cell to the start
circularViewportPaging_pastTheLastCell_keepsAdvancing
        AssertionError: the first page should reach the last cell
```

and all four selection cases in `ViewPagerIntervalInstrumentedTest`:

```
anIntervalOfZeroInXml_pagesByTheWholeViewport
noIntervalInXml_pagesByTheWholeViewport
theViewportConstantInXml_pagesByTheWholeViewport
aNegativeIntervalInXml_pagesByTheWholeViewport
        AssertionError: the page should be the whole run of cells that fit
```

The two that still passed with the change reverted are
`aCellTallerThanTheViewport_advancesExactlyThatOneCell` and
`pagingBackAtTheFirstCell_holdsTheFirstCellOnTheSnapPosition`, for the same
structural reason as their unit counterparts.

### Tests that failed against the first version of the fit test

The review below found that the walk measured the viewport from the anchor's
own start rather than from where the anchor settles. These are the cases that
were red against that first version and green after `maximumPageSize` replaced
it — captured by reverting just that one expression:

```
viewportPaging_withAnEndSnapPosition_advancesOnlyTheCellsFullyVisible
                                                                  expected:<-[1]00> but was:<-[3]00>
viewportPaging_withACentreSnapPosition_advancesOnlyTheCellsFullyVisible
                                                                  expected:<-[2]00> but was:<-[3]00>
viewportPaging_fromARestPartWayThroughACell_leavesNoCellUnshown
                                                                  expected:<-[2]00> but was:<-[3]00>
```

### What the tests cover

Viewport mode, unit (`ViewPagerTest`, `GridLayoutManagerTest`,
`GridPatternLayoutManagerTest`): cells that fit the viewport exactly; cells that
do not divide it, leaving a partial cell; cells of unequal size; a cell larger
than the viewport; cell spacing; the first and last cell without circular
scroll, where it clamps and then asks for no movement; a short final page;
paging back; a page back over cells no longer drawn, pinning the extrapolation
as a limitation; circular scroll forward past the end and back from the start,
each landing a named cell; `android:padding`, where the fit must use the size
inside it; both orientations; all four snap positions, including `center` and
`end` where the anchor does not sit at the viewport edge, and `onScreen` from a
rest part-way through a cell; and `GridView` and `GridPatternView`, where a cell
is a whole group — the pattern twice, once with groups of equal height and once
with groups whose heights differ, where the page is the sum of two spans the
test first proves are different.

Selection, unit and instrumented: attribute absent, `0`, `viewport`, `1`, `2`
and `4`, and negative — through the attribute getters, through a real
`TypedArray`, and through a real fling.

### Probes

- **Does aapt2 accept `format="integer"` with an `<enum>` child, and what value
  does the name resolve to?** Unproven until run, so it was run rather than
  assumed from how `layout_width` is declared. It compiles on both the
  Robolectric resource path and the real AGP/aapt2 androidTest path.
  `theViewportConstantInXml_resolvesToZeroBeforeAnyClampSeesIt` reads the raw
  `TypedArray` value with a sentinel default and asserts exactly `0`, and
  `anAbsentViewPagerIntervalInXml_isNotPresentInTheTypedArrayAtAll` shows the
  sentinel comes back when the attribute is absent, so the first test is
  reading a real entry and not a default. Both kept.
- **Is `parchment_snapPosition` really dead on a circular view?** No — and this
  disproved a premise I started from. See below.
- **Does the existing over-draw clamp handle a viewport page that overshoots
  the adapter's end?** Yes, pinned by
  `viewportPaging_withAPartialPageLeftAtTheEnd_advancesOnlyAsFarAsTheLastCell`
  and `viewportPaging_atTheLastCellWithoutCircularScroll_asksForNoMovement`.

### `parchment_snapPosition` is not dead on a circular view

An earlier commit on this branch removed `parchment_snapPosition="start"` from
`sample/.../activity_simple_view_pager.xml`, on the grounds that
`LayoutManager.getSnapPosition` answers `onScreen` whatever the attribute says
once `parchment_isCircularScroll` is on. **That commit has been reverted**: the
premise is false and I had not tested it.

`getSnapPosition(isCircularScroll)` only chooses which `SnapPositionInterface`
places cells. `getSnapDistanceToNearestView` reads the **declared** attribute
and returns null for `onScreen`, and that is the only gate on
`LayoutManager.snapTo` besides `parchment_snapToPosition`, which that demo sets.
So the attribute does not decide *where* a cell settles on a circular view, but
it does decide *whether the settle runs at all*. `CircularScrollSnapPositionTest`
is the new proof: with `start` declared, a cell dragged 50px off the boundary
snaps back by 50; with the attribute absent it stays where the finger left it.

Removing the line would therefore have silently disabled the demo's settle, so
it stays. No other layout in the repo pairs the two attributes except
`library/src/test/res/layout/attribute_parsing_list_view.xml`, which is an
attribute-parsing fixture and correct as it stands.

## Independent review

A fresh agent reviewed the branch adversarially against `CONTRIBUTING.md` and
returned 32 findings. The two that mattered are both fixed and both are in this
description: the fit test measuring from the anchor's own start instead of the
viewport edge, with a worked counterexample under the XML-default `onScreen`
snap; and the sample commit's false premise above. The rest drove the `end`,
`center` and mid-cell-rest cases, the backward-extrapolation test, the pattern
groups of differing heights, making the pattern expectation independent of
measured layout, reading the interval once instead of three times, and removing
narration comments from the new instrumented tests.

Findings deliberately not acted on:

- The stale `// Todo: consider padding for newSize` in `LayoutManager.layout`.
  It is owned by the in-flight branch `chore/drop-stale-padding-todo`; removing
  it here would collide.
- Neither page distance is clamped to be non-negative. The reviewer could not
  construct a settled layout that produces a negative one, and interval mode —
  already on this branch — has exactly the same shape, so this is pre-existing
  rather than introduced here. Listed as follow-up.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Not verified here

- CI's API 35 emulator. Locally the instrumented suite ran on an API 36
  emulator only. A Pixel 8 (`43301FDJH003CZ`) was attached when this work
  started and dropped off adb before the suite could be pinned to it;
  `adb kill-server` and `adb start-server` did not bring it back, so the
  instrumented results here are from one device, not two.
- Behaviour with a zero-sized cell. The walk's "is there a further cell" guard
  covers a zero-size step, but it is not tested because `layoutCells` already
  loops forever on zero-sized cells independently of this change.

## Follow-up this exposed

- The first layout computes its offset from the full view size while every
  later snap uses the size inside the padding, so `center` and `end` rest
  slightly off inside a padded view until the first gesture. Older than this
  branch.
- `getViewPagerScrollDistance` can in principle answer with a negative page
  distance at the adapter's end when the anchor is not settled, in both paging
  modes. No reproduction yet.
- `sample/.../MenuActivity.java` uses lambdas, which `CONTRIBUTING.md` forbids
  in library, sample and test code alike.

---

# Follow-up round: one method, one flow, and per-method coverage

Four further commits. No behaviour change: this round is a refactor, a written
rule, and tests.

| | |
|---|---|
| `Dispatch each paging mode to a method that does only that` | the refactor |
| `Write down the one method, one flow rule` | `CONTRIBUTING.md` |
| `Test each paging method on its own, and prove it by mutation` | `LayoutManagerPagingMethodsTest` |
| `Close the gaps an independent review found in the paging tests` | review fixes |

## The refactor

`getPageCellIndexForward` and `getPageCellIndexBack` each held **both** paging
algorithms: an early return that counted cells, with the viewport walk falling
through underneath it. Reading either meant working out where one algorithm
ended and the other began, and neither could be exercised without going through
the other.

Each direction is now a dispatcher of a condition and two calls:

```java
long getPageCellIndexForward(
        final int viewPagerInterval,
        final int maximumPageSize,
        final int anchorIndex,
        final int anchorStart) {
    if (pagesByCellCount(viewPagerInterval)) {
        return getPageCellIndexForwardByCellCount(viewPagerInterval, anchorIndex);
    }
    return getPageCellIndexForwardByViewport(maximumPageSize, anchorIndex, anchorStart);
}
```

The names say which algorithm they are — `ByCellCount`, `ByViewport` — not
which branch they came from.

`getCellStartAtIndex` had the same shape with three flows, so its two
extrapolations moved out to `getCellStartExtrapolatedBeforeFirst` and
`getCellStartExtrapolatedAfterLast`, leaving the dispatcher the two boundary
tests and the in-range lookup.

**The other helpers were deliberately left alone.** `pagesByCellCount`,
`pageFits`, `getSnapDisplacement`, `setViewPageDistances` and the two join
predicates each run one flow behind a guard clause. A guard clause is not a
second algorithm, and splitting them would add indirection where there is only
one flow.

One difference is worth naming: `getCellSpacing()` is no longer called on
`getCellStartAtIndex`'s in-range path, because it moved into the two
extrapolation methods that actually use it. It is a pure attribute getter with
no override anywhere in `library/src/main` or `sample`, so nothing is
observable.

## Why the visibility changed

These methods, and the `mViewPageDistanceForward` / `mViewPageDistanceBack`
fields, widen from `private` to **package-private** so the unit tests — which
sit in the same package, `mobi.parchment.widget.adapterview` — can exercise each
one directly rather than through a whole gesture. Nothing becomes `public`, and
no annotation was added to justify it. The fields are read *and written* by
`setViewPageDistances_whenTheViewIsNotAViewPager_leavesTheDistancesAlone`, which
seeds them with values nothing would measure so it can tell "left alone" from
"set to zero"; a read-only accessor pair would not support that.

## The rule, written down

`CONTRIBUTING.md` → "Shape of the code" gains **One method, one flow**, in the
voice of the entries around it: when a method would hold two algorithms chosen
by a condition, the condition dispatches to two named methods that each do one
thing and the dispatcher does nothing else — never an early return with the
second algorithm falling through underneath it. A guard clause is not an
algorithm; do not invent indirection where there is only one flow.

## Per-method coverage

`library/src/test/java/mobi/parchment/widget/adapterview/LayoutManagerPagingMethodsTest.java`
— 129 tests. `ViewPagerTest` drives whole gestures, so a method could be wrong
in a way another method's behaviour hid. These exercise each method directly,
including states a gesture cannot easily be driven into.

**Dispatch:** interval 0, 1, 2, larger than the adapter, `Integer.MAX_VALUE`,
negative, `Integer.MIN_VALUE`; the boundary that selects each mode (0 →
viewport, 1 → counting), asserted as concrete differing landing indices rather
than by comparing the dispatcher against the method it calls.

**Cell-count flow:** anchor at the first cell, in the middle, at the last cell;
a target beyond the adapter end and before its start, with and without circular
scroll; an interval larger than the adapter; `Integer.MAX_VALUE` and
`Integer.MIN_VALUE` intervals asserted against the exact `long` result *and*
against the sign, which is what int arithmetic would get wrong.

**Viewport flow:** a single-cell adapter; a cell larger than the viewport; a
page that fits exactly and one that misses by a single pixel, on both the
forward and the backward walk; zero and non-zero cell spacing; unequal cell
sizes; padding; the anchor resting part-way through a cell; zero and negative
`maximumPageSize`; circular scroll walking past both adapter ends; both
orientations; and an anchor near the adapter end, where the cap freezes the
extrapolated starts and the further-cell guard is what ends the walk.

**`pageFits`:** the inclusive boundary in both directions and one pixel either
side; a negative page size; a negative maximum; spacing wider than the gap;
the whole drawable range (±`Integer.MAX_VALUE / 2`); and starts beyond the int
range, which pins the `long` parameters.

**Join predicates:** no further cell because the next start equals the current
one, and because it is on the wrong side (including a wrong-side cell that
would otherwise fit, so the guard is shown to win over the fit); a further cell
that fits, that fits exactly, and that does not.

**`getCellStartAtIndex`:** inside the drawn cells; past them; at the last
adapter cell; one past and far past the end; one before and far before the
start; with spacing; under circular scroll in both directions, including that
the **index itself is not wrapped** — it keeps counting, and the wrap happens
only when cells are fetched, so no wrapped position reaches the adapter; and
far enough out to hit the ±`Integer.MAX_VALUE / 2` drawable clamp.

**`getSnapDisplacement`:** a cell with a view, off the snap so the expected
value is non-zero, under `start`, `centre` and `end` snap positions; and a cell
whose view is null — reached through a `Group` with no views, and through a
`Group` of zero-sized views, which is the *reachable* production route because
`Group.getWidestView` requires `width > 0` strictly and so answers `null` for a
group of zero-width views.

**`setViewPageDistances`:** not a view pager; viewport paging; cell-count
paging; padding; an anchor part-way through a cell; a size the padding has
eaten away to negative; and `centre` and `end` snap positions, where the page
room genuinely differs from the whole viewport.

## How coverage was proved

**No test could fail before this change** — it is a pure refactor, and none of
the 207 tests already on this branch was edited to accommodate the new shape.
So coverage is shown by mutation instead: **31 small changes to the extracted
methods, every one caught by at least one named test, 0 survivors.** Three
mutants are caught by *non-termination* rather than a wrong answer, which is
itself the finding that the further-cell guard and the carried page-cell start
are what make the walks terminate at the adapter's ends.

The set did not start adequate, and saying so is the point:

| Mutation | Why it survived | What kills it now |
|---|---|---|
| `maximumPageSize = viewportEnd` | every `setViewPageDistances` case used a `start` snap, where the anchor's snapped start is 0 | `..._withACentreSnapPosition_...`, `..._withAnEndSnapPosition_...` |
| drop `+ cellSpacing` from the before-first step | every test reaching that branch had zero spacing, zero steps, or a clamped result | `getCellStartExtrapolatedBeforeFirst_withCellSpacing_stepsBackBySizeAndSpacing` |
| drop `pageCellStart = nextCellStart` | no forward case advanced more than once before the cap froze the starts | `forwardByViewport_walkingIntoTheAdapterEnd_stopsWhenTheCapFreezesTheCellStarts` |
| drop `getStartSizePadding()` from `viewportEnd` | the only padded case had 60px of slack either side of its decision | `setViewPageDistances_withViewportPadding_startsTheViewportAtThePaddingNotAtZero` |
| hand the walk `anchorSnappedStart` | the two are equal in every earlier case, and equal cells hid the difference | `setViewPageDistances_fromAnAnchorPartWayThroughACell_countsFromWhereItSitsNow` |

The first was found by the author; the next three by the independent review;
the last while widening the set.

The mutation harness is a scratch script, not committed — the repo gains no
mutation-testing dependency.

### A harness bug worth recording

The first mutation run reported all 31 mutants as "survived" with **0 tests
run**: the runner shelled out in a way that never actually started Gradle, and
counted an empty result as a pass. That is the unit-test twin of the trap in
the house rules about `connectedDebugAndroidTest` reporting success having run
nothing. The harness now aborts outright if a run produces zero tests.

## Independent review

Reviewed adversarially by a fresh agent against the house rules, read-only.
It confirmed the refactor is behaviour-preserving line by line, and found the
three surviving mutations above plus five tests whose names promised more than
their bodies pinned. **Every finding was acted on:**

- the three surviving mutations — new tests, above;
- `paddingLargerThanTheViewport…` asserted only a relation between two
  constants the harness was handed; it now asserts the page distance the
  negative size actually produces;
- the not-a-view-pager test could not tell "left alone" from "set to zero"; it
  now seeds both fields first;
- `…forACellOfZeroSizedViews_isZeroRatherThanACrash` reached the same null
  guard as the test above it; renamed to say what it proves;
- two `getCellStartAtIndex` names claimed the extrapolation branch though their
  assertions hold either way; renamed;
- one test was a byte-identical duplicate of another and is gone;
- an assertion about two compile-time constants, removed.

Not acted on, with reasons:

- **`anchorIndex + ONE_CELL` in the viewport walks is int, not long.** True, and
  it would wrap for an anchor index near `Integer.MAX_VALUE`. Production cannot
  reach it: `anchorIndex` comes from `getNearestCellIndexToSnapPosition`, which
  returns an index into `mCells`. Changing it would be a behaviour change in a
  pure-refactor commit. Listed as follow-up instead. Note the `long` arithmetic
  the commit message claims is in the `ByCellCount` pair, which is where the
  attribute-supplied interval is added, and that *is* tested.
- **`getCellStartExtrapolatedAfterLast` recomputes `lastCellIndex`.** Passing it
  in would add a parameter to keep the dispatcher trivial; recomputing keeps the
  method readable on its own.

## Edge cases tested but **not reachable in production**

Recorded because the methods now have package-private contracts of their own:

- **A negative interval reaching the dispatch.** `pagesByCellCount(-2)` answers
  `true`, so a negative would select *counting* and count backwards. It cannot
  arrive: `LayoutManagerAttributes` clamps with `Math.max(viewPagerInterval, 0)`,
  which `aNegativeAttributeInterval_isClampedToViewportPagingBeforeTheDispatchSeesIt`
  and `theMostNegativeAttributeInterval_…` prove. The dispatch tests pin the raw
  method contract; the clamp tests pin that production never exercises it.
- **`Integer.MIN_VALUE` as an interval.** Same clamp.
- **`getCellStartAtIndex(Long.MIN_VALUE)`.** `-cellIndex` would overflow. The
  only producers are `anchorIndex ± interval` (both ints) and the walks, which
  step by one from an int seed, so the value cannot occur. Not tested, because a
  test asserting overflowed arithmetic documents nothing.
- **`pageFits` with starts beyond the int range.** Tested, to pin the `long`
  parameters, but `getCellStartAtIndex` clamps every real start to
  ±`Integer.MAX_VALUE / 2`.

Reachable and tested, contrary to what the earlier revision of this PR
recorded as unverifiable:

- **A negative `maximumPageSize`.** `layout` computes
  `newSize = size - startPadding - endPadding` with no clamp, so padding wider
  than the view makes it negative. The page then advances exactly one cell
  rather than misbehaving, pinned by
  `paddingLargerThanTheViewport_leavesANegativePageRoomAndStillAdvancesOneCell`,
  which lays out a 100px viewport with 100px of padding each side and reads the
  distance the real `layout` path produced.

## No `CHANGELOG.md` entry

Deliberate. Nothing user-visible changed: no attribute, no public method, no
behaviour. None of Added / Changed / Fixed / Removed fits an internal refactor,
and the `[Unreleased]` section holds only consumer-facing entries. Said here
rather than left silent.

## Instrumented run: an emulator failure worth recording

The first full instrumented run reported **`BUILD FAILED` with 5 failures out of
57 tests** — and the 57 is itself the tell, because the suite has 78. All five
were in `ViewPagerIntervalInstrumentedTest` and all five said the gesture had
moved nothing.

They were not caused by this change. After that run,
`adb shell service check package` answered **`not found`**: the emulator had
degraded mid-run, exactly the state the house rules describe. Following the
documented recovery — kill the emulator and every `adb.exe`, restart the adb
server, relaunch the AVD detached, wait for both `sys.boot_completed` = 1 and
`service check package` = found — re-running
`anIntervalOfZeroInXml_pagesByTheWholeViewport` on the healthy device passed it,
and the full suite was then re-run from scratch: **78 tests, 0 failures, 0
errors.**

The timings settle it beyond doubt. On the degraded emulator single tests took
40–110 seconds each (`aGridViewportFling_advancesEveryWholeRowThatFits`: 56s;
`viewPagerTurnedOffInXml_letsTheSameFlingRunPastOnePage`: 110s) and the run
burned 77 minutes before dying at 57 of 78. On the healthy one the **entire
suite** takes 86.5 seconds, slowest test 3.9 seconds. The gestures were not
failing on their merits; the device was too slow to deliver them.

Worth noting for the next agent: the background-task notification for that
failing run reported **exit code 0** while the Gradle log said `BUILD FAILED`.
Parsing `library/build/outputs/androidTest-results/connected/**/*.xml` is the
only thing that told the truth, in both directions.

Refs #26

---

# Follow-up round: paging modes become a strategy package, and no declaration is left bare

The previous round split the two paging algorithms into separate methods, which
was right, and made them **package-private** so the unit tests could reach them.
That left `LayoutManager` with fourteen declarations carrying no access keyword
at all, beside `private int getDrawableCellStart(...)` and
`public int getViewPagerScrollDistance(...)`, where they read as omissions.
Needing to weaken visibility to test something is the signal that the logic
wants to live somewhere else. It now does.

## First, a correction to the brief

This round was asked for on the premise that the library had **zero**
package-private members on `main` and that the previous refactor invented the
category. That is not true, and repeating it would have been the easy thing to
do. Counting every declaration with no explicit `public`/`protected`/`private`
under `library/src/main` — members, nested-class members and constructors:

| tree | bare declarations |
|---|---|
| `main` (4c2b7c7) | **7** |
| this branch at 1416ac5 (before this round) | **24** |
| this branch now | **0** |

The seven on `main` are `AdapterAnimator.setState`, `Animation.setId`,
`Animation.setDisplacement`, `Animation.newAnimation`,
`AnimationFrameScheduler.requestAnimationFrame()`, the three-argument
`LayoutManagerState` constructor, and the constructor of
`AbstractAdapterView.AnimationFrameRunnable` — which is the class `CONTRIBUTING`
holds up as *the* pattern for a named callback. So the category was already in
use; the previous round enlarged it from 7 to 24. This round clears all of them,
so the rule holds over the whole source set rather than only over the code this
PR touched.

The last two of those seven were found late, by an independent review and by a
bytecode check respectively, after a first source scanner reported a confident
and wrong "zero" — it only looked at outermost class bodies, so it missed
members of nested classes, and it had no pattern for constructors, which carry
no return type. Both checks are described under *How "no bare declarations" was
verified* below.

## The shape it moved to

`pageinterval/`, one package over from `snapposition/`:

```
pageinterval/
  PageIntervalInterface<Cell>   which cell index does a page land on, forward and back
  CellCountPageInterval<Cell>   answers by counting N cells from the anchor
  ViewportPageInterval<Cell>    answers by walking while the page still fits
  PageIntervalSelector          reads the interval once and picks between them
```

`LayoutManager` holds the answer as `mPageIntervalInterface`, chosen in its
constructor on the line after `mSnapPositionInterface`, and
`setViewPageDistances` asks it for the two cell indices instead of branching.

### Why those names

`snapposition` is named for the attribute it implements, `parchment_snapPosition`,
and its types read as "center snap position", "end snap position". `pageinterval`
is named for `parchment_viewPagerInterval` the same way, and `viewport` is
literally one of that attribute's values, so `ViewportPageInterval` takes its
name from the public vocabulary rather than from the algorithm.
`CellCountPageInterval` / `ViewportPageInterval` read as
`CenterSnapPosition` / `EndSnapPosition` do. No name contains `Utils` or
`Helper`.

### The one place it deliberately differs from `snapposition/`

For snapping, the switch that turns a `SnapPosition` into a strategy is a
`private` method on `LayoutManager`. Here it is a `public static` factory,
`PageIntervalSelector`. That is on purpose: the interval is an `int`, not an
enum, so "0 means viewport" is a rule about what an interval *means* and belongs
with the interval types; and keeping it reachable is what lets the twelve
existing dispatch tests keep exercising the **production** selection.

The independent review argued the opposite — that a final class with a private
constructor and two public statics is a utils bag with a better haircut, and
that the asymmetry undercuts the claim that the two packages are the same shape.
That is a fair call and it is recorded here rather than argued away. It was not
taken because making the selector private would force
`getPageCellIndexForward_withAnIntervalOfTwo_countsTwoCells` and its eleven
siblings to choose the strategy themselves, and they would then pass with the
dispatch deleted. The docs no longer claim the packages are identical; they name
this as the one difference.

### Which methods take only scalars

`pageFits`, `nextCellJoinsThePage` and `previousCellJoinsThePage` need no
collaborator once the cell spacing is a parameter, so they are `public static`
with parameters only — the `ViewGroupUtilities` pattern applied inside the
strategy that uses them. The walk reads the spacing once per call instead of
once per loop iteration.

### What stayed on `LayoutManager`

`getCellStartAtIndex` and its two extrapolations know about the drawn cells and
about circular wrapping, so they stayed. The strategies reach the cell run only
through `getCellStartAtIndex`; `mCells` is untouched.

## Visibility: the rule narrows more than it widens

An earlier draft of this branch answered "every declaration needs a modifier" with
`public` everywhere, which the independent review correctly called out: it turned
`mViewPageDistanceForward` / `Back` into public mutable `int` fields on a public
abstract class, purely because a test writes them. **`protected` carries package
access in Java**, so it is an explicit modifier that keeps the same-package tests
working without adding anything to the API. The final state:

| Declaration | Before | After | Why |
|---|---|---|---|
| `LayoutManager.getCellStartAtIndex` | package-private | `public` | the viewport walk calls it from another package |
| `LayoutManager.getCellSpacing` | `protected` | `public` | same; sits beside the already-public `getStartSizePadding`, `getCellSize`, `getCellCenter` |
| `LayoutManager.setViewPageDistances` | package-private | `protected` | called by `layout`, pinned by ten tests |
| `LayoutManager.getSnapDisplacement` | package-private | `protected` | pinned by six tests |
| `LayoutManager.getCellStartExtrapolated{BeforeFirst,AfterLast}` | package-private | `protected` | pinned by four tests |
| `LayoutManager.mViewPageDistance{Forward,Back}` | package-private | `protected` | written by one test to tell "left alone" from "set to zero" |
| `Animation.setDisplacement`, `newAnimation` | package-private | `protected` | called by `AdapterAnimator` and across the test suite |
| `LayoutManagerState(Parcelable,int,int)` | package-private | `protected` | called by `LayoutManager` |
| `AdapterAnimator.setState` | package-private | `private` | all thirteen callers are inside `AdapterAnimator` |
| `AbstractAdapterView.AnimationFrameRunnable(...)` | package-private | `private` | its class is already `private static final` |
| `AnimationFrameScheduler.requestAnimationFrame` | bare | `public` | `protected` is illegal in an interface; matches `SnapPositionInterface` |
| `Animation.setId` | package-private | **deleted** | no caller in `library` or `sample` |

**Exactly two widenings**, `getCellStartAtIndex` and `getCellSpacing`, and both
are forced by the move to another package. Nothing else became API. No effective
access changed for a consumer: a package-private member was never callable from
outside its package.

`LayoutManagerAttributes`' nine fields are now `final`. The new design reads
`parchment_viewPagerInterval` once at construction, and that was safe only by
convention; `final` makes the type say it.

## Behaviour is unchanged

- **336 JVM unit tests before, 338 after** (the two added below), 0 failures. No
  test deleted, disabled or weakened.
- ****156 instrumented results, 0 failures** — the suite of 78 on each of
  `emulator-5554` (API 36 phone) and `emulator-5556` (API 35 tablet), with
  `ANDROID_SERIAL` unset so it runs on both. 156 is 78 x 2, which is the check
  that matters: see *Not verified here* for the run where it was not.**
- `ViewPagerTest` and `ListViewViewPagerIntervalTest` are **untouched by this
  diff** and still pass; they are the end-to-end evidence that paging behaviour
  did not move.

The independent review checked the four ways this restructure could have changed
behaviour and found none of them did: the interval cannot change after
construction (no setter anywhere, `getViewPagerInterval` overridden nowhere, and
the three views pass it in at construction); the hoisted `cellSpacing` is the
same value the old code read on every iteration (`getCellSpacing` is overridden
nowhere); the `int`/`long` promotions and the `±Integer.MAX_VALUE/2` clamp are
bit-identical; and both walks stop on the same conditions in the same order.

## The tests that reached the old package-private methods

They construct a strategy and call its public methods now:

| Old call | New call |
|---|---|
| `LayoutManager.pagesByCellCount(i)` | `PageIntervalSelector.pagesByCellCount(i)` |
| `manager.getPageCellIndexForward(i, ...)` | `PageIntervalSelector.getPageIntervalInterface(i).getPageCellIndexForward(manager, ...)` |
| `LayoutManager.getPageCellIndexForwardByCellCount(i, a)` | `new CellCountPageInterval<View>(i).getPageCellIndexForward(NO_LAYOUT_MANAGER, ...)` |
| `manager.getPageCellIndexForwardByViewport(...)` | `new ViewportPageInterval<View>().getPageCellIndexForward(manager, ...)` |
| `manager.pageFits(max, start, limit)` | `ViewportPageInterval.pageFits(max, spacing, start, limit)` |

Two things got *stronger*:

- The cell-count tests pass `NO_LAYOUT_MANAGER` (null) and pass, which proves
  that mode answers from the interval alone and touches no cell. If anyone makes
  it read the manager, they fail with an NPE rather than quietly asserting a
  wrong number. The old `...ByCellCount` methods were `static` and took no
  manager either, so nothing is lost.
- The `pageFits` and join-predicate tests state the cell spacing at the call site
  instead of having it arrive invisibly through whichever manager the test
  happened to build. Twenty-three `final LayoutManager<View> manager = ...`
  locals became unused and were removed.

## Two new tests, and the hole they close

A pure restructure cannot have a failing test first, so coverage is shown by
mutation. **The first run found a survivor, and it was a real hole this
restructure opened.**

Cell spacing used to be fetched *inside* `pageFits` via
`LayoutManager.getCellSpacing()`; it is now passed in by the walk. Replacing
`final int cellSpacing = layoutManager.getCellSpacing();` with
`final int cellSpacing = 0;` left **every test green**. The two pre-existing
tests whose names promise that coverage —
`forwardByViewport_withCellSpacing_countsTheSpacingThatComesWithEachCell` and its
`backByViewport_` twin — do not discriminate: with cells of 100 and spacing of
10, at a page size of 300 they answer the same whether the spacing is 10 or 0.

So there was no test proving the walk reads the manager's cell spacing — not
before this change either. There are now two, which pick a page size where the
spacing decides:

```
forwardByViewport_withAPageThatOnlyFitsBecauseTheSpacingIsNotPartOfIt_takesIt
backByViewport_withAPageThatOnlyFitsBecauseTheSpacingIsNotPartOfIt_takesIt
```

With starts at 0 / 110 / 220 / 330 and a page size of 210, `pageFits` measures
`220 - 10 - 0 = 210 ≤ 210` and the walk takes the third cell; drop the spacing
and it is `220 > 210`, so it stops one cell short. The back walk mirrors it.
Each fails against its own mutant and against nothing else.

## Mutation coverage of the moved code

15 mutations, **0 survivors**, against the 6 test classes that cover paging
(206 tests):

| Mutation | Caught by |
|---|---|
| cell count forward: advance one cell too far | 32 red, incl. `GridLayoutManagerTest.viewPagerGesture_onAGrid_advancesOneWholeGroup` |
| cell count back: retreat one cell too far | 13 red, incl. `backByCellCount_fromACellInTheMiddle_subtractsTheInterval` |
| viewport forward: start the walk on the anchor itself | 8 red, incl. `forwardByViewport_withASingleCellAdapter_findsNoFurtherCell` |
| viewport back: start the walk on the anchor itself | 5 red, incl. `backByViewport_atTheFirstCellWithoutCircularScroll_findsNoFurtherCell` |
| next cell joins: accept a cell that is not further on | **non-termination** |
| previous cell joins: accept a cell that is not further back | **non-termination** |
| viewport forward: drop the carried page cell start | **non-termination** |
| page fits: reject a page that measures exactly the maximum | 39 red |
| page fits: stop taking the cell spacing off the end | 4 red, incl. both new tests |
| viewport forward: stop reading the cell spacing off the manager | **1 red: the new forward test, alone** |
| viewport back: stop reading the cell spacing off the manager | **1 red: the new back test, alone** |
| selector: invert which interval means viewport paging | 79 red |
| selector: hand back the viewport walk for a cell count interval | 30 red |
| layout manager: hand the strategies the unsnapped anchor start | 1 red: `setViewPageDistances_fromAnAnchorPartWayThroughACell_countsFromWhereItSitsNow` |
| layout manager: stop holding the strategy, always count by one | 35 red |

The three non-terminating mutants are the finding, not a nuisance: the
further-cell guard and the carried page-cell start are what make the walks
terminate, so removing one hangs the suite rather than answering wrongly.

### The harness, and the three ways it refuses to lie

The previous round recorded a harness that reported every mutant surviving while
running zero tests. This one **aborts** if a run produces no result files, and
**aborts** if a run's test count is not the baseline's. Both fired for real:

1. The first attempt could not find `./gradlew.bat` by a relative path on
   Windows, produced no results, and the harness stopped instead of reporting
   fifteen survivors.
2. `subprocess.run(capture_output=True, timeout=...)` **deadlocks** on Windows
   when the timeout kills the launcher but a spinning Gradle worker still holds
   the inherited pipe handle. The first non-terminating mutant hung the harness
   for ten minutes with the worker at 100% CPU. Writing to `DEVNULL` instead
   fixed it; a run that exceeds 150s is now recorded as *caught by
   non-termination* and its worker killed by name.

The harness is a scratch script, not committed: the repo gains no
mutation-testing dependency.

## How "no bare declarations" was verified

Two independent checks, because the first answer was wrong:

1. **Source scan** of all 49 files under `library/src/main/java`, tracking a
   stack of scope kinds so members of nested classes and constructors are judged
   too: **`TOTAL_BARE=0`**. The same scanner reports 7 on `main` and 24 on
   1416ac5.
2. **Bytecode scan**, `javap -p` over the 61 classes of the release build:
   **764 members checked, 0 with no access flag.** This is what caught the
   `AnimationFrameRunnable` constructor after the first source scanner missed it.

The bytecode scan also lists six `$N` classes. Three are compiler-generated
`$SwitchMap` holders; the other three are hand-written anonymous classes
(`AbstractAdapterView`'s `DataSetObserver`, `LayoutManager`'s `Runnable`,
`LayoutManagerState`'s `Parcelable.Creator`). Those violate "no anonymous
methods", they are all pre-existing on `main`, and this change does not touch
them — see follow-ups.

## Docs

- `docs/architecture.md` describes `pageinterval/` where it describes
  `snapposition/`, names the one way the two differ, and the "Where to look" row
  for a ViewPager gesture points at the package.
- `CONTRIBUTING.md`'s layout-engine rules gain the paging rule beside the snap
  rule.
- `CONTRIBUTING.md`'s **One method, one flow** example was
  `long getPageCellIndexForward(...)` — a method this round deletes, printed with
  no access modifier, so the style guide was displaying the very shape being
  removed. It is now `PageIntervalSelector.getPageIntervalInterface`, and the
  prose above it now says "two named things … two methods, or two strategies",
  because the new example dispatches to strategies rather than methods.

Four claims written in the first draft of these docs were wrong and were
corrected after review: that both strategies call back into `LayoutManager`
(only `ViewportPageInterval` does — `CellCountPageInterval` ignores its
`layoutManager` argument entirely); that neither holds state
(`CellCountPageInterval` holds the interval, immutably); that the change removes
a per-frame branch (nothing branched per frame — `setViewPageDistances` runs once
per gesture, on a new animation id); and that `PageIntervalSelector` reads the
attribute (it is handed an `int`; `LayoutManager`'s constructor does the
reading).

## A `CHANGELOG.md` entry, unlike last round

The previous round recorded "No `CHANGELOG.md` entry — deliberate". This round
gets one, under `### Changed`: it adds a package with four public types to the
library's namespace, and both `docs/architecture.md` and `CONTRIBUTING.md` now
name it as the extension point for a new paging mode. For the record, the
previous round's supporting claim — that `[Unreleased]` "holds only
consumer-facing entries" — is not accurate; it already documents Spotless, the
SPDX headers, the workflows, `CONTRIBUTING.md` and `scripts/ci_local.sh`.

## Independent review

Reviewed adversarially by a fresh agent against the house rules, read-only, on
the full diff. It returned **15 findings** and cleared the behaviour-preservation
question on all four axes it was asked to attack. Acted on:

- **public → protected** for the eight declarations that only the package needs,
  including the two page-distance fields (finding 1, the most serious).
- **`AbstractAdapterView.AnimationFrameRunnable`'s constructor** — the one bare
  declaration still left, which falsified this PR's headline claim (finding 2).
- **Four wrong doc claims** in `CHANGELOG.md`, `CONTRIBUTING.md` and
  `docs/architecture.md` (findings 3–6), listed above.
- **`LayoutManagerAttributes` fields are now `final`** (finding 12), pinning the
  invariant the once-only selection depends on.
- **Two stale section comments** in the test naming a deleted method (finding 10).
- **The `CHANGELOG` now says `Animation.setId` was deleted, not widened**
  (finding 13).
- **The "one method, one flow" prose** now matches its new example (finding 14).

Recorded and not acted on, with reasons:

- **`PageIntervalSelector` should be a private method on `LayoutManager`**
  (finding 7) — declined; see above. The docs no longer overclaim the symmetry.
- **`pagesByCellCount` is public only for seven tests** (finding 8) — the review
  suggested deleting them. No existing test may be deleted for this change.
- **`ViewportPageInterval` has an implicit public no-arg constructor**
  (finding 15) — an implicit constructor is not a declaration; adding an empty
  one is noise.
- **Anonymous classes and `private final int MAX` in edited files** (finding 11)
  — pre-existing on `main`, not touched by this change; see follow-ups.

## Follow-ups this exposed

1. Three anonymous inner classes remain on `main` (`AbstractAdapterView`'s
   `DataSetObserver`, `LayoutManager`'s `Runnable`, `LayoutManagerState`'s
   `Parcelable.Creator`), against the "no anonymous methods" rule.
2. `LayoutManager.java` has `private final int MAX = Integer.MAX_VALUE / 2;` —
   `UPPER_SNAKE_CASE` on a non-static instance field.
3. `forwardByViewport_withCellSpacing_countsTheSpacingThatComesWithEachCell` and
   its `backByViewport_` twin claim more than they prove; they should be renamed.
4. `LayoutManagerPagingMethodsTest` now tests `pageinterval/` types as much as
   `LayoutManager` methods, and could be split.
5. `LayoutManagerState.writeToParcel` and its `Parcel` constructor take
   non-`final` parameters.

## Not verified here

- The instrumented suite's first attempt on this change failed on the **tablet**
  (API 35) at 50 of 78 tests with
  `java.util.concurrent.TimeoutException: ReferenceQueueDaemon timed out while
  targeting android.graphics.HardwareRenderer$DestroyContextRunnable` — an ART
  finalizer watchdog, not an assertion. The same test passed on the phone in
  16.9s and took 75.3s on the tablet before the process died. The device was
  rebooted per the house rules and the suite re-run; the numbers reported above
  are from the clean run. This is the same emulator degradation the previous
  round of this PR recorded, and the count being 128 rather than a multiple of 78
  is what exposed it — the console said nothing useful.
