### PR TITLE
Sample: Picasso 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ everything around them is new.
   cell sizes themselves; the three that a layout dimension already states
   alias it rather than repeating the number. Requests are in device pixels,
   so density is applied once by `getDimensionPixelSize`.
+- Sample: Picasso 2.8 (was 2.71828). Same okhttp, but it depends on
+  `androidx.exifinterface` instead of `com.android.support:exifinterface` and
+  `support-annotations`, which were the last `com.android.support` artifacts
+  in the build.
+
 - Sample: Picasso is built with a memory cache of a third of the heap instead
   of the seventh it sizes itself at. A photo requested at the size of the view
   is several times larger than the fixed 800px one it replaces, and on a

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ androidxTestRules = "1.7.0"
 espresso = "3.7.0"
 
 # Sample
-picasso = "2.71828"
+picasso = "2.8"
 
 [libraries]
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidxAnnotation" }


### PR DESCRIPTION
## Description

Recovers the Picasso 2.8 upgrade, which was reviewed and merged in #41 but never
reached `main`.

#41 was opened against `sample-sized-image-requests` rather than `main`. That base
branch had already been squash-merged into `main` as f9e1098 by the time #41 landed on
it, so the merge had nowhere to carry the change and the content was orphaned. The
pull request list shows #41 as merged, which is why this went unnoticed.

Only one of the three commits on `sample-picasso-2-8` was actually missing. Cherry-picking
the other two onto current `main` produced empty commits, so their content is already
there through the squash. This pull request is the remaining one, unmodified:

- `Sample: keep the ImageView cast and group the url with its use` — already on `main`, skipped
- `Sample: give Picasso a third of the heap and trim the pattern request` — already on `main`, skipped
- `Sample: Picasso 2.8` — recovered here

The branch was cut fresh from `main` rather than rebasing `sample-picasso-2-8`, because
`main` already holds a squashed copy of a commit on that branch and it is already pushed.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [x] Build / dependency change, sample module only

## How Has This Been Tested?

- [x] Unit tests
- [ ] Instrumented tests
- [ ] Manual testing on device/emulator

`scripts/ci_local.sh --no-instrumented` is fully green on this branch: spotlessCheck,
Android Lint on library and sample with warnings as errors and no baseline, 131 unit
tests with no failures, and `:library:assembleRelease` plus `:sample:assembleDebug`.

Instrumented tests did not run. No device or emulator is attached to the machine this
was prepared on.

## Verification of the claims in the commit message

The commit message makes two factual claims. Neither was taken on faith.

**That 2.71828 pulls the last `com.android.support` artifacts, and 2.8 does not.**
Confirmed by comparing `./gradlew :sample:dependencies --configuration debugRuntimeClasspath`
on `main` and on this branch.

On `main`:

```
\--- com.squareup.picasso:picasso:2.71828
     +--- com.android.support:support-annotations:27.1.0
     \--- com.android.support:exifinterface:27.1.0
          \--- com.android.support:support-annotations:27.1.0
```

On this branch:

```
\--- com.squareup.picasso:picasso:2.8
     \--- androidx.exifinterface:exifinterface:1.0.0
```

No `com.android.support` artifact remains anywhere in the sample's debug runtime
classpath.

**That 2.8 is genuinely newer than 2.71828, and Maven only reports otherwise because
71828 sorts above 8.** Confirmed against the Maven Central release index: 2.8 was
released 2020-08-10, 2.71828 on 2018-03-07. 2.8 is the newest release Picasso has.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (this repo avoids narration comments)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

No test accompanies this change. It is a dependency version bump in the sample module
with no library behaviour attached, and the two claims it rests on are verified above
against the dependency graph and the release index rather than against a test.
