### PR TITLE
Draw a divider on every edge internal to the content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ All notable changes to Parchment, newest first. The format follows
 
 ## [Unreleased]
 
-The first work on Parchment since 2014. Behaviour of the views is unchanged;
-everything around them is new.
+The first work on Parchment since 2014. Apart from the new cell divider,
+behaviour of the views is unchanged; everything around them is new.
 
 ### Changed
+
+- **Breaking:** `AbstractAdapterView.createAdapterViewInitializer` takes two
+  more parameters, the divider drawable and its size. It is `protected` and
+  an implementation detail, but a subclass that overrides it — the pattern
+  the in-tree test views use to reach the gesture listener — has to take the
+  two new parameters and pass them on.
 
 - `GridView` rows report their bounds without allocating. `Group.getTop`,
   `getBottom`, `getLeft` and `getRight` walked their views with an iterator
@@ -130,11 +136,30 @@ everything around them is new.
 
 ### Added
 
+- `parchment_divider` and `parchment_dividerSize` draw a divider between
+  adjacent cells in all three views, the thing the platform `ListView` has
+  and Parchment did not (#25). There is one fewer divider than there are
+  cells on screen: never before the first, never after the last. A cell is
+  one view in `ListView` and a whole group in `GridView` and
+  `GridPatternView`, so a divider separates rows rather than the items
+  inside a row. The divider is decoration and takes no space of its own: it
+  is centred in the `parchment_cellSpacing` gap, so the spacing is what you
+  size to make room for it, and a divider thicker than the spacing overflows
+  evenly onto both cells and is painted over them — which is also what makes
+  one visible when the spacing is zero. Along the breadth it runs inside
+  `android:padding*`; `android:clipToPadding` is applied to the cells inside
+  `ViewGroup.dispatchDraw` and restored before it returns, so it never
+  reaches the divider under either setting. Without `parchment_dividerSize`
+  the drawable's intrinsic size along the scroll axis is used, and a colour
+  has none, so a colour divider with no size paints nothing, as with the
+  platform widget. The divider is drawn as it is given: drawable state and
+  animation are not driven, as with the platform widget.
 - An instrumented harness, `ParchmentViewHarness`, that inflates a view
   from a layout with a real `LayoutInflater`, attaches it to an Activity at
   an exact pixel size, drives real measure and layout passes, dispatches
   real gestures, and hands a test an immutable snapshot of where the
-  children landed. All eleven `parchment_` attributes are covered by
+  children landed. All eleven `parchment_`
+  attributes are covered by
   on-device tests built on it, asserting geometry rather than getters, as is
   paging in both modes: a real fling and a real slow drag each page by the
   cells that fit the viewport, or by `parchment_viewPagerInterval` cells, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ everything around them is new.
 
 ### Changed
 
+- `GridView` rows report their bounds without allocating. `Group.getTop`,
+  `getBottom`, `getLeft` and `getRight` walked their views with an iterator
+  and a boxed `Integer` accumulator; they now index the list and accumulate
+  an `int`, because the divider pass reads a cell's bounds on every frame
+  while the view moves. An empty group reported those bounds by throwing a
+  `NullPointerException` and now reports 0, matching `getMeasuredWidth` and
+  `getMeasuredHeight`, which already did.
+
 - **Breaking:** every custom XML attribute now carries a `parchment_`
   prefix: `orientation` is `parchment_orientation`, `cellSpacing` is
   `parchment_cellSpacing`, and so on for all eleven. Custom attribute names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ behaviour of the views is unchanged; everything around them is new.
   the in-tree test views use to reach the gesture listener — has to take the
   two new parameters and pass them on.
 
+- The `GridPatternView` sample screen and the wrapping-height `GridView`
+  sample screen draw a divider, so the feature is visible in the app. A
+  colour has no intrinsic size, so both declare an explicit
+  `parchment_dividerSize`.
+
 - `GridView` rows report their bounds without allocating. `Group.getTop`,
   `getBottom`, `getLeft` and `getRight` walked their views with an iterator
   and a boxed `Integer` accumulator; they now index the list and accumulate
@@ -136,24 +141,34 @@ behaviour of the views is unchanged; everything around them is new.
 
 ### Added
 
-- `parchment_divider` and `parchment_dividerSize` draw a divider between
-  adjacent cells in all three views, the thing the platform `ListView` has
-  and Parchment did not (#25). There is one fewer divider than there are
-  cells on screen: never before the first, never after the last. A cell is
-  one view in `ListView` and a whole group in `GridView` and
-  `GridPatternView`, so a divider separates rows rather than the items
-  inside a row. The divider is decoration and takes no space of its own: it
-  is centred in the `parchment_cellSpacing` gap, so the spacing is what you
+- `parchment_divider` and `parchment_dividerSize` draw a divider in all
+  three views, the thing the platform `ListView` has and Parchment did not
+  (#25). A divider falls on every edge internal to the content and on none
+  at the content's outer boundary. Each drawn item is asked about its
+  trailing edge along each axis: where another item lies across the gap a
+  divider is painted there, spanning exactly the run the two items share
+  along the other axis, and an item with no neighbour on a side is at the
+  boundary and gets nothing. In a `ListView` that is one divider between
+  each pair of items and one fewer than there are cells on screen. In
+  `GridView` and `GridPatternView`, where a cell is a whole group, it is
+  also a divider between the items stacked inside one group, so a
+  `GridPatternView` pattern of mixed spans and T-junctions is divided
+  without rows or columns having to exist. Every shared edge is painted
+  once. The divider is decoration and takes no space of its own: it is
+  centred in the `parchment_cellSpacing` gap, so the spacing is what you
   size to make room for it, and a divider thicker than the spacing overflows
-  evenly onto both cells and is painted over them — which is also what makes
-  one visible when the spacing is zero. Along the breadth it runs inside
-  `android:padding*`; `android:clipToPadding` is applied to the cells inside
-  `ViewGroup.dispatchDraw` and restored before it returns, so it never
-  reaches the divider under either setting. Without `parchment_dividerSize`
-  the drawable's intrinsic size along the scroll axis is used, and a colour
-  has none, so a colour divider with no size paints nothing, as with the
-  platform widget. The divider is drawn as it is given: drawable state and
-  animation are not driven, as with the platform widget.
+  evenly onto both items and is painted over them — which is also what makes
+  one visible when the spacing is zero. Where a gap between rows crosses a
+  gap between columns nothing abuts either gap, so the crossing is left
+  unpainted. A divider begins and ends where the items it separates do, so
+  it stays inside `android:padding*` with them; `android:clipToPadding` is
+  applied to the cells inside `ViewGroup.dispatchDraw` and restored before
+  it returns, so it never reaches the divider under either setting. Without
+  `parchment_dividerSize` the drawable's intrinsic size along the scroll
+  axis is used, and a colour has none, so a colour divider with no size
+  paints nothing, as with the platform widget. The divider is drawn as it is
+  given: drawable state and animation are not driven, as with the platform
+  widget.
 - An instrumented harness, `ParchmentViewHarness`, that inflates a view
   from a layout with a real `LayoutInflater`, attaches it to an Activity at
   an exact pixel size, drives real measure and layout passes, dispatches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,10 +158,9 @@ behaviour of the views is unchanged; everything around them is new.
   from a layout with a real `LayoutInflater`, attaches it to an Activity at
   an exact pixel size, drives real measure and layout passes, dispatches
   real gestures, and hands a test an immutable snapshot of where the
-  children landed. All eleven `parchment_`
-  attributes are covered by
-  on-device tests built on it, asserting geometry rather than getters, as is
-  paging in both modes: a real fling and a real slow drag each page by the
+  children landed or of the pixels it painted. All fourteen `parchment_`
+  attributes are covered by on-device tests built on it, asserting geometry
+  and painted pixels rather than getters, as is paging in both modes: a real fling and a real slow drag each page by the
   cells that fit the viewport, or by `parchment_viewPagerInterval` cells, with
   several cells on screen, with cells that do not divide the viewport, with
   cells of unequal size, with a cell taller than the viewport, from a resting

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ every child in memory. The story, and a feature-by-feature comparison with
 - ViewPager behaviour on the same ListView and the same adapter: one
   completed gesture advances a whole viewport of cells, or exactly
   `parchment_viewPagerInterval` of them
+- A divider drawn between adjacent cells, in either orientation and in all
+  three views
 - GridView whose rows wrap to the tallest cell
 - GridPatternView: declare a repeating pattern of mixed-span cells and let
   the engine tile your data through it
@@ -106,6 +108,47 @@ cd parchment
     parchment:parchment_viewPagerInterval="viewport" />
 ```
 
+### Dividers
+
+`parchment_divider` paints a drawable or a colour between adjacent cells,
+one fewer divider than there are cells on screen: never before the first
+cell or after the last. In a `ListView` a cell is one view, so a divider
+sits between items. In `GridView` and `GridPatternView` a cell is a whole
+group, so a divider separates rows (or columns, scrolling horizontally),
+never the items inside a row.
+
+The divider is decoration and takes no space of its own: it is centred in
+the `parchment_cellSpacing` gap between the two cells, so the gap is what
+you size to make room for it. A divider thicker than the spacing overflows
+evenly onto both cells and is painted over them, which is also what makes
+one visible when the spacing is zero. Along the breadth it runs from
+`android:paddingLeft` to `android:paddingRight` (from `paddingTop` to
+`paddingBottom` scrolling horizontally). `android:clipToPadding` decides
+whether a cell is clipped at the padding; either way it never reaches the
+divider, which is painted inside the padding regardless.
+
+`parchment_dividerSize` gives the thickness along the scroll axis. Leave it
+out and the drawable's intrinsic size along that axis is used instead — but
+a colour has no intrinsic size, so a colour divider with no
+`parchment_dividerSize` paints nothing, the same as the platform `ListView`.
+A `parchment_dividerSize` of zero or less paints nothing either; that is not
+the same as leaving the attribute out, which is what asks for the intrinsic
+size.
+
+The drawable is drawn as it is given: its state is not tracked and an
+`AnimationDrawable` will not animate, again as with the platform `ListView`.
+
+```xml
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_cellSpacing="8dp"
+    parchment:parchment_divider="#33000000"
+    parchment:parchment_dividerSize="1dp" />
+```
+
 ### Java
 
 ```java
@@ -145,6 +188,8 @@ All views:
 | `parchment_selectWhileScrolling` | boolean | Fire selection while the content is still moving |
 | `parchment_isViewPager` | boolean | One page per gesture, ViewPager style |
 | `parchment_viewPagerInterval` | integer, or `viewport` | How far one ViewPager gesture pages. `viewport` (or `0`, or unset, the default) advances every cell that fits the viewport whole; `N` advances exactly N cells. Values below zero are read as `viewport` |
+| `parchment_divider` | drawable or colour | Drawn between adjacent cells, never before the first or after the last |
+| `parchment_dividerSize` | dimension | Divider thickness along the scroll axis; without it the drawable's intrinsic size along that axis is used, and a colour has none, so a colour divider with no size paints nothing |
 
 GridView:
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ every child in memory. The story, and a feature-by-feature comparison with
 - ViewPager behaviour on the same ListView and the same adapter: one
   completed gesture advances a whole viewport of cells, or exactly
   `parchment_viewPagerInterval` of them
-- A divider drawn between adjacent cells, in either orientation and in all
-  three views
+- A divider drawn on every edge internal to the content, in either
+  orientation and in all three views, including between the items stacked
+  inside one `GridView` row or one `GridPatternView` group
 - GridView whose rows wrap to the tallest cell
 - GridPatternView: declare a repeating pattern of mixed-span cells and let
   the engine tile your data through it
@@ -110,22 +111,38 @@ cd parchment
 
 ### Dividers
 
-`parchment_divider` paints a drawable or a colour between adjacent cells,
-one fewer divider than there are cells on screen: never before the first
-cell or after the last. In a `ListView` a cell is one view, so a divider
-sits between items. In `GridView` and `GridPatternView` a cell is a whole
-group, so a divider separates rows (or columns, scrolling horizontally),
-never the items inside a row.
+`parchment_divider` paints a drawable or a colour on every edge internal to
+the content and on none at the content's outer boundary. Each drawn item is
+asked about its trailing edge along each axis: where another item lies across
+the gap, a divider is painted in that gap, spanning exactly the run the two
+items share along the other axis. An item with no neighbour on a side is at
+the boundary and gets nothing, so nothing is ever painted before the first
+cell, after the last, or down the outside of the content.
+
+In a `ListView` a cell is one view and there is one axis, so that is one
+divider between each pair of items and one fewer divider than there are cells
+on screen. In `GridView` and `GridPatternView` a cell is a whole group, so
+dividers fall both between the groups and between the items stacked inside
+one: scrolling vertically, a line between the rows and a line between the
+columns. Because a divider spans only what the two items it separates share,
+a `GridPatternView` pattern of mixed spans is divided correctly without rows
+or columns having to exist: an item that abuts two stacked ones is divided
+from each of them over its own share of the edge. Every shared edge is
+painted once.
 
 The divider is decoration and takes no space of its own: it is centred in
-the `parchment_cellSpacing` gap between the two cells, so the gap is what
+the `parchment_cellSpacing` gap between the two items, so the gap is what
 you size to make room for it. A divider thicker than the spacing overflows
-evenly onto both cells and is painted over them, which is also what makes
-one visible when the spacing is zero. Along the breadth it runs from
-`android:paddingLeft` to `android:paddingRight` (from `paddingTop` to
-`paddingBottom` scrolling horizontally). `android:clipToPadding` decides
-whether a cell is clipped at the padding; either way it never reaches the
-divider, which is painted inside the padding regardless.
+evenly onto both items and is painted over them, which is also what makes
+one visible when the spacing is zero. Where two gaps cross — the corner at
+which a gap between rows meets a gap between columns — no item lies on either
+side of either gap, so the crossing is left unpainted.
+
+A divider follows the items it separates rather than the view's padding: it
+begins and ends where they do. Cells are laid out inside `android:padding*`,
+so a divider stays inside the padding with them. `android:clipToPadding`
+decides whether a cell is clipped at the padding; either way it never reaches
+the divider.
 
 `parchment_dividerSize` gives the thickness along the scroll axis. Leave it
 out and the drawable's intrinsic size along that axis is used instead — but
@@ -188,7 +205,7 @@ All views:
 | `parchment_selectWhileScrolling` | boolean | Fire selection while the content is still moving |
 | `parchment_isViewPager` | boolean | One page per gesture, ViewPager style |
 | `parchment_viewPagerInterval` | integer, or `viewport` | How far one ViewPager gesture pages. `viewport` (or `0`, or unset, the default) advances every cell that fits the viewport whole; `N` advances exactly N cells. Values below zero are read as `viewport` |
-| `parchment_divider` | drawable or colour | Drawn between adjacent cells, never before the first or after the last |
+| `parchment_divider` | drawable or colour | Drawn on every edge internal to the content and on none at its outer boundary: between adjacent cells and between the items stacked inside one |
 | `parchment_dividerSize` | dimension | Divider thickness along the scroll axis; without it the drawable's intrinsic size along that axis is used, and a colour has none, so a colour divider with no size paints nothing |
 
 GridView:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,41 +62,102 @@ the rule that keeps one engine working for both orientations.
 ## The draw pass
 
 `AbstractAdapterView.dispatchDraw` draws the cells through `super`, then
-hands the canvas to `CellDivider`, which paints `parchment_divider` once
-between each pair of adjacent drawn cells. It reads the boundaries through
-`LayoutManager.getDrawnCellCount`, `getDrawnCellStart` and `getDrawnCellEnd`,
-so the cell list itself stays inside the engine, and it maps thickness and
-breadth onto left/top/right/bottom through `ScrollDirectionManager` like
-everything else orientation-specific. Drawing runs on every frame while
-anything moves, so nothing in Parchment allocates on that path: one `Rect`
-field is refilled per divider, the loop is indexed rather than iterated, and
-`Group` reads a row's bounds without an iterator or a boxed accumulator.
-What a `Drawable` does inside its own `draw` is its own business.
+hands the canvas to `CellDivider`. A divider belongs on every edge internal
+to the content and on none at the content's outer boundary, and `CellDivider`
+gets that by working in edges rather than in full-breadth lines. It walks the
+drawn items — the child views themselves, not the cells — and asks each one
+about its trailing edge along each of the two axes: where another drawn item
+lies across the gap, a divider is painted in that gap spanning exactly the run
+the two items share along the perpendicular axis. An item with no neighbour on
+a side is at the content boundary and gets nothing, so the boundary rule falls
+out instead of being a case, and `GridPatternView`'s mixed spans and
+T-junctions are handled without rows or columns having to exist.
 
-`CellDivider` is the whole of the divider, the way `snapposition/` and
-`pageinterval/` hold the whole of a snap or a page: the drawable, the
-thickness and the orientation reach it as constructor parameters, the
-thickness is resolved once there from either `parchment_dividerSize` or the
-drawable's intrinsic size, and nothing selects between algorithms per frame,
-so it needs no strategy family of its own. `getDividerStart` takes scalars
-in and returns a scalar, the shape `ViewGroupUtilities` uses, so
-the placement arithmetic is pinned on its own without a layout manager. The
-three accessors it reads cells through are `protected final`: `protected`
-carries the package access `CellDivider` and the tests need, and `final` keeps
-a subclass from overriding one and silently relocating every divider.
+Only trailing edges are considered, which is what paints each shared edge
+exactly once: `CellEdges.isAcrossTheEndEdge` holds for at most one of an
+ordered pair, because it requires the neighbour to reach further than the
+item. The same asymmetry means the size pass and the breadth pass can never
+both claim one pair: a pair separated along both axes would have to overlap on
+neither, and each pass requires a positive overlap on the other axis
+(`gridDivider_onAnEdgeSharedByTwoItems_isDrawnOnlyOnce`).
 
-Dividers are decoration and never enter the layout: the cells sit where
+The two passes are two named methods rather than one parameterised by an axis
+strategy. They read the same four spans through `ScrollDirectionManager` with
+the roles of the axes swapped, and they fill the `Rect` in opposite orders; a
+strategy family next to `ScrollDirectionManager` would be a second thing
+called an "axis" and would invite exactly the `getLeft()`/`getTop()` confusion
+the engine rule exists to stop. What they share is the geometry, and that
+lives in `CellEdges`: whether a neighbour lies across an end edge, the overlap
+of two spans, whether an overlap is real, and whether a third item stands in
+the gap inside the band a divider would span. `CellEdges` takes scalars and
+returns scalars, the shape `getDividerStart` already had, so every one of
+those facts is pinned on its own in `CellEdgesTest` without a layout manager
+and without weakening anything's visibility.
+
+The third of those facts is what keeps a divider from being drawn across an
+item that stands between two others: a candidate occludes the edge when it is
+across the item's end edge and the neighbour is across *its* end edge, and it
+reaches the band. Without it, three items in a line would be divided 1-2, 2-3
+and also 1-3, the last drawn straight through the middle one.
+
+Because this runs on every frame while anything moves, the neighbour search is
+bounded by structure rather than cached. The candidates for an item in a drawn
+cell are the items of that cell and of the next one, and nothing else: cells
+are laid end to end along the scroll axis, so an item two cells away is either
+not adjacent or separated by a hole rather than by a gap. That makes the work
+per frame linear in the number of drawn items, with a constant set by the
+items in one cell — one for `ListView`, `parchment_numberOfViewsPerCell` for
+`GridView`, the pattern's item count for `GridPatternView` — and independent
+of the adapter's size and of how far the view has been scrolled. Nothing is
+computed once per layout pass and kept, because the layout pass runs on every
+frame too while scrolling, so a cache would save nothing and would have to be
+allocated and invalidated on every cell that is recycled or prepended
+mid-gesture.
+
+Nothing on the path allocates: one `Rect` field is refilled per divider
+(`everyGridDividerOfEveryFrame_isMeasuredIntoTheSameBoundsRect`), every loop
+is indexed rather than iterated, and the items are reached through
+`LayoutManager.getDrawnCellViewCount` and `getDrawnCellView`, which index into
+a cell instead of copying its view list the way `getViews` does. Those two,
+with `getDrawnCellCount`, are `protected final`: `protected` carries the
+package access `CellDivider` and the tests need, and `final` keeps a subclass
+from overriding one and silently relocating every divider. What a `Drawable`
+does inside its own `draw` is its own business.
+
+Dividers are decoration and never enter the layout: the items sit where
 `parchment_cellSpacing` puts them and the divider is centred in the gap
-between two cells' boundaries, measured as `gapStart + (gapEnd - gapStart) / 2`
+between two items' boundaries, measured as `gapStart + (gapEnd - gapStart) / 2`
 rather than `(gapStart + gapEnd) / 2`, because a gap that straddles the
 leading edge has a negative start and integer division truncates toward zero
 (`dividerStart_inAGapThatStartsBeforeTheOrigin_centresTheDividerInTheGap`).
 Painting after the children is what makes a divider thicker than the
-spacing — a zero spacing included — visible rather than hidden under the cell
-it overlaps. `android:clipToPadding` is applied by `ViewGroup.dispatchDraw`
-and restored before it returns, so it never clips the divider; `CellDivider`
-applies `getStartBreadthPadding` and `getEndBreadthPadding` itself instead
-(`CellDividerPaintTest`).
+spacing — a zero spacing included — visible rather than hidden under the item
+it overlaps. Where a gap between rows crosses a gap between columns no item
+abuts either gap, so the crossing is left unpainted and the grid reads as a
+grid (`dividerInXmlOnAGridView_whereTwoGapsCross_paintsNothing`).
+
+A divider begins and ends where the items it separates do, and knows nothing
+about padding. It does not need to: the layout managers place cells inside
+`android:padding*`, so a divider that follows them is inside the padding too
+(`divider_withPaddingSet_spansTheRowsItSeparatesAndNoFurther`). This is the one
+place the new rule moved an existing line. `ListLayoutManager.layoutCell`
+centres a row in the *whole* breadth rather than inside the padding box, so
+with asymmetric padding the row sits off-centre of that box; the divider used
+to span the padding box and now spans the row, which is where the content
+actually is. `android:clipToPadding` is applied by `ViewGroup.dispatchDraw`
+and restored before it returns, so it never clips the divider either way.
+
+`parchment_gravity` can leave a view shorter than its row along the scroll
+axis, and the divider follows the view there too: two items of different
+lengths in one row are each divided from their own neighbour, in their own
+gap, so the line is not continuous across the row. That is the rule working
+rather than failing — the alternative, snapping every divider onto the cell
+boundary, would put a line part-way inside a short view
+(`gridDivider_withAShortViewPlacedByGravity_followsTheViewRatherThanTheCell`).
+
+`CellDivider` still resolves its thickness once, in its constructor, from
+either `parchment_dividerSize` or the drawable's intrinsic size, and nothing
+selects between algorithms per frame.
 
 With `parchment_isCircularScroll` on, the drawn cells already wrap, so the
 divider between the last cell and the first is just a divider between two
@@ -267,5 +328,5 @@ same content position without the adapter's help.
 | Why did scrolling stop early / overshoot? | `LayoutManager.layout` bounds handling, `*OverScrollTest` |
 | Why did the snap land in the wrong place? | the strategy in `snapposition/`, `getCellDisplacementFromSnapPositionTests` |
 | Why is padding wrong? | `ListLayoutPaddingTest`; padding is applied in the layout managers, not the views |
-| Why is the divider missing or in the wrong place? | `CellDivider`, `CellDividerTest`, `CellDividerPaintTest` |
+| Why is the divider missing or in the wrong place? | `CellDivider` and the edge geometry in `CellEdges`; `CellDividerTest`, `CellDividerGroupTest`, `CellEdgesTest`, `CellDividerPaintTest` |
 | Why did a ViewPager gesture land where it did? | `LayoutManager.setViewPageDistances` and the strategy in `pageinterval/` + `ViewPagerTest`, with each method it is built from in `LayoutManagerPagingMethodsTest` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,6 +59,56 @@ The step itself:
 The layout managers never call `getLeft()`/`getTop()` directly; that is
 the rule that keeps one engine working for both orientations.
 
+## The draw pass
+
+`AbstractAdapterView.dispatchDraw` draws the cells through `super`, then
+hands the canvas to `CellDivider`, which paints `parchment_divider` once
+between each pair of adjacent drawn cells. It reads the boundaries through
+`LayoutManager.getDrawnCellCount`, `getDrawnCellStart` and `getDrawnCellEnd`,
+so the cell list itself stays inside the engine, and it maps thickness and
+breadth onto left/top/right/bottom through `ScrollDirectionManager` like
+everything else orientation-specific. Drawing runs on every frame while
+anything moves, so nothing in Parchment allocates on that path: one `Rect`
+field is refilled per divider, the loop is indexed rather than iterated, and
+`Group` reads a row's bounds without an iterator or a boxed accumulator.
+What a `Drawable` does inside its own `draw` is its own business.
+
+`CellDivider` is the whole of the divider, the way `snapposition/` and
+`pageinterval/` hold the whole of a snap or a page: the drawable, the
+thickness and the orientation reach it as constructor parameters, the
+thickness is resolved once there from either `parchment_dividerSize` or the
+drawable's intrinsic size, and nothing selects between algorithms per frame,
+so it needs no strategy family of its own. `getDividerStart` takes scalars
+in and returns a scalar, the shape `ViewGroupUtilities` uses, so
+the placement arithmetic is pinned on its own without a layout manager. The
+three accessors it reads cells through are `protected final`: `protected`
+carries the package access `CellDivider` and the tests need, and `final` keeps
+a subclass from overriding one and silently relocating every divider.
+
+Dividers are decoration and never enter the layout: the cells sit where
+`parchment_cellSpacing` puts them and the divider is centred in the gap
+between two cells' boundaries, measured as `gapStart + (gapEnd - gapStart) / 2`
+rather than `(gapStart + gapEnd) / 2`, because a gap that straddles the
+leading edge has a negative start and integer division truncates toward zero
+(`dividerStart_inAGapThatStartsBeforeTheOrigin_centresTheDividerInTheGap`).
+Painting after the children is what makes a divider thicker than the
+spacing — a zero spacing included — visible rather than hidden under the cell
+it overlaps. `android:clipToPadding` is applied by `ViewGroup.dispatchDraw`
+and restored before it returns, so it never clips the divider; `CellDivider`
+applies `getStartBreadthPadding` and `getEndBreadthPadding` itself instead
+(`CellDividerPaintTest`).
+
+With `parchment_isCircularScroll` on, the drawn cells already wrap, so the
+divider between the last cell and the first is just a divider between two
+adjacent drawn cells and needs no case of its own.
+
+A cell that scrolls off the start keeps its divider for as long as the gap
+after it is on screen, without the draw pass knowing anything about it:
+`layout` recycles a cell once its end passes 0, but the backward pass then
+prepends cells while `mOffset` is still above 0, and `mOffset` is above 0
+exactly when part of that gap is still visible
+(`divider_whenACellScrollsOffTheStart_isStillDrawnWhileItsGapIsOnScreen`).
+
 ## Recycling
 
 `AdapterViewManager` keeps a `Queue<View>` per adapter view type plus a
@@ -217,4 +267,5 @@ same content position without the adapter's help.
 | Why did scrolling stop early / overshoot? | `LayoutManager.layout` bounds handling, `*OverScrollTest` |
 | Why did the snap land in the wrong place? | the strategy in `snapposition/`, `getCellDisplacementFromSnapPositionTests` |
 | Why is padding wrong? | `ListLayoutPaddingTest`; padding is applied in the layout managers, not the views |
+| Why is the divider missing or in the wrong place? | `CellDivider`, `CellDividerTest`, `CellDividerPaintTest` |
 | Why did a ViewPager gesture land where it did? | `LayoutManager.setViewPageDistances` and the strategy in `pageinterval/` + `ViewPagerTest`, with each method it is built from in `LayoutManagerPagingMethodsTest` |

--- a/library/src/androidTest/java/mobi/parchment/attributes/CellDividerGroupInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/CellDividerGroupInstrumentedTest.java
@@ -29,10 +29,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Proves that in the two views whose cell is a whole group, parchment_divider separates the groups
- * and never the items inside one: a row of a GridView and one repeat of a GridPatternView pattern
- * each get a single divider after them, painted on a real framework canvas. Expected bands are
- * literal pixels, not a recomputation of the production formula.
+ * Proves that in the two views whose cell is a whole group, parchment_divider falls on every edge
+ * internal to the content and on none at its outer boundary: between the rows of a GridView and
+ * between one repeat of a GridPatternView pattern and the next, and also between the items stacked
+ * inside a single group, painted on a real framework canvas. Expected bands are literal pixels, not
+ * a recomputation of the production formula.
  */
 @RunWith(AndroidJUnit4.class)
 public final class CellDividerGroupInstrumentedTest {
@@ -46,7 +47,8 @@ public final class CellDividerGroupInstrumentedTest {
     private static final int CELL_SPACING = 24;
     private static final int CELL_COLOUR = 0xff0000ff;
     private static final int DIVIDER_COLOUR = 0xff00ff00;
-    private static final int NO_RUNS = 0;
+    private static final int THE_START_BREADTH_EDGE = 0;
+    private static final int ONE_PIXEL = 1;
     private static final int MATCH_PARENT = ViewGroup.LayoutParams.MATCH_PARENT;
     private static final int A_COLUMN_INSIDE_THE_FIRST_ITEM = 20;
     private static final int INSIDE_THE_FIRST_ROW = 50;
@@ -56,6 +58,10 @@ public final class CellDividerGroupInstrumentedTest {
     private static final int[] GRID_BAND_ENDS = {116, 240, 364, 488};
     private static final int[] PATTERN_BAND_STARTS = {227, 470};
     private static final int[] PATTERN_BAND_ENDS = {235, 478};
+    private static final int[] GRID_COLUMN_BAND_STARTS = {292, 600};
+    private static final int[] GRID_COLUMN_BAND_ENDS = {300, 608};
+    private static final int[] PATTERN_COLUMN_BAND_STARTS = {446};
+    private static final int[] PATTERN_COLUMN_BAND_ENDS = {454};
 
     @Rule
     public final ActivityScenarioRule<HarnessActivity> mActivityRule =
@@ -83,16 +89,28 @@ public final class CellDividerGroupInstrumentedTest {
     }
 
     @Test
-    public void dividerInXmlOnAGridView_isNotPaintedBetweenTheItemsOfARow() {
+    public void dividerInXmlOnAGridView_isPaintedBetweenTheItemsOfARow() {
         final ParchmentViewHarness<GridView<BaseAdapter>> harness = attachGrid();
         final PaintedPixels pixels = harness.paint();
 
         final List<PixelRun> acrossTheRow =
                 pixels.runsAcrossRow(INSIDE_THE_FIRST_ROW, DIVIDER_COLOUR);
+        assertBands(acrossTheRow, GRID_COLUMN_BAND_STARTS, GRID_COLUMN_BAND_ENDS);
+    }
+
+    @Test
+    public void dividerInXmlOnAGridView_isNotPaintedAtTheOuterBreadthEdges() {
+        final ParchmentViewHarness<GridView<BaseAdapter>> harness = attachGrid();
+        final PaintedPixels pixels = harness.paint();
+
         assertEquals(
-                "a row of items must carry no divider between them: " + acrossTheRow,
-                NO_RUNS,
-                acrossTheRow.size());
+                "nothing may be painted on the first item's leading breadth edge",
+                CELL_COLOUR,
+                pixels.colourAt(THE_START_BREADTH_EDGE, INSIDE_THE_FIRST_ROW));
+        assertEquals(
+                "nothing may be painted on the last item's trailing breadth edge",
+                CELL_COLOUR,
+                pixels.colourAt(VIEWPORT_WIDTH - ONE_PIXEL, INSIDE_THE_FIRST_ROW));
     }
 
     @Test
@@ -113,16 +131,28 @@ public final class CellDividerGroupInstrumentedTest {
     }
 
     @Test
-    public void dividerInXmlOnAGridPatternView_isNotPaintedBetweenTheItemsOfAGroup() {
+    public void dividerInXmlOnAGridPatternView_isPaintedBetweenTheItemsOfAGroup() {
         final ParchmentViewHarness<GridPatternView<BaseAdapter>> harness = attachGridPattern();
         final PaintedPixels pixels = harness.paint();
 
         final List<PixelRun> acrossTheGroup =
                 pixels.runsAcrossRow(INSIDE_THE_FIRST_PATTERN_GROUP, DIVIDER_COLOUR);
+        assertBands(acrossTheGroup, PATTERN_COLUMN_BAND_STARTS, PATTERN_COLUMN_BAND_ENDS);
+    }
+
+    @Test
+    public void dividerInXmlOnAGridPatternView_isNotPaintedAtTheOuterBreadthEdges() {
+        final ParchmentViewHarness<GridPatternView<BaseAdapter>> harness = attachGridPattern();
+        final PaintedPixels pixels = harness.paint();
+
         assertEquals(
-                "a pattern group must carry no divider inside it: " + acrossTheGroup,
-                NO_RUNS,
-                acrossTheGroup.size());
+                "nothing may be painted on the first item's leading breadth edge",
+                CELL_COLOUR,
+                pixels.colourAt(THE_START_BREADTH_EDGE, INSIDE_THE_FIRST_PATTERN_GROUP));
+        assertEquals(
+                "nothing may be painted on the last item's trailing breadth edge",
+                CELL_COLOUR,
+                pixels.colourAt(VIEWPORT_WIDTH - ONE_PIXEL, INSIDE_THE_FIRST_PATTERN_GROUP));
     }
 
     private static List<PixelRun> dividersDownTheView(final PaintedPixels pixels) {

--- a/library/src/androidTest/java/mobi/parchment/attributes/CellDividerGroupInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/CellDividerGroupInstrumentedTest.java
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.attributes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.util.ArrayList;
+import java.util.List;
+import mobi.parchment.harness.HarnessActivity;
+import mobi.parchment.harness.LaidOutChildren;
+import mobi.parchment.harness.PaintedPixels;
+import mobi.parchment.harness.ParchmentViewHarness;
+import mobi.parchment.harness.PixelRun;
+import mobi.parchment.harness.SolidColourAdapter;
+import mobi.parchment.test.R;
+import mobi.parchment.widget.adapterview.gridpatternview.GridPatternItemDefinition;
+import mobi.parchment.widget.adapterview.gridpatternview.GridPatternView;
+import mobi.parchment.widget.adapterview.gridview.GridView;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Proves that in the two views whose cell is a whole group, parchment_divider separates the groups
+ * and never the items inside one: a row of a GridView and one repeat of a GridPatternView pattern
+ * each get a single divider after them, painted on a real framework canvas. Expected bands are
+ * literal pixels, not a recomputation of the production formula.
+ */
+@RunWith(AndroidJUnit4.class)
+public final class CellDividerGroupInstrumentedTest {
+
+    private static final int VIEWPORT_WIDTH = 900;
+    private static final int VIEWPORT_HEIGHT = 600;
+    private static final int ITEM_COUNT = 30;
+    private static final int ITEM_HEIGHT = 100;
+    private static final int VIEWS_PER_CELL = 3;
+    private static final int UNITS_ACROSS = 2;
+    private static final int CELL_SPACING = 24;
+    private static final int CELL_COLOUR = 0xff0000ff;
+    private static final int DIVIDER_COLOUR = 0xff00ff00;
+    private static final int NO_RUNS = 0;
+    private static final int MATCH_PARENT = ViewGroup.LayoutParams.MATCH_PARENT;
+    private static final int A_COLUMN_INSIDE_THE_FIRST_ITEM = 20;
+    private static final int INSIDE_THE_FIRST_ROW = 50;
+    private static final int INSIDE_THE_FIRST_PATTERN_GROUP = 50;
+
+    private static final int[] GRID_BAND_STARTS = {108, 232, 356, 480};
+    private static final int[] GRID_BAND_ENDS = {116, 240, 364, 488};
+    private static final int[] PATTERN_BAND_STARTS = {227, 470};
+    private static final int[] PATTERN_BAND_ENDS = {235, 478};
+
+    @Rule
+    public final ActivityScenarioRule<HarnessActivity> mActivityRule =
+            new ActivityScenarioRule<>(HarnessActivity.class);
+
+    @Test
+    public void dividerInXmlOnAGridView_isPaintedOnceAfterEachRow() {
+        final ParchmentViewHarness<GridView<BaseAdapter>> harness = attachGrid();
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        final List<Integer> rowTops = distinctTops(children);
+        assertTrue(children.toString(), rowTops.size() > 1);
+        assertEquals(
+                "every row should hold " + VIEWS_PER_CELL + " views: " + children,
+                rowTops.size() * VIEWS_PER_CELL,
+                children.count());
+        assertEquals(
+                "the rows should be a cell spacing apart: " + children,
+                CELL_SPACING,
+                rowTops.get(1).intValue() - (rowTops.get(0).intValue() + ITEM_HEIGHT));
+        final List<PixelRun> painted = dividersDownTheView(pixels);
+        assertOneFewerDividerThanGroups(rowTops, painted);
+        assertBands(painted, GRID_BAND_STARTS, GRID_BAND_ENDS);
+    }
+
+    @Test
+    public void dividerInXmlOnAGridView_isNotPaintedBetweenTheItemsOfARow() {
+        final ParchmentViewHarness<GridView<BaseAdapter>> harness = attachGrid();
+        final PaintedPixels pixels = harness.paint();
+
+        final List<PixelRun> acrossTheRow =
+                pixels.runsAcrossRow(INSIDE_THE_FIRST_ROW, DIVIDER_COLOUR);
+        assertEquals(
+                "a row of items must carry no divider between them: " + acrossTheRow,
+                NO_RUNS,
+                acrossTheRow.size());
+    }
+
+    @Test
+    public void dividerInXmlOnAGridPatternView_isPaintedOnceAfterEachPatternGroup() {
+        final ParchmentViewHarness<GridPatternView<BaseAdapter>> harness = attachGridPattern();
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        final List<Integer> groupTops = distinctTops(children);
+        assertTrue(children.toString(), groupTops.size() > 1);
+        assertEquals(
+                "every group should hold " + UNITS_ACROSS + " views: " + children,
+                groupTops.size() * UNITS_ACROSS,
+                children.count());
+        final List<PixelRun> painted = dividersDownTheView(pixels);
+        assertOneFewerDividerThanGroups(groupTops, painted);
+        assertBands(painted, PATTERN_BAND_STARTS, PATTERN_BAND_ENDS);
+    }
+
+    @Test
+    public void dividerInXmlOnAGridPatternView_isNotPaintedBetweenTheItemsOfAGroup() {
+        final ParchmentViewHarness<GridPatternView<BaseAdapter>> harness = attachGridPattern();
+        final PaintedPixels pixels = harness.paint();
+
+        final List<PixelRun> acrossTheGroup =
+                pixels.runsAcrossRow(INSIDE_THE_FIRST_PATTERN_GROUP, DIVIDER_COLOUR);
+        assertEquals(
+                "a pattern group must carry no divider inside it: " + acrossTheGroup,
+                NO_RUNS,
+                acrossTheGroup.size());
+    }
+
+    private static List<PixelRun> dividersDownTheView(final PaintedPixels pixels) {
+        return pixels.runsDownColumn(A_COLUMN_INSIDE_THE_FIRST_ITEM, DIVIDER_COLOUR);
+    }
+
+    private static void assertOneFewerDividerThanGroups(
+            final List<Integer> groupTops, final List<PixelRun> painted) {
+        final int gapsBetweenGroups = groupTops.size() - 1;
+        assertEquals(
+                "one divider fewer than there are drawn groups, painted "
+                        + painted
+                        + " for group tops "
+                        + groupTops,
+                gapsBetweenGroups,
+                painted.size());
+    }
+
+    private static void assertBands(
+            final List<PixelRun> painted, final int[] starts, final int[] ends) {
+        assertEquals("dividers painted: " + painted, starts.length, painted.size());
+        for (int index = 0; index < starts.length; index++) {
+            assertEquals(
+                    "start of divider " + index + " of " + painted,
+                    starts[index],
+                    painted.get(index).start());
+            assertEquals(
+                    "end of divider " + index + " of " + painted,
+                    ends[index],
+                    painted.get(index).end());
+        }
+    }
+
+    /** The top of every distinct row or group of the laid-out children, in ascending order. */
+    private static List<Integer> distinctTops(final LaidOutChildren children) {
+        final List<Integer> tops = new ArrayList<Integer>();
+        for (int index = 0; index < children.count(); index++) {
+            final Integer top = Integer.valueOf(children.top(index));
+            if (!tops.contains(top)) {
+                tops.add(top);
+            }
+        }
+        sortAscending(tops);
+        return tops;
+    }
+
+    private static void sortAscending(final List<Integer> values) {
+        for (int outer = 0; outer < values.size(); outer++) {
+            for (int inner = outer + 1; inner < values.size(); inner++) {
+                final int left = values.get(outer).intValue();
+                final int right = values.get(inner).intValue();
+                if (right < left) {
+                    values.set(outer, Integer.valueOf(right));
+                    values.set(inner, Integer.valueOf(left));
+                }
+            }
+        }
+    }
+
+    private ParchmentViewHarness<GridView<BaseAdapter>> attachGrid() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<GridView<BaseAdapter>> harness =
+                ParchmentViewHarness.attach(
+                        mActivityRule.getScenario(),
+                        R.layout.instrumented_divider_grid,
+                        VIEWPORT_WIDTH,
+                        VIEWPORT_HEIGHT);
+        harness.setAdapter(
+                new SolidColourAdapter(
+                        context, ITEM_COUNT, MATCH_PARENT, ITEM_HEIGHT, CELL_COLOUR));
+        return harness;
+    }
+
+    private ParchmentViewHarness<GridPatternView<BaseAdapter>> attachGridPattern() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<GridPatternView<BaseAdapter>> harness =
+                ParchmentViewHarness.attach(
+                        mActivityRule.getScenario(),
+                        R.layout.instrumented_divider_pattern,
+                        VIEWPORT_WIDTH,
+                        VIEWPORT_HEIGHT);
+        harness.apply(new AddTwoUnitSquares());
+        harness.setAdapter(
+                new SolidColourAdapter(
+                        context, ITEM_COUNT, MATCH_PARENT, MATCH_PARENT, CELL_COLOUR));
+        return harness;
+    }
+
+    /**
+     * Adds a pattern of two one-by-one grid units side by side, so one repeat of the pattern is one
+     * row of two items and a divider that separates groups has to fall between the rows. The
+     * definition takes its arguments as top, left, height, width.
+     */
+    private static final class AddTwoUnitSquares
+            implements ParchmentViewHarness.ViewSetup<GridPatternView<BaseAdapter>> {
+
+        private static final int ONE_UNIT = 1;
+        private static final int FIRST_ROW = 0;
+        private static final int FIRST_COLUMN = 0;
+        private static final int SECOND_COLUMN = 1;
+
+        @Override
+        public void setUp(final GridPatternView<BaseAdapter> view) {
+            final List<GridPatternItemDefinition> definitions =
+                    new ArrayList<GridPatternItemDefinition>();
+            definitions.add(
+                    new GridPatternItemDefinition(FIRST_ROW, FIRST_COLUMN, ONE_UNIT, ONE_UNIT));
+            definitions.add(
+                    new GridPatternItemDefinition(FIRST_ROW, SECOND_COLUMN, ONE_UNIT, ONE_UNIT));
+            view.addGridPatternGroupDefinition(definitions);
+        }
+    }
+}

--- a/library/src/androidTest/java/mobi/parchment/attributes/CellDividerInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/CellDividerInstrumentedTest.java
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.attributes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.util.List;
+import mobi.parchment.harness.HarnessActivity;
+import mobi.parchment.harness.LaidOutChildren;
+import mobi.parchment.harness.PaintedPixels;
+import mobi.parchment.harness.ParchmentViewHarness;
+import mobi.parchment.harness.PixelRun;
+import mobi.parchment.harness.SolidColourAdapter;
+import mobi.parchment.test.R;
+import mobi.parchment.widget.adapterview.listview.ListView;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Proves that parchment_divider and parchment_dividerSize, parsed by a real LayoutInflater, put
+ * real pixels on a real framework canvas between the cells of a ListView. Every expected band is
+ * written out as literal pixels rather than recomputed from the production formula, so a change to
+ * that formula fails here.
+ */
+@RunWith(AndroidJUnit4.class)
+public final class CellDividerInstrumentedTest {
+
+    private static final int VIEWPORT_WIDTH = 900;
+    private static final int VIEWPORT_HEIGHT = 600;
+    private static final int ITEM_WIDTH = 200;
+    private static final int ITEM_HEIGHT = 100;
+    private static final int ITEM_COUNT = 30;
+    private static final int SHORTER_THAN_VIEWPORT_COUNT = 3;
+    private static final int ONE_ITEM = 1;
+    private static final int NO_ITEMS = 0;
+    private static final int WRAPPING_ITEM_COUNT = 8;
+    private static final int LAST_WRAPPING_POSITION = WRAPPING_ITEM_COUNT - 1;
+    private static final int FIRST_POSITION = 0;
+    private static final int CELL_SPACING = 24;
+    private static final int NO_CELL_SPACING = 0;
+    private static final int START_BREADTH_PADDING = 40;
+    private static final int START_SIZE_PADDING = 30;
+    private static final int END_BREADTH_PADDING = 60;
+    private static final int CELL_COLOUR = 0xff0000ff;
+    private static final int DIVIDER_COLOUR = 0xff00ff00;
+    private static final int NOTHING_PAINTED = 0;
+    private static final int ONE_RUN = 1;
+    private static final int MATCH_PARENT = ViewGroup.LayoutParams.MATCH_PARENT;
+    private static final int A_COLUMN_INSIDE_EVERY_CELL = 100;
+    private static final int A_ROW_INSIDE_EVERY_CELL = 50;
+    private static final int A_COLUMN_INSIDE_THE_BREADTH_PADDING = 10;
+    private static final int INSIDE_THE_FIRST_CELL = 50;
+    private static final int UNDER_A_THICK_DIVIDER = 95;
+
+    private static final int[] VERTICAL_BAND_STARTS = {108, 232, 356, 480};
+    private static final int[] VERTICAL_BAND_ENDS = {116, 240, 364, 488};
+    private static final int[] HORIZONTAL_BAND_STARTS = {208, 432, 656, 880};
+    private static final int[] HORIZONTAL_BAND_ENDS = {216, 440, 664, 888};
+    private static final int[] INTRINSIC_BAND_STARTS = {107, 231, 355, 479};
+    private static final int[] INTRINSIC_BAND_ENDS = {117, 241, 365, 489};
+    private static final int[] HORIZONTAL_INTRINSIC_BAND_STARTS = {197, 421, 645, 869};
+    private static final int[] HORIZONTAL_INTRINSIC_BAND_ENDS = {227, 451, 675, 899};
+    private static final int[] THICK_BAND_STARTS = {92, 216, 340, 464};
+    private static final int[] THICK_BAND_ENDS = {132, 256, 380, 504};
+    private static final int[] NO_SPACING_BAND_STARTS = {96, 196, 296, 396, 496, 596};
+    private static final int[] NO_SPACING_BAND_ENDS = {104, 204, 304, 404, 504, 600};
+    private static final int[] PADDED_SHORT_BAND_STARTS = {234, 358};
+    private static final int[] PADDED_SHORT_BAND_ENDS = {242, 366};
+
+    @Rule
+    public final ActivityScenarioRule<HarnessActivity> mActivityRule =
+            new ActivityScenarioRule<>(HarnessActivity.class);
+
+    @Test
+    public void dividerInXml_isPaintedInEveryGapBetweenAdjacentCells() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachVerticalList(R.layout.instrumented_divider_vertical, ITEM_COUNT);
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        assertTrue(children.toString(), children.count() > 1);
+        assertEquals(children.toString(), CELL_SPACING, children.top(1) - children.bottom(0));
+        final List<PixelRun> painted = dividersDownTheList(pixels);
+        assertOneFewerDividerThanCells(children, painted);
+        assertBands(painted, VERTICAL_BAND_STARTS, VERTICAL_BAND_ENDS);
+    }
+
+    @Test
+    public void dividerInXml_inAHorizontalList_isPaintedAcrossTheGapAlongTheXAxis() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(
+                        R.layout.instrumented_divider_horizontal,
+                        ITEM_COUNT,
+                        ITEM_WIDTH,
+                        MATCH_PARENT);
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        assertTrue(children.toString(), children.count() > 1);
+        assertEquals(children.toString(), CELL_SPACING, children.left(1) - children.right(0));
+        final List<PixelRun> painted = dividersAcrossTheList(pixels);
+        assertOneFewerDividerThanCells(children, painted);
+        assertBands(painted, HORIZONTAL_BAND_STARTS, HORIZONTAL_BAND_ENDS);
+    }
+
+    @Test
+    public void divider_paintsNothingBeforeTheFirstCellOrAfterTheLast() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachVerticalList(
+                        R.layout.instrumented_divider_padded, SHORTER_THAN_VIEWPORT_COUNT);
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        assertEquals(children.toString(), SHORTER_THAN_VIEWPORT_COUNT, children.count());
+        final int lastIndex = children.count() - 1;
+        assertTrue(
+                "there has to be room above the first cell to paint into: " + children,
+                children.top(0) > 0);
+        assertTrue(
+                "there has to be room below the last cell to paint into: " + children,
+                children.bottom(lastIndex) < VIEWPORT_HEIGHT);
+        final List<PixelRun> painted = dividersDownTheList(pixels);
+        assertOneFewerDividerThanCells(children, painted);
+        assertBands(painted, PADDED_SHORT_BAND_STARTS, PADDED_SHORT_BAND_ENDS);
+        assertTrue(
+                "no divider may be painted above the first cell: " + painted + " for " + children,
+                painted.get(0).start() >= children.bottom(0));
+        assertTrue(
+                "no divider may be painted below the last cell: " + painted + " for " + children,
+                painted.get(painted.size() - 1).end() <= children.top(lastIndex));
+    }
+
+    @Test
+    public void divider_spansTheBreadthInsideThePaddingAndNoFurther() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachVerticalList(R.layout.instrumented_divider_padded, ITEM_COUNT);
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        assertEquals(children.toString(), START_SIZE_PADDING, children.top(0));
+        final List<PixelRun> down = dividersDownTheList(pixels);
+        assertTrue("some divider has to be painted: " + children, down.size() > 0);
+        final int insideADivider = down.get(0).start();
+        final List<PixelRun> across = pixels.runsAcrossRow(insideADivider, DIVIDER_COLOUR);
+        assertEquals("one unbroken divider across the breadth: " + across, ONE_RUN, across.size());
+        assertEquals(
+                "the divider starts at the start breadth padding: " + across,
+                START_BREADTH_PADDING,
+                across.get(0).start());
+        assertEquals(
+                "the divider ends at the end breadth padding: " + across,
+                VIEWPORT_WIDTH - END_BREADTH_PADDING,
+                across.get(0).end());
+        assertEquals(
+                "nothing may be painted in the breadth padding",
+                NOTHING_PAINTED,
+                pixels.colourAt(A_COLUMN_INSIDE_THE_BREADTH_PADDING, insideADivider));
+    }
+
+    @Test
+    public void noDividerInXml_paintsNothingBetweenTheCells() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachVerticalList(R.layout.instrumented_divider_absent, ITEM_COUNT);
+        final PaintedPixels pixels = harness.paint();
+
+        assertEquals(
+                "no pixel may carry the divider colour",
+                NOTHING_PAINTED,
+                pixels.countOfColour(DIVIDER_COLOUR));
+        assertEquals(
+                "the cells still paint",
+                CELL_COLOUR,
+                pixels.colourAt(A_COLUMN_INSIDE_EVERY_CELL, INSIDE_THE_FIRST_CELL));
+    }
+
+    @Test
+    public void aColourDividerWithNoDividerSizeInXml_paintsNothing() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachVerticalList(R.layout.instrumented_divider_colour_no_size, ITEM_COUNT);
+        final PaintedPixels pixels = harness.paint();
+
+        assertEquals(
+                "a colour has no intrinsic size, so nothing may be painted",
+                NOTHING_PAINTED,
+                pixels.countOfColour(DIVIDER_COLOUR));
+    }
+
+    @Test
+    public void dividerWithNoSize_scrollingVertically_takesTheDrawablesIntrinsicHeight() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachVerticalList(R.layout.instrumented_divider_intrinsic, ITEM_COUNT);
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        final List<PixelRun> painted = dividersDownTheList(pixels);
+        assertOneFewerDividerThanCells(children, painted);
+        assertBands(painted, INTRINSIC_BAND_STARTS, INTRINSIC_BAND_ENDS);
+    }
+
+    @Test
+    public void dividerWithNoSize_scrollingHorizontally_takesTheDrawablesIntrinsicWidth() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachList(
+                        R.layout.instrumented_divider_intrinsic_horizontal,
+                        ITEM_COUNT,
+                        ITEM_WIDTH,
+                        MATCH_PARENT);
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        final List<PixelRun> painted = dividersAcrossTheList(pixels);
+        assertOneFewerDividerThanCells(children, painted);
+        assertBands(painted, HORIZONTAL_INTRINSIC_BAND_STARTS, HORIZONTAL_INTRINSIC_BAND_ENDS);
+    }
+
+    @Test
+    public void aDividerThickerThanTheCellSpacing_isPaintedOverTheCellsItOverlaps() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachVerticalList(R.layout.instrumented_divider_thick, ITEM_COUNT);
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        final List<PixelRun> painted = dividersDownTheList(pixels);
+        assertOneFewerDividerThanCells(children, painted);
+        assertBands(painted, THICK_BAND_STARTS, THICK_BAND_ENDS);
+        assertEquals(
+                "the thick divider must cover the bottom of the first cell",
+                DIVIDER_COLOUR,
+                pixels.colourAt(A_COLUMN_INSIDE_EVERY_CELL, UNDER_A_THICK_DIVIDER));
+    }
+
+    @Test
+    public void aDividerWithNoCellSpacing_isPaintedOnTheBoundaryBetweenTheCells() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachVerticalList(R.layout.instrumented_divider_no_spacing, ITEM_COUNT);
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        assertTrue(children.toString(), children.count() > 1);
+        assertEquals(children.toString(), NO_CELL_SPACING, children.top(1) - children.bottom(0));
+        final List<PixelRun> painted = dividersDownTheList(pixels);
+        assertOneFewerDividerThanCells(children, painted);
+        assertBands(painted, NO_SPACING_BAND_STARTS, NO_SPACING_BAND_ENDS);
+    }
+
+    @Test
+    public void dividerWithCircularScroll_isPaintedAcrossTheWrapLikeAnyOtherGap() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachVerticalList(R.layout.instrumented_divider_circular, WRAPPING_ITEM_COUNT);
+        harness.setSelection(LAST_WRAPPING_POSITION);
+        harness.settle();
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        final int lastItemIndex = children.indexOfAdapterPosition(LAST_WRAPPING_POSITION);
+        assertTrue("the last item should be laid out: " + children, lastItemIndex >= 0);
+        assertTrue(
+                "the wrap should lay out cells after the last item: " + children,
+                lastItemIndex < children.count() - 1);
+        assertEquals(
+                "item 0 should follow the last item: " + children,
+                FIRST_POSITION,
+                children.adapterPosition(lastItemIndex + 1));
+        final List<PixelRun> painted = dividersDownTheList(pixels);
+        assertOneFewerDividerThanCells(children, painted);
+        assertBands(painted, VERTICAL_BAND_STARTS, VERTICAL_BAND_ENDS);
+    }
+
+    @Test
+    public void aSingleCellAdapter_paintsNoDivider() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachVerticalList(R.layout.instrumented_divider_vertical, ONE_ITEM);
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        assertEquals(children.toString(), ONE_ITEM, children.count());
+        assertEquals(
+                "one cell has no gap to divide",
+                NOTHING_PAINTED,
+                pixels.countOfColour(DIVIDER_COLOUR));
+    }
+
+    @Test
+    public void anEmptyAdapter_paintsNoDivider() {
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                attachVerticalList(R.layout.instrumented_divider_vertical, NO_ITEMS);
+        final LaidOutChildren children = harness.children();
+        final PaintedPixels pixels = harness.paint();
+
+        assertEquals(children.toString(), NO_ITEMS, children.count());
+        assertEquals(
+                "no cells means no dividers",
+                NOTHING_PAINTED,
+                pixels.countOfColour(DIVIDER_COLOUR));
+    }
+
+    private static List<PixelRun> dividersDownTheList(final PaintedPixels pixels) {
+        return pixels.runsDownColumn(A_COLUMN_INSIDE_EVERY_CELL, DIVIDER_COLOUR);
+    }
+
+    private static List<PixelRun> dividersAcrossTheList(final PaintedPixels pixels) {
+        return pixels.runsAcrossRow(A_ROW_INSIDE_EVERY_CELL, DIVIDER_COLOUR);
+    }
+
+    private static void assertOneFewerDividerThanCells(
+            final LaidOutChildren children, final List<PixelRun> painted) {
+        final int gapsBetweenCells = children.count() - 1;
+        assertEquals(
+                "one divider fewer than there are drawn cells, painted "
+                        + painted
+                        + " for "
+                        + children,
+                gapsBetweenCells,
+                painted.size());
+    }
+
+    private static void assertBands(
+            final List<PixelRun> painted, final int[] starts, final int[] ends) {
+        assertEquals("dividers painted: " + painted, starts.length, painted.size());
+        for (int index = 0; index < starts.length; index++) {
+            assertEquals(
+                    "start of divider " + index + " of " + painted,
+                    starts[index],
+                    painted.get(index).start());
+            assertEquals(
+                    "end of divider " + index + " of " + painted,
+                    ends[index],
+                    painted.get(index).end());
+        }
+    }
+
+    private ParchmentViewHarness<ListView<BaseAdapter>> attachVerticalList(
+            final int layoutResource, final int itemCount) {
+        return attachList(layoutResource, itemCount, MATCH_PARENT, ITEM_HEIGHT);
+    }
+
+    private ParchmentViewHarness<ListView<BaseAdapter>> attachList(
+            final int layoutResource,
+            final int itemCount,
+            final int itemWidth,
+            final int itemHeight) {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final ParchmentViewHarness<ListView<BaseAdapter>> harness =
+                ParchmentViewHarness.attach(
+                        mActivityRule.getScenario(),
+                        layoutResource,
+                        VIEWPORT_WIDTH,
+                        VIEWPORT_HEIGHT);
+        final SolidColourAdapter adapter =
+                new SolidColourAdapter(context, itemCount, itemWidth, itemHeight, CELL_COLOUR);
+        harness.setAdapter(adapter);
+        return harness;
+    }
+}

--- a/library/src/androidTest/java/mobi/parchment/attributes/CellDividerInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/attributes/CellDividerInstrumentedTest.java
@@ -140,7 +140,7 @@ public final class CellDividerInstrumentedTest {
     }
 
     @Test
-    public void divider_spansTheBreadthInsideThePaddingAndNoFurther() {
+    public void divider_withPaddingSet_spansTheRowsItSeparatesAndNoFurther() {
         final ParchmentViewHarness<ListView<BaseAdapter>> harness =
                 attachVerticalList(R.layout.instrumented_divider_padded, ITEM_COUNT);
         final LaidOutChildren children = harness.children();
@@ -153,12 +153,12 @@ public final class CellDividerInstrumentedTest {
         final List<PixelRun> across = pixels.runsAcrossRow(insideADivider, DIVIDER_COLOUR);
         assertEquals("one unbroken divider across the breadth: " + across, ONE_RUN, across.size());
         assertEquals(
-                "the divider starts at the start breadth padding: " + across,
-                START_BREADTH_PADDING,
+                "the divider starts where the rows it separates start: " + across,
+                children.left(0),
                 across.get(0).start());
         assertEquals(
-                "the divider ends at the end breadth padding: " + across,
-                VIEWPORT_WIDTH - END_BREADTH_PADDING,
+                "the divider ends where the rows it separates end: " + across,
+                children.right(0),
                 across.get(0).end());
         assertEquals(
                 "nothing may be painted in the breadth padding",

--- a/library/src/androidTest/java/mobi/parchment/harness/PaintedPixels.java
+++ b/library/src/androidTest/java/mobi/parchment/harness/PaintedPixels.java
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.harness;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An immutable snapshot of what a view actually painted, read on the main thread so a test never
+ * rasterises a live view from the instrumentation thread. Geometry is asserted through the runs of
+ * a colour along a row or a column: one run per thing painted, with the pixels it covers.
+ */
+public final class PaintedPixels {
+
+    private static final int NO_RUN = -1;
+
+    private final int[] mPixels;
+    private final int mWidth;
+    private final int mHeight;
+
+    public PaintedPixels(final int[] pixels, final int width, final int height) {
+        mPixels = pixels.clone();
+        mWidth = width;
+        mHeight = height;
+    }
+
+    public int width() {
+        return mWidth;
+    }
+
+    public int height() {
+        return mHeight;
+    }
+
+    public int colourAt(final int x, final int y) {
+        requireInside(x, y);
+        final int index = y * mWidth + x;
+        return mPixels[index];
+    }
+
+    /** The runs of the colour down the column at x, in top-to-bottom order. */
+    public List<PixelRun> runsDownColumn(final int x, final int colour) {
+        requireInside(x, 0);
+        final int firstIndex = x;
+        final int stride = mWidth;
+        return runsAlong(firstIndex, stride, mHeight, colour);
+    }
+
+    /** The runs of the colour across the row at y, in left-to-right order. */
+    public List<PixelRun> runsAcrossRow(final int y, final int colour) {
+        requireInside(0, y);
+        final int firstIndex = y * mWidth;
+        final int stride = 1;
+        return runsAlong(firstIndex, stride, mWidth, colour);
+    }
+
+    /** Every pixel of the colour, anywhere in the snapshot. */
+    public int countOfColour(final int colour) {
+        int count = 0;
+        for (int index = 0; index < mPixels.length; index++) {
+            if (mPixels[index] == colour) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private List<PixelRun> runsAlong(
+            final int firstIndex, final int stride, final int length, final int colour) {
+        final List<PixelRun> runs = new ArrayList<PixelRun>();
+        int runStart = NO_RUN;
+        for (int step = 0; step < length; step++) {
+            final int index = firstIndex + step * stride;
+            final boolean isColour = mPixels[index] == colour;
+            if (isColour && runStart == NO_RUN) {
+                runStart = step;
+            }
+            if (!isColour && runStart != NO_RUN) {
+                runs.add(new PixelRun(runStart, step));
+                runStart = NO_RUN;
+            }
+        }
+        if (runStart != NO_RUN) {
+            runs.add(new PixelRun(runStart, length));
+        }
+        return runs;
+    }
+
+    private void requireInside(final int x, final int y) {
+        final boolean isInside = x >= 0 && x < mWidth && y >= 0 && y < mHeight;
+        if (!isInside) {
+            throw new AssertionError(
+                    "(" + x + "," + y + ") is outside a " + mWidth + "x" + mHeight + " snapshot");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "painted pixels of a " + mWidth + "x" + mHeight + " view";
+    }
+}

--- a/library/src/androidTest/java/mobi/parchment/harness/ParchmentViewHarness.java
+++ b/library/src/androidTest/java/mobi/parchment/harness/ParchmentViewHarness.java
@@ -4,6 +4,8 @@
 package mobi.parchment.harness;
 
 import android.app.Instrumentation;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.os.SystemClock;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -34,6 +36,7 @@ public final class ParchmentViewHarness<VIEW extends AbstractAdapterView<BaseAda
     private static final float WHOLE_GESTURE = 1f;
     private static final int FRAME_MILLISECONDS = 16;
     private static final int NO_META_STATE = 0;
+    private static final int NO_OFFSET = 0;
     private static final int NO_HOLD = 0;
     private static final int RELEASE_HOLD_STEPS = 10;
 
@@ -93,6 +96,16 @@ public final class ParchmentViewHarness<VIEW extends AbstractAdapterView<BaseAda
         final ReadSelectedPosition<VIEW> readSelectedPosition = new ReadSelectedPosition<>(mView);
         InstrumentationRegistry.getInstrumentation().runOnMainSync(readSelectedPosition);
         return readSelectedPosition.selectedPosition();
+    }
+
+    /**
+     * Rasterises the view into a bitmap on the main thread and hands back an immutable snapshot of
+     * the pixels, so a test can assert what was painted and not only where the children landed.
+     */
+    public PaintedPixels paint() {
+        final DrawToBitmap<VIEW> drawToBitmap = new DrawToBitmap<>(mView);
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(drawToBitmap);
+        return drawToBitmap.paintedPixels();
     }
 
     /** Reads every child's bounds and adapter position on the main thread. */
@@ -474,6 +487,39 @@ public final class ParchmentViewHarness<VIEW extends AbstractAdapterView<BaseAda
                             adapterPositions,
                             mView.getWidth(),
                             mView.getHeight());
+        }
+    }
+
+    private static final class DrawToBitmap<VIEW extends AbstractAdapterView<BaseAdapter, ?>>
+            implements Runnable {
+
+        private final VIEW mView;
+        private PaintedPixels mPaintedPixels;
+
+        private DrawToBitmap(final VIEW view) {
+            mView = view;
+        }
+
+        private PaintedPixels paintedPixels() {
+            return mPaintedPixels;
+        }
+
+        @Override
+        public void run() {
+            final int width = mView.getWidth();
+            final int height = mView.getHeight();
+            final boolean hasSize = width > 0 && height > 0;
+            if (!hasSize) {
+                throw new AssertionError(
+                        "the view has no size to paint into: " + width + "x" + height);
+            }
+            final Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+            final Canvas canvas = new Canvas(bitmap);
+            mView.draw(canvas);
+            final int[] pixels = new int[width * height];
+            bitmap.getPixels(pixels, NO_OFFSET, width, NO_OFFSET, NO_OFFSET, width, height);
+            bitmap.recycle();
+            mPaintedPixels = new PaintedPixels(pixels, width, height);
         }
     }
 

--- a/library/src/androidTest/java/mobi/parchment/harness/PixelRun.java
+++ b/library/src/androidTest/java/mobi/parchment/harness/PixelRun.java
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.harness;
+
+/** An unbroken run of one colour along a single row or column of a {@link PaintedPixels}. */
+public final class PixelRun {
+
+    private final int mStart;
+    private final int mEnd;
+
+    public PixelRun(final int start, final int end) {
+        mStart = start;
+        mEnd = end;
+    }
+
+    /** The first pixel of the run. */
+    public int start() {
+        return mStart;
+    }
+
+    /** One past the last pixel of the run, so it reads like a view's right or bottom. */
+    public int end() {
+        return mEnd;
+    }
+
+    public int size() {
+        return mEnd - mStart;
+    }
+
+    @Override
+    public String toString() {
+        return "[" + mStart + ".." + mEnd + ")";
+    }
+}

--- a/library/src/androidTest/java/mobi/parchment/harness/SolidColourAdapter.java
+++ b/library/src/androidTest/java/mobi/parchment/harness/SolidColourAdapter.java
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.harness;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+
+/**
+ * An adapter of identically sized views filled with one solid colour, so a test that reads pixels
+ * can tell a cell from whatever a view paints over it.
+ */
+public final class SolidColourAdapter extends BaseAdapter {
+
+    private final Context mContext;
+    private final int mCount;
+    private final int mItemWidth;
+    private final int mItemHeight;
+    private final int mColour;
+
+    public SolidColourAdapter(
+            final Context context,
+            final int count,
+            final int itemWidth,
+            final int itemHeight,
+            final int colour) {
+        mContext = context;
+        mCount = count;
+        mItemWidth = itemWidth;
+        mItemHeight = itemHeight;
+        mColour = colour;
+    }
+
+    @Override
+    public int getCount() {
+        return mCount;
+    }
+
+    @Override
+    public Object getItem(final int position) {
+        return Integer.valueOf(position);
+    }
+
+    @Override
+    public long getItemId(final int position) {
+        return position;
+    }
+
+    @Override
+    public View getView(final int position, final View convertView, final ViewGroup parent) {
+        final View view = convertView == null ? new View(mContext) : convertView;
+        view.setBackgroundColor(mColour);
+        sizeTo(view, mItemWidth, mItemHeight);
+        return view;
+    }
+
+    private static void sizeTo(final View view, final int width, final int height) {
+        final ViewGroup.LayoutParams existing = view.getLayoutParams();
+        if (existing == null) {
+            giveNewLayoutParams(view, width, height);
+        } else {
+            resizeLayoutParams(existing, width, height);
+        }
+    }
+
+    private static void giveNewLayoutParams(final View view, final int width, final int height) {
+        view.setLayoutParams(new ViewGroup.LayoutParams(width, height));
+    }
+
+    private static void resizeLayoutParams(
+            final ViewGroup.LayoutParams layoutParams, final int width, final int height) {
+        layoutParams.width = width;
+        layoutParams.height = height;
+    }
+}

--- a/library/src/androidTest/java/mobi/parchment/widget/adapterview/listview/ListViewInstrumentedTest.java
+++ b/library/src/androidTest/java/mobi/parchment/widget/adapterview/listview/ListViewInstrumentedTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -97,14 +98,18 @@ public class ListViewInstrumentedTest {
                 final boolean isViewPager,
                 final AdapterViewManager adapterViewManager,
                 final LayoutManager<View> layoutManager,
-                final boolean isVerticalScroll) {
+                final boolean isVerticalScroll,
+                final Drawable divider,
+                final int dividerSize) {
             final AdapterViewInitializer<View> initializer =
                     super.createAdapterViewInitializer(
                             context,
                             isViewPager,
                             adapterViewManager,
                             layoutManager,
-                            isVerticalScroll);
+                            isVerticalScroll,
+                            divider,
+                            dividerSize);
             mGestureListener = initializer.getChildTouchListener();
             return initializer;
         }

--- a/library/src/androidTest/res/drawable/instrumented_divider_band.xml
+++ b/library/src/androidTest/res/drawable/instrumented_divider_band.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#ff00ff00" />
+    <size
+        android:width="30px"
+        android:height="10px" />
+</shape>

--- a/library/src/androidTest/res/layout/instrumented_divider_absent.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_absent.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_cellSpacing="24px" />

--- a/library/src/androidTest/res/layout/instrumented_divider_circular.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_circular.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_cellSpacing="24px"
+    parchment:parchment_snapToPosition="true"
+    parchment:parchment_isCircularScroll="true"
+    parchment:parchment_divider="#ff00ff00"
+    parchment:parchment_dividerSize="8px" />

--- a/library/src/androidTest/res/layout/instrumented_divider_colour_no_size.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_colour_no_size.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_cellSpacing="24px"
+    parchment:parchment_divider="#ff00ff00" />

--- a/library/src/androidTest/res/layout/instrumented_divider_grid.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_grid.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.gridview.GridView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_snapPosition="start"
+    parchment:parchment_numberOfViewsPerCell="3"
+    parchment:parchment_cellSpacing="24px"
+    parchment:parchment_divider="#ff00ff00"
+    parchment:parchment_dividerSize="8px" />

--- a/library/src/androidTest/res/layout/instrumented_divider_horizontal.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="horizontal"
+    parchment:parchment_cellSpacing="24px"
+    parchment:parchment_divider="#ff00ff00"
+    parchment:parchment_dividerSize="8px" />

--- a/library/src/androidTest/res/layout/instrumented_divider_intrinsic.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_intrinsic.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_cellSpacing="24px"
+    parchment:parchment_divider="@drawable/instrumented_divider_band" />

--- a/library/src/androidTest/res/layout/instrumented_divider_intrinsic_horizontal.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_intrinsic_horizontal.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="horizontal"
+    parchment:parchment_cellSpacing="24px"
+    parchment:parchment_divider="@drawable/instrumented_divider_band" />

--- a/library/src/androidTest/res/layout/instrumented_divider_no_spacing.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_no_spacing.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_divider="#ff00ff00"
+    parchment:parchment_dividerSize="8px" />

--- a/library/src/androidTest/res/layout/instrumented_divider_padded.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_padded.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingLeft="40px"
+    android:paddingTop="30px"
+    android:paddingRight="60px"
+    android:paddingBottom="50px"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_cellSpacing="24px"
+    parchment:parchment_divider="#ff00ff00"
+    parchment:parchment_dividerSize="8px" />

--- a/library/src/androidTest/res/layout/instrumented_divider_pattern.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_pattern.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.gridpatternview.GridPatternView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_snapPosition="start"
+    parchment:parchment_ratio="0.5"
+    parchment:parchment_cellSpacing="24px"
+    parchment:parchment_divider="#ff00ff00"
+    parchment:parchment_dividerSize="8px" />

--- a/library/src/androidTest/res/layout/instrumented_divider_thick.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_thick.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_cellSpacing="24px"
+    parchment:parchment_divider="#ff00ff00"
+    parchment:parchment_dividerSize="40px" />

--- a/library/src/androidTest/res/layout/instrumented_divider_vertical.xml
+++ b/library/src/androidTest/res/layout/instrumented_divider_vertical.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mobi.parchment.widget.adapterview.listview.ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:parchment="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/parchment_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    parchment:parchment_orientation="vertical"
+    parchment:parchment_cellSpacing="24px"
+    parchment:parchment_divider="#ff00ff00"
+    parchment:parchment_dividerSize="8px" />

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
@@ -5,6 +5,8 @@ package mobi.parchment.widget.adapterview;
 
 import android.content.Context;
 import android.database.DataSetObserver;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
 import android.os.Parcelable;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
@@ -71,7 +73,9 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
             final boolean isViewPager,
             final AdapterViewManager adapterViewManager,
             final LayoutManager<Cell> layoutManager,
-            final boolean isVerticalScroll) {
+            final boolean isVerticalScroll,
+            final Drawable divider,
+            final int dividerSize) {
         final LayoutManagerBridge layoutManagerBridge = new LayoutManagerBridge(layoutManager);
         final ViewConfiguration viewConfiguration = ViewConfiguration.get(context);
         final ChildTouchGestureListener childTouchGestureListener =
@@ -87,11 +91,17 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
         final AdapterViewGestureDetector adapterViewGestureDetector =
                 new AdapterViewGestureDetector(context, childTouchGestureListener);
 
+        final ScrollDirectionManager scrollDirectionManager =
+                layoutManager.getScrollDirectionManager();
+        final CellDivider cellDivider =
+                new CellDivider(divider, dividerSize, scrollDirectionManager);
+
         return new AdapterViewInitializer<Cell>(
                 childTouchGestureListener,
                 adapterViewGestureDetector,
                 layoutManager,
-                adapterViewManager);
+                adapterViewManager,
+                cellDivider);
     }
 
     protected abstract AdapterViewInitializer<Cell> getAdapterViewInitializer(
@@ -238,6 +248,14 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
             default:
                 break;
         }
+    }
+
+    @Override
+    protected void dispatchDraw(final Canvas canvas) {
+        super.dispatchDraw(canvas);
+        final LayoutManager<Cell> layoutManager = mAdapterViewInitializer.getLayoutManager();
+        final CellDivider cellDivider = mAdapterViewInitializer.getCellDivider();
+        cellDivider.draw(canvas, this, layoutManager);
     }
 
     @Override

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AbstractAdapterView.java
@@ -255,7 +255,7 @@ public abstract class AbstractAdapterView<ADAPTER extends Adapter, Cell>
         super.dispatchDraw(canvas);
         final LayoutManager<Cell> layoutManager = mAdapterViewInitializer.getLayoutManager();
         final CellDivider cellDivider = mAdapterViewInitializer.getCellDivider();
-        cellDivider.draw(canvas, this, layoutManager);
+        cellDivider.draw(canvas, layoutManager);
     }
 
     @Override

--- a/library/src/main/java/mobi/parchment/widget/adapterview/AdapterViewInitializer.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/AdapterViewInitializer.java
@@ -11,16 +11,19 @@ public class AdapterViewInitializer<Cell> {
     private final GestureDetector mGestureDetector;
     private final LayoutManager<Cell> mLayoutManager;
     private final AdapterViewManager mAdapterViewManager;
+    private final CellDivider mCellDivider;
 
     public AdapterViewInitializer(
             final ChildTouchGestureListener childTouchListener,
             final GestureDetector gestureDetector,
             final LayoutManager<Cell> layoutManager,
-            final AdapterViewManager adapterViewManager) {
+            final AdapterViewManager adapterViewManager,
+            final CellDivider cellDivider) {
         mChildTouchListener = childTouchListener;
         mGestureDetector = gestureDetector;
         mLayoutManager = layoutManager;
         mAdapterViewManager = adapterViewManager;
+        mCellDivider = cellDivider;
     }
 
     public ChildTouchGestureListener getChildTouchListener() {
@@ -37,5 +40,9 @@ public class AdapterViewInitializer<Cell> {
 
     public AdapterViewManager getAdapterViewManager() {
         return mAdapterViewManager;
+    }
+
+    protected final CellDivider getCellDivider() {
+        return mCellDivider;
     }
 }

--- a/library/src/main/java/mobi/parchment/widget/adapterview/Attributes.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/Attributes.java
@@ -5,6 +5,7 @@ package mobi.parchment.widget.adapterview;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import mobi.parchment.R;
 
@@ -20,6 +21,9 @@ public class Attributes {
         private static final boolean SELECT_ON_SNAP = false;
         private static final SnapPosition SNAP_POSITION = SnapPosition.center;
         private static final boolean SELECT_WHILE_SCROLLING = false;
+        private static final Drawable DIVIDER = null;
+        private static final int DIVIDER_SIZE = CellDivider.INTRINSIC_SIZE;
+        private static final int NO_DIVIDER_SIZE = 0;
     }
 
     private Orientation mOrientation;
@@ -33,6 +37,8 @@ public class Attributes {
 
     private boolean mIsViewPager;
     private int mViewPagerInterval;
+    private Drawable mDivider;
+    private int mDividerSize;
 
     public Attributes(final Context context, final AttributeSet attributeSet) {
         initialize(context, attributeSet);
@@ -83,6 +89,8 @@ public class Attributes {
                         typedArray.getBoolean(
                                 R.styleable.ListView_parchment_selectWhileScrolling,
                                 DefaultValues.SELECT_WHILE_SCROLLING);
+                mDivider = typedArray.getDrawable(R.styleable.ListView_parchment_divider);
+                mDividerSize = getDividerSize(typedArray);
 
                 final int orientationOrdinal =
                         typedArray.getInteger(
@@ -109,6 +117,8 @@ public class Attributes {
             mSelectOnSnap = DefaultValues.SELECT_ON_SNAP;
             mSelectWhileScrolling = DefaultValues.SELECT_WHILE_SCROLLING;
             mOrientation = DefaultValues.ORIENTATION;
+            mDivider = DefaultValues.DIVIDER;
+            mDividerSize = DefaultValues.DIVIDER_SIZE;
         }
 
         final boolean isVertical = mOrientation == Orientation.vertical;
@@ -149,6 +159,30 @@ public class Attributes {
 
     public boolean selectWhileScrolling() {
         return mSelectWhileScrolling;
+    }
+
+    private static int getDividerSize(final TypedArray typedArray) {
+        final boolean isDividerSizeDeclared =
+                typedArray.hasValue(R.styleable.ListView_parchment_dividerSize);
+        if (isDividerSizeDeclared) {
+            return getDeclaredDividerSize(typedArray);
+        }
+        return DefaultValues.DIVIDER_SIZE;
+    }
+
+    private static int getDeclaredDividerSize(final TypedArray typedArray) {
+        final int dividerSize =
+                typedArray.getDimensionPixelSize(
+                        R.styleable.ListView_parchment_dividerSize, DefaultValues.NO_DIVIDER_SIZE);
+        return Math.max(dividerSize, DefaultValues.NO_DIVIDER_SIZE);
+    }
+
+    public Drawable getDivider() {
+        return mDivider;
+    }
+
+    public int getDividerSize() {
+        return mDividerSize;
     }
 
     protected void setIsVertical(final boolean isVertical) {

--- a/library/src/main/java/mobi/parchment/widget/adapterview/CellDivider.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/CellDivider.java
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.view.ViewGroup;
+
+public final class CellDivider {
+
+    protected static final int INTRINSIC_SIZE = -1;
+
+    private static final int NO_DIVIDER_SIZE = 0;
+    private static final int FIRST_CELL_WITH_A_DIVIDER_BEFORE_IT = 1;
+    private static final int ONE_CELL = 1;
+    private static final int HALVES = 2;
+
+    private final Rect mBounds = new Rect();
+    private final ScrollDirectionManager mScrollDirectionManager;
+    private final Drawable mDivider;
+    private final int mDividerSize;
+
+    public CellDivider(
+            final Drawable divider,
+            final int dividerSize,
+            final ScrollDirectionManager scrollDirectionManager) {
+        mDivider = divider;
+        mScrollDirectionManager = scrollDirectionManager;
+        mDividerSize = getResolvedDividerSize(divider, dividerSize, scrollDirectionManager);
+    }
+
+    private static int getResolvedDividerSize(
+            final Drawable divider,
+            final int dividerSize,
+            final ScrollDirectionManager scrollDirectionManager) {
+        if (divider == null) return NO_DIVIDER_SIZE;
+
+        final boolean isDividerSizeDeclared = dividerSize != INTRINSIC_SIZE;
+        if (isDividerSizeDeclared) {
+            return getDeclaredDividerSize(dividerSize);
+        }
+        return getIntrinsicDividerSize(divider, scrollDirectionManager);
+    }
+
+    private static int getDeclaredDividerSize(final int dividerSize) {
+        return Math.max(dividerSize, NO_DIVIDER_SIZE);
+    }
+
+    private static int getIntrinsicDividerSize(
+            final Drawable divider, final ScrollDirectionManager scrollDirectionManager) {
+        final int intrinsicSize = scrollDirectionManager.getDrawableSize(divider);
+        return Math.max(intrinsicSize, NO_DIVIDER_SIZE);
+    }
+
+    protected static int getDividerStart(
+            final int gapStart, final int gapEnd, final int dividerSize) {
+        final int gapSize = gapEnd - gapStart;
+        final int halfGapSize = gapSize / HALVES;
+        final int gapMiddle = gapStart + halfGapSize;
+        final int halfDividerSize = dividerSize / HALVES;
+        final int dividerStart = gapMiddle - halfDividerSize;
+        return dividerStart;
+    }
+
+    public void draw(
+            final Canvas canvas, final ViewGroup viewGroup, final LayoutManager<?> layoutManager) {
+        if (mDividerSize == NO_DIVIDER_SIZE) return;
+
+        final int breadth =
+                mScrollDirectionManager.getDrawBreadth(
+                        viewGroup.getLeft(),
+                        viewGroup.getTop(),
+                        viewGroup.getRight(),
+                        viewGroup.getBottom());
+        final int breadthStart = layoutManager.getStartBreadthPadding();
+        final int endBreadthPadding = layoutManager.getEndBreadthPadding();
+        final int breadthEnd = breadth - endBreadthPadding;
+        final int cellCount = layoutManager.getDrawnCellCount();
+
+        for (int cellIndex = FIRST_CELL_WITH_A_DIVIDER_BEFORE_IT;
+                cellIndex < cellCount;
+                cellIndex++) {
+            final int previousCellIndex = cellIndex - ONE_CELL;
+            final int gapStart = layoutManager.getDrawnCellEnd(previousCellIndex);
+            final int gapEnd = layoutManager.getDrawnCellStart(cellIndex);
+            final int dividerStart = getDividerStart(gapStart, gapEnd, mDividerSize);
+            final int dividerEnd = dividerStart + mDividerSize;
+
+            mScrollDirectionManager.setDrawBounds(
+                    mBounds, dividerStart, dividerEnd, breadthStart, breadthEnd);
+            mDivider.setBounds(mBounds);
+            mDivider.draw(canvas);
+        }
+    }
+}

--- a/library/src/main/java/mobi/parchment/widget/adapterview/CellDivider.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/CellDivider.java
@@ -6,19 +6,24 @@ package mobi.parchment.widget.adapterview;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
-import android.view.ViewGroup;
+import android.view.View;
+import mobi.parchment.widget.adapterview.divideraxis.BreadthDividerAxis;
+import mobi.parchment.widget.adapterview.divideraxis.DividerAxisInterface;
+import mobi.parchment.widget.adapterview.divideraxis.SizeDividerAxis;
 
 public final class CellDivider {
 
     protected static final int INTRINSIC_SIZE = -1;
 
     private static final int NO_DIVIDER_SIZE = 0;
-    private static final int FIRST_CELL_WITH_A_DIVIDER_BEFORE_IT = 1;
+    private static final int FIRST_CELL = 0;
     private static final int ONE_CELL = 1;
+    private static final int FIRST_VIEW = 0;
     private static final int HALVES = 2;
 
     private final Rect mBounds = new Rect();
-    private final ScrollDirectionManager mScrollDirectionManager;
+    private final DividerAxisInterface mSizeAxis;
+    private final DividerAxisInterface mBreadthAxis;
     private final Drawable mDivider;
     private final int mDividerSize;
 
@@ -27,7 +32,8 @@ public final class CellDivider {
             final int dividerSize,
             final ScrollDirectionManager scrollDirectionManager) {
         mDivider = divider;
-        mScrollDirectionManager = scrollDirectionManager;
+        mSizeAxis = new SizeDividerAxis(scrollDirectionManager);
+        mBreadthAxis = new BreadthDividerAxis(scrollDirectionManager);
         mDividerSize = getResolvedDividerSize(divider, dividerSize, scrollDirectionManager);
     }
 
@@ -64,34 +70,141 @@ public final class CellDivider {
         return dividerStart;
     }
 
-    public void draw(
-            final Canvas canvas, final ViewGroup viewGroup, final LayoutManager<?> layoutManager) {
+    protected static int getLastCandidateCellIndex(final int cellIndex, final int cellCount) {
+        final int nextCellIndex = cellIndex + ONE_CELL;
+        final int lastCellIndex = cellCount - ONE_CELL;
+        return Math.min(nextCellIndex, lastCellIndex);
+    }
+
+    public void draw(final Canvas canvas, final LayoutManager<?> layoutManager) {
         if (mDividerSize == NO_DIVIDER_SIZE) return;
 
-        final int breadth =
-                mScrollDirectionManager.getDrawBreadth(
-                        viewGroup.getLeft(),
-                        viewGroup.getTop(),
-                        viewGroup.getRight(),
-                        viewGroup.getBottom());
-        final int breadthStart = layoutManager.getStartBreadthPadding();
-        final int endBreadthPadding = layoutManager.getEndBreadthPadding();
-        final int breadthEnd = breadth - endBreadthPadding;
         final int cellCount = layoutManager.getDrawnCellCount();
-
-        for (int cellIndex = FIRST_CELL_WITH_A_DIVIDER_BEFORE_IT;
-                cellIndex < cellCount;
-                cellIndex++) {
-            final int previousCellIndex = cellIndex - ONE_CELL;
-            final int gapStart = layoutManager.getDrawnCellEnd(previousCellIndex);
-            final int gapEnd = layoutManager.getDrawnCellStart(cellIndex);
-            final int dividerStart = getDividerStart(gapStart, gapEnd, mDividerSize);
-            final int dividerEnd = dividerStart + mDividerSize;
-
-            mScrollDirectionManager.setDrawBounds(
-                    mBounds, dividerStart, dividerEnd, breadthStart, breadthEnd);
-            mDivider.setBounds(mBounds);
-            mDivider.draw(canvas);
+        for (int cellIndex = FIRST_CELL; cellIndex < cellCount; cellIndex++) {
+            drawCellEdges(canvas, layoutManager, cellIndex, cellCount);
         }
+    }
+
+    private void drawCellEdges(
+            final Canvas canvas,
+            final LayoutManager<?> layoutManager,
+            final int cellIndex,
+            final int cellCount) {
+        final int viewCount = layoutManager.getDrawnCellViewCount(cellIndex);
+        for (int viewIndex = FIRST_VIEW; viewIndex < viewCount; viewIndex++) {
+            final View item = layoutManager.getDrawnCellView(cellIndex, viewIndex);
+            drawEdges(canvas, layoutManager, item, cellIndex, cellCount, mSizeAxis);
+            drawEdges(canvas, layoutManager, item, cellIndex, cellCount, mBreadthAxis);
+        }
+    }
+
+    private void drawEdges(
+            final Canvas canvas,
+            final LayoutManager<?> layoutManager,
+            final View item,
+            final int cellIndex,
+            final int cellCount,
+            final DividerAxisInterface axis) {
+        final int lastCellIndex = getLastCandidateCellIndex(cellIndex, cellCount);
+        for (int candidateCellIndex = cellIndex;
+                candidateCellIndex <= lastCellIndex;
+                candidateCellIndex++) {
+            final int candidateCount = layoutManager.getDrawnCellViewCount(candidateCellIndex);
+            for (int candidateIndex = FIRST_VIEW;
+                    candidateIndex < candidateCount;
+                    candidateIndex++) {
+                final View neighbour =
+                        layoutManager.getDrawnCellView(candidateCellIndex, candidateIndex);
+                drawEdge(canvas, layoutManager, item, neighbour, cellIndex, lastCellIndex, axis);
+            }
+        }
+    }
+
+    private void drawEdge(
+            final Canvas canvas,
+            final LayoutManager<?> layoutManager,
+            final View item,
+            final View neighbour,
+            final int cellIndex,
+            final int lastCellIndex,
+            final DividerAxisInterface axis) {
+        final int itemStart = axis.getStart(item);
+        final int itemEnd = axis.getEnd(item);
+        final int neighbourStart = axis.getStart(neighbour);
+        final int neighbourEnd = axis.getEnd(neighbour);
+        final boolean isAcrossTheEndEdge =
+                CellEdges.isAcrossTheEndEdge(itemStart, itemEnd, neighbourStart, neighbourEnd);
+        if (!isAcrossTheEndEdge) return;
+
+        final int itemBandStart = axis.getBandStart(item);
+        final int itemBandEnd = axis.getBandEnd(item);
+        final int neighbourBandStart = axis.getBandStart(neighbour);
+        final int neighbourBandEnd = axis.getBandEnd(neighbour);
+        final int bandStart = CellEdges.getOverlapStart(itemBandStart, neighbourBandStart);
+        final int bandEnd = CellEdges.getOverlapEnd(itemBandEnd, neighbourBandEnd);
+        if (!CellEdges.isAnOverlap(bandStart, bandEnd)) return;
+
+        final boolean isOccupied =
+                isGapOccupied(
+                        layoutManager,
+                        cellIndex,
+                        lastCellIndex,
+                        itemStart,
+                        itemEnd,
+                        neighbourStart,
+                        neighbourEnd,
+                        bandStart,
+                        bandEnd,
+                        axis);
+        if (isOccupied) return;
+
+        final int dividerStart = getDividerStart(itemEnd, neighbourStart, mDividerSize);
+        final int dividerEnd = dividerStart + mDividerSize;
+        axis.setDividerBounds(mBounds, dividerStart, dividerEnd, bandStart, bandEnd);
+        mDivider.setBounds(mBounds);
+        mDivider.draw(canvas);
+    }
+
+    private boolean isGapOccupied(
+            final LayoutManager<?> layoutManager,
+            final int cellIndex,
+            final int lastCellIndex,
+            final int itemStart,
+            final int itemEnd,
+            final int neighbourStart,
+            final int neighbourEnd,
+            final int bandStart,
+            final int bandEnd,
+            final DividerAxisInterface axis) {
+        for (int candidateCellIndex = cellIndex;
+                candidateCellIndex <= lastCellIndex;
+                candidateCellIndex++) {
+            final int candidateCount = layoutManager.getDrawnCellViewCount(candidateCellIndex);
+            for (int candidateIndex = FIRST_VIEW;
+                    candidateIndex < candidateCount;
+                    candidateIndex++) {
+                final View candidate =
+                        layoutManager.getDrawnCellView(candidateCellIndex, candidateIndex);
+                final int candidateStart = axis.getStart(candidate);
+                final int candidateEnd = axis.getEnd(candidate);
+                final boolean isInTheGap =
+                        CellEdges.isInTheGap(
+                                itemStart,
+                                itemEnd,
+                                neighbourStart,
+                                neighbourEnd,
+                                candidateStart,
+                                candidateEnd);
+                if (!isInTheGap) continue;
+
+                final int candidateBandStart = axis.getBandStart(candidate);
+                final int candidateBandEnd = axis.getBandEnd(candidate);
+                final boolean reachesTheBand =
+                        CellEdges.reachesTheBand(
+                                bandStart, bandEnd, candidateBandStart, candidateBandEnd);
+                if (reachesTheBand) return true;
+            }
+        }
+        return false;
     }
 }

--- a/library/src/main/java/mobi/parchment/widget/adapterview/CellEdges.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/CellEdges.java
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+public final class CellEdges {
+
+    private CellEdges() {}
+
+    public static boolean isAcrossTheEndEdge(
+            final int itemStart,
+            final int itemEnd,
+            final int neighbourStart,
+            final int neighbourEnd) {
+        final boolean neighbourStartsNoEarlier = neighbourStart >= itemStart;
+        final boolean neighbourReachesFurther = neighbourEnd > itemEnd;
+        return neighbourStartsNoEarlier && neighbourReachesFurther;
+    }
+
+    public static int getOverlapStart(final int itemStart, final int neighbourStart) {
+        return Math.max(itemStart, neighbourStart);
+    }
+
+    public static int getOverlapEnd(final int itemEnd, final int neighbourEnd) {
+        return Math.min(itemEnd, neighbourEnd);
+    }
+
+    public static boolean isAnOverlap(final int overlapStart, final int overlapEnd) {
+        return overlapEnd > overlapStart;
+    }
+
+    public static boolean isInTheGap(
+            final int itemStart,
+            final int itemEnd,
+            final int neighbourStart,
+            final int neighbourEnd,
+            final int candidateStart,
+            final int candidateEnd) {
+        final boolean isAfterTheItem =
+                isAcrossTheEndEdge(itemStart, itemEnd, candidateStart, candidateEnd);
+        final boolean isBeforeTheNeighbour =
+                isAcrossTheEndEdge(candidateStart, candidateEnd, neighbourStart, neighbourEnd);
+        return isAfterTheItem && isBeforeTheNeighbour;
+    }
+
+    public static boolean reachesTheBand(
+            final int bandStart,
+            final int bandEnd,
+            final int candidateStart,
+            final int candidateEnd) {
+        final int overlapStart = getOverlapStart(bandStart, candidateStart);
+        final int overlapEnd = getOverlapEnd(bandEnd, candidateEnd);
+        return isAnOverlap(overlapStart, overlapEnd);
+    }
+}

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
@@ -149,6 +149,10 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
 
     public abstract List<View> getViews(final Cell cell);
 
+    public abstract int getCellViewCount(final Cell cell);
+
+    public abstract View getCellView(final Cell cell, final int viewIndex);
+
     protected abstract Cell getCell(final int adapterPosition);
 
     public abstract void layoutCell(
@@ -575,6 +579,16 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
 
     protected final int getDrawnCellCount() {
         return mCells.size();
+    }
+
+    protected final int getDrawnCellViewCount(final int cellIndex) {
+        final Cell cell = mCells.get(cellIndex);
+        return getCellViewCount(cell);
+    }
+
+    protected final View getDrawnCellView(final int cellIndex, final int viewIndex) {
+        final Cell cell = mCells.get(cellIndex);
+        return getCellView(cell, viewIndex);
     }
 
     protected final int getDrawnCellStart(final int cellIndex) {

--- a/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/LayoutManager.java
@@ -569,6 +569,24 @@ public abstract class LayoutManager<Cell> extends AdapterViewDataSetObserver {
         return nearestView;
     }
 
+    protected final ScrollDirectionManager getScrollDirectionManager() {
+        return mScrollDirectionManager;
+    }
+
+    protected final int getDrawnCellCount() {
+        return mCells.size();
+    }
+
+    protected final int getDrawnCellStart(final int cellIndex) {
+        final Cell cell = mCells.get(cellIndex);
+        return getCellStart(cell);
+    }
+
+    protected final int getDrawnCellEnd(final int cellIndex) {
+        final Cell cell = mCells.get(cellIndex);
+        return getCellEnd(cell);
+    }
+
     public int getCellCenter(final Cell cell) {
         return (getCellStart(cell) + getCellEnd(cell)) / 2;
     }

--- a/library/src/main/java/mobi/parchment/widget/adapterview/ScrollDirectionManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/ScrollDirectionManager.java
@@ -3,6 +3,8 @@
 
 package mobi.parchment.widget.adapterview;
 
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;
 import mobi.parchment.widget.adapterview.utilities.ViewGroupUtilities;
@@ -56,5 +58,41 @@ public class ScrollDirectionManager {
     public int getDrawBreadth(int left, int top, int right, int bottom) {
         if (isVerticalScroll()) return right - left;
         return bottom - top;
+    }
+
+    public int getDrawableSize(final Drawable drawable) {
+        if (isVerticalScroll()) return drawable.getIntrinsicHeight();
+        return drawable.getIntrinsicWidth();
+    }
+
+    public void setDrawBounds(
+            final Rect bounds,
+            final int start,
+            final int end,
+            final int breadthStart,
+            final int breadthEnd) {
+        if (isVerticalScroll()) {
+            setVerticalDrawBounds(bounds, start, end, breadthStart, breadthEnd);
+        } else {
+            setHorizontalDrawBounds(bounds, start, end, breadthStart, breadthEnd);
+        }
+    }
+
+    private static void setVerticalDrawBounds(
+            final Rect bounds,
+            final int start,
+            final int end,
+            final int breadthStart,
+            final int breadthEnd) {
+        bounds.set(breadthStart, start, breadthEnd, end);
+    }
+
+    private static void setHorizontalDrawBounds(
+            final Rect bounds,
+            final int start,
+            final int end,
+            final int breadthStart,
+            final int breadthEnd) {
+        bounds.set(start, breadthStart, end, breadthEnd);
     }
 }

--- a/library/src/main/java/mobi/parchment/widget/adapterview/ScrollDirectionManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/ScrollDirectionManager.java
@@ -40,6 +40,16 @@ public class ScrollDirectionManager {
         return view.getMeasuredWidth();
     }
 
+    public int getViewBreadthStart(final View view) {
+        if (isVerticalScroll()) return view.getLeft();
+        return view.getTop();
+    }
+
+    public int getViewBreadthEnd(final View view) {
+        if (isVerticalScroll()) return view.getRight();
+        return view.getBottom();
+    }
+
     public int getViewBreadth(final View view) {
         if (isVerticalScroll()) return view.getMeasuredWidth();
         return view.getMeasuredHeight();

--- a/library/src/main/java/mobi/parchment/widget/adapterview/divideraxis/BreadthDividerAxis.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/divideraxis/BreadthDividerAxis.java
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview.divideraxis;
+
+import android.graphics.Rect;
+import android.view.View;
+import mobi.parchment.widget.adapterview.ScrollDirectionManager;
+
+public final class BreadthDividerAxis implements DividerAxisInterface {
+
+    private final ScrollDirectionManager mScrollDirectionManager;
+
+    public BreadthDividerAxis(final ScrollDirectionManager scrollDirectionManager) {
+        mScrollDirectionManager = scrollDirectionManager;
+    }
+
+    @Override
+    public int getStart(final View view) {
+        return mScrollDirectionManager.getViewBreadthStart(view);
+    }
+
+    @Override
+    public int getEnd(final View view) {
+        return mScrollDirectionManager.getViewBreadthEnd(view);
+    }
+
+    @Override
+    public int getBandStart(final View view) {
+        return mScrollDirectionManager.getViewStart(view);
+    }
+
+    @Override
+    public int getBandEnd(final View view) {
+        return mScrollDirectionManager.getViewEnd(view);
+    }
+
+    @Override
+    public void setDividerBounds(
+            final Rect bounds,
+            final int dividerStart,
+            final int dividerEnd,
+            final int bandStart,
+            final int bandEnd) {
+        mScrollDirectionManager.setDrawBounds(bounds, bandStart, bandEnd, dividerStart, dividerEnd);
+    }
+}

--- a/library/src/main/java/mobi/parchment/widget/adapterview/divideraxis/DividerAxisInterface.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/divideraxis/DividerAxisInterface.java
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview.divideraxis;
+
+import android.graphics.Rect;
+import android.view.View;
+
+public interface DividerAxisInterface {
+
+    public int getStart(final View view);
+
+    public int getEnd(final View view);
+
+    public int getBandStart(final View view);
+
+    public int getBandEnd(final View view);
+
+    public void setDividerBounds(
+            final Rect bounds,
+            final int dividerStart,
+            final int dividerEnd,
+            final int bandStart,
+            final int bandEnd);
+}

--- a/library/src/main/java/mobi/parchment/widget/adapterview/divideraxis/SizeDividerAxis.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/divideraxis/SizeDividerAxis.java
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview.divideraxis;
+
+import android.graphics.Rect;
+import android.view.View;
+import mobi.parchment.widget.adapterview.ScrollDirectionManager;
+
+public final class SizeDividerAxis implements DividerAxisInterface {
+
+    private final ScrollDirectionManager mScrollDirectionManager;
+
+    public SizeDividerAxis(final ScrollDirectionManager scrollDirectionManager) {
+        mScrollDirectionManager = scrollDirectionManager;
+    }
+
+    @Override
+    public int getStart(final View view) {
+        return mScrollDirectionManager.getViewStart(view);
+    }
+
+    @Override
+    public int getEnd(final View view) {
+        return mScrollDirectionManager.getViewEnd(view);
+    }
+
+    @Override
+    public int getBandStart(final View view) {
+        return mScrollDirectionManager.getViewBreadthStart(view);
+    }
+
+    @Override
+    public int getBandEnd(final View view) {
+        return mScrollDirectionManager.getViewBreadthEnd(view);
+    }
+
+    @Override
+    public void setDividerBounds(
+            final Rect bounds,
+            final int dividerStart,
+            final int dividerEnd,
+            final int bandStart,
+            final int bandEnd) {
+        mScrollDirectionManager.setDrawBounds(bounds, dividerStart, dividerEnd, bandStart, bandEnd);
+    }
+}

--- a/library/src/main/java/mobi/parchment/widget/adapterview/gridpatternview/GridPatternGroup.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/gridpatternview/GridPatternGroup.java
@@ -119,6 +119,10 @@ public class GridPatternGroup {
         return mViews;
     }
 
+    public View getView(final int index) {
+        return mViews.get(index);
+    }
+
     public int getWidth() {
         if (mViews.isEmpty()) {
             return 0;

--- a/library/src/main/java/mobi/parchment/widget/adapterview/gridpatternview/GridPatternLayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/gridpatternview/GridPatternLayoutManager.java
@@ -109,6 +109,16 @@ public class GridPatternLayoutManager extends LayoutManager<GridPatternGroup> {
     }
 
     @Override
+    public int getCellViewCount(final GridPatternGroup gridPatternGroup) {
+        return gridPatternGroup.getNumberOfItems();
+    }
+
+    @Override
+    public View getCellView(final GridPatternGroup gridPatternGroup, final int viewIndex) {
+        return gridPatternGroup.getView(viewIndex);
+    }
+
+    @Override
     protected GridPatternGroup getCell(final int adapterPosition) {
         final GridPatternGroupDefinition gridPatternGroupDefinition =
                 getGridPatternGroupDefinition(adapterPosition);

--- a/library/src/main/java/mobi/parchment/widget/adapterview/gridpatternview/GridPatternView.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/gridpatternview/GridPatternView.java
@@ -4,6 +4,7 @@
 package mobi.parchment.widget.adapterview.gridpatternview;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
@@ -49,6 +50,8 @@ public class GridPatternView<ADAPTER extends Adapter>
         final SnapPosition snapPosition = gridPatternAttributes.getSnapPosition();
         final boolean selectOnSnap = gridPatternAttributes.selectOnSnap();
         final boolean selectWhileScrolling = gridPatternAttributes.selectWhileScrolling();
+        final Drawable divider = gridPatternAttributes.getDivider();
+        final int dividerSize = gridPatternAttributes.getDividerSize();
         final float ratio = gridPatternAttributes.getRatio();
         mIsVerticalScroll = gridPatternAttributes.isVertical();
 
@@ -75,7 +78,9 @@ public class GridPatternView<ADAPTER extends Adapter>
                         isViewPager,
                         adapterViewManager,
                         mGridPatternLayoutManager,
-                        mIsVerticalScroll);
+                        mIsVerticalScroll,
+                        divider,
+                        dividerSize);
         return adapterViewAdapterInitializer;
     }
 

--- a/library/src/main/java/mobi/parchment/widget/adapterview/gridview/GridLayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/gridview/GridLayoutManager.java
@@ -159,6 +159,16 @@ public class GridLayoutManager extends LayoutManager<Group> {
         return group.getViews();
     }
 
+    @Override
+    public int getCellViewCount(final Group group) {
+        return group.getNumberOfItems();
+    }
+
+    @Override
+    public View getCellView(final Group group, final int viewIndex) {
+        return group.getView(viewIndex);
+    }
+
     public int getNumberOfViewsPerCell() {
         return mGridLayoutManagerAttributes.getNumberOfViewsPerCell();
     }

--- a/library/src/main/java/mobi/parchment/widget/adapterview/gridview/GridView.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/gridview/GridView.java
@@ -4,6 +4,7 @@
 package mobi.parchment.widget.adapterview.gridview;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
@@ -45,6 +46,8 @@ public class GridView<ADAPTER extends Adapter> extends AbstractAdapterView<ADAPT
         final SnapPosition snapPosition = gridAttributes.getSnapPosition();
         final boolean selectOnSnap = gridAttributes.selectOnSnap();
         final boolean selectWhileScrolling = gridAttributes.selectWhileScrolling();
+        final Drawable divider = gridAttributes.getDivider();
+        final int dividerSize = gridAttributes.getDividerSize();
         final boolean isTop = gridAttributes.isTop();
         final boolean isBottom = gridAttributes.isBottom();
         final boolean isLeft = gridAttributes.isLeft();
@@ -72,7 +75,13 @@ public class GridView<ADAPTER extends Adapter> extends AbstractAdapterView<ADAPT
 
         final AdapterViewInitializer<Group> adapterViewAdapterViewInitializer =
                 createAdapterViewInitializer(
-                        context, isViewPager, adapterViewManager, gridLayoutManager, isVertical);
+                        context,
+                        isViewPager,
+                        adapterViewManager,
+                        gridLayoutManager,
+                        isVertical,
+                        divider,
+                        dividerSize);
         return adapterViewAdapterViewInitializer;
     }
 }

--- a/library/src/main/java/mobi/parchment/widget/adapterview/gridview/Group.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/gridview/Group.java
@@ -19,6 +19,10 @@ public class Group {
         return new ArrayList<View>(mViews);
     }
 
+    public View getView(final int index) {
+        return mViews.get(index);
+    }
+
     private final boolean mIsVerticalScroll;
 
     public Group(final boolean isVerticalScroll) {

--- a/library/src/main/java/mobi/parchment/widget/adapterview/gridview/Group.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/gridview/Group.java
@@ -9,7 +9,11 @@ import java.util.List;
 
 public class Group {
 
-    private List<View> mViews = new ArrayList<View>();
+    private static final int NO_PIXEL = 0;
+    private static final int FIRST_VIEW_INDEX = 0;
+    private static final int SECOND_VIEW_INDEX = 1;
+
+    private final List<View> mViews = new ArrayList<View>();
 
     public List<View> getViews() {
         return new ArrayList<View>(mViews);
@@ -22,49 +26,45 @@ public class Group {
     }
 
     public int getTop() {
-        Integer lowestPixel = null;
-        for (final View view : mViews) {
-            final int top = view.getTop();
+        if (mViews.isEmpty()) return NO_PIXEL;
 
-            if (lowestPixel == null || top < lowestPixel) {
-                lowestPixel = top;
-            }
+        int lowestPixel = mViews.get(FIRST_VIEW_INDEX).getTop();
+        for (int viewIndex = SECOND_VIEW_INDEX; viewIndex < mViews.size(); viewIndex++) {
+            final int top = mViews.get(viewIndex).getTop();
+            if (top < lowestPixel) lowestPixel = top;
         }
         return lowestPixel;
     }
 
     public int getLeft() {
-        Integer lowestPixel = null;
-        for (final View view : mViews) {
-            final int left = view.getLeft();
+        if (mViews.isEmpty()) return NO_PIXEL;
 
-            if (lowestPixel == null || left < lowestPixel) {
-                lowestPixel = left;
-            }
+        int lowestPixel = mViews.get(FIRST_VIEW_INDEX).getLeft();
+        for (int viewIndex = SECOND_VIEW_INDEX; viewIndex < mViews.size(); viewIndex++) {
+            final int left = mViews.get(viewIndex).getLeft();
+            if (left < lowestPixel) lowestPixel = left;
         }
         return lowestPixel;
     }
 
     public int getBottom() {
-        Integer highestPixel = null;
-        for (final View view : mViews) {
-            final int bottom = view.getBottom();
+        if (mViews.isEmpty()) return NO_PIXEL;
 
-            if (highestPixel == null || bottom > highestPixel) {
-                highestPixel = bottom;
-            }
+        int highestPixel = mViews.get(FIRST_VIEW_INDEX).getBottom();
+        for (int viewIndex = SECOND_VIEW_INDEX; viewIndex < mViews.size(); viewIndex++) {
+            final int bottom = mViews.get(viewIndex).getBottom();
+            if (bottom > highestPixel) highestPixel = bottom;
         }
         return highestPixel;
     }
 
     public int getRight() {
-        Integer highestPixel = null;
-        for (final View view : mViews) {
-            final int right = view.getRight();
+        if (mViews.isEmpty()) return NO_PIXEL;
 
-            if (highestPixel == null || right > highestPixel) {
-                highestPixel = right;
-            }
+        int highestPixel = mViews.get(FIRST_VIEW_INDEX).getRight();
+        for (int viewIndex = SECOND_VIEW_INDEX; viewIndex < mViews.size(); viewIndex++) {
+            final int right = mViews.get(viewIndex).getRight();
+            if (right > highestPixel) highestPixel = right;
         }
         return highestPixel;
     }
@@ -153,7 +153,7 @@ public class Group {
         if (mViews.isEmpty()) {
             return null;
         }
-        return mViews.get(0);
+        return mViews.get(FIRST_VIEW_INDEX);
     }
 
     public void clear() {

--- a/library/src/main/java/mobi/parchment/widget/adapterview/listview/ListLayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/listview/ListLayoutManager.java
@@ -15,6 +15,8 @@ import mobi.parchment.widget.adapterview.utilities.ViewGroupUtilities;
 
 public class ListLayoutManager extends LayoutManager<View> {
 
+    private static final int ONE_VIEW = 1;
+
     public ListLayoutManager(
             final ViewGroup viewGroup,
             final OnSelectedListener onSelectedListener,
@@ -139,6 +141,16 @@ public class ListLayoutManager extends LayoutManager<View> {
 
     @Override
     public View getFirstView(final View view) {
+        return view;
+    }
+
+    @Override
+    public int getCellViewCount(final View view) {
+        return ONE_VIEW;
+    }
+
+    @Override
+    public View getCellView(final View view, final int viewIndex) {
         return view;
     }
 

--- a/library/src/main/java/mobi/parchment/widget/adapterview/listview/ListView.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/listview/ListView.java
@@ -4,6 +4,7 @@
 package mobi.parchment.widget.adapterview.listview;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -47,6 +48,8 @@ public class ListView<ADAPTER extends Adapter> extends AbstractAdapterView<ADAPT
         final SnapPosition snapPosition = attributes.getSnapPosition();
         final boolean selectOnSnap = attributes.selectOnSnap();
         final boolean selectWhileScrolling = attributes.selectWhileScrolling();
+        final Drawable divider = attributes.getDivider();
+        final int dividerSize = attributes.getDividerSize();
         final LayoutManagerAttributes layoutManagerAttributes =
                 new LayoutManagerAttributes(
                         isCircularScroll,
@@ -69,7 +72,9 @@ public class ListView<ADAPTER extends Adapter> extends AbstractAdapterView<ADAPT
                         isViewPager,
                         adapterViewManager,
                         listLayoutManager,
-                        isVerticalScroll);
+                        isVerticalScroll,
+                        divider,
+                        dividerSize);
         return adapterViewAdapterViewInitializer;
     }
 }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -21,6 +21,8 @@
             <enum name="onScreen" value="3"/>
         </attr>
         <attr name="parchment_selectWhileScrolling" format="boolean"/>
+        <attr name="parchment_divider" format="reference|color"/>
+        <attr name="parchment_dividerSize" format="dimension"/>
     </declare-styleable>
 
     <declare-styleable name="GridView">

--- a/library/src/test/java/mobi/parchment/HorizontalListViewTest.java
+++ b/library/src/test/java/mobi/parchment/HorizontalListViewTest.java
@@ -10,6 +10,8 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.content.res.XmlResourceParser;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.View;
@@ -57,6 +59,9 @@ public class HorizontalListViewTest {
     private static final String ID_ATTRIBUTE = "id";
     private static final String ORIENTATION_ATTRIBUTE = "parchment_orientation";
     private static final String SNAP_POSITION_ATTRIBUTE = "parchment_snapPosition";
+    private static final int TEST_DIVIDER_COLOUR = 0xff112233;
+    private static final int DEFAULT_DIVIDER_SIZE = -1;
+    private static final int NO_DIVIDER_SIZE = 0;
 
     @Test
     public void testBasicIntegration() {
@@ -173,6 +178,8 @@ public class HorizontalListViewTest {
                         "parchment_viewPagerInterval",
                         "parchment_snapPosition",
                         "parchment_selectWhileScrolling",
+                        "parchment_divider",
+                        "parchment_dividerSize",
                         "parchment_numberOfViewsPerCell",
                         "parchment_gravity",
                         "parchment_ratio");
@@ -195,6 +202,38 @@ public class HorizontalListViewTest {
         assertThat(attributes.getViewPagerInterval()).isEqualTo(TEST_VIEW_PAGER_INTERVAL);
         assertThat(attributes.getSnapPosition()).isEqualTo(SnapPosition.end);
         assertThat(attributes.selectWhileScrolling()).isTrue();
+    }
+
+    @Test
+    public void dividerAttributesSetInXml_reachTheAttributesGetters() {
+        final Attributes attributes =
+                listViewAttributesFrom(
+                        R.layout.attribute_parsing_list_view, R.id.horizontal_list_view);
+
+        final Drawable divider = attributes.getDivider();
+        assertThat(divider).isInstanceOf(ColorDrawable.class);
+        assertThat(((ColorDrawable) divider).getColor()).isEqualTo(TEST_DIVIDER_COLOUR);
+        assertThat(attributes.getDividerSize())
+                .isEqualTo(dimensionPixelSize(R.dimen.divider_test_size));
+    }
+
+    @Test
+    public void aNegativeDividerSizeInXml_isReadAsDeclaredAndNotAsAnAbsentAttribute() {
+        final Attributes attributes =
+                listViewAttributesFrom(
+                        R.layout.attribute_parsing_divider_sizes,
+                        R.id.negative_divider_size_list_view);
+
+        assertThat(attributes.getDividerSize()).isEqualTo(NO_DIVIDER_SIZE);
+    }
+
+    @Test
+    public void anAbsentDividerSizeInXml_leavesTheIntrinsicSizeMarker() {
+        final Attributes attributes =
+                listViewAttributesFrom(
+                        R.layout.attribute_parsing_divider_sizes, R.id.no_divider_size_list_view);
+
+        assertThat(attributes.getDividerSize()).isEqualTo(DEFAULT_DIVIDER_SIZE);
     }
 
     @Test
@@ -363,6 +402,8 @@ public class HorizontalListViewTest {
         assertThat(attributes.getViewPagerInterval()).isEqualTo(VIEWPORT_VIEW_PAGER_INTERVAL);
         assertThat(attributes.selectWhileScrolling()).isFalse();
         assertThat(attributes.getSnapPosition()).isEqualTo(SnapPosition.onScreen);
+        assertThat(attributes.getDivider()).isNull();
+        assertThat(attributes.getDividerSize()).isEqualTo(DEFAULT_DIVIDER_SIZE);
     }
 
     @Test
@@ -379,6 +420,8 @@ public class HorizontalListViewTest {
         assertThat(attributes.getViewPagerInterval()).isEqualTo(VIEWPORT_VIEW_PAGER_INTERVAL);
         assertThat(attributes.selectWhileScrolling()).isFalse();
         assertThat(attributes.getSnapPosition()).isEqualTo(SnapPosition.center);
+        assertThat(attributes.getDivider()).isNull();
+        assertThat(attributes.getDividerSize()).isEqualTo(DEFAULT_DIVIDER_SIZE);
     }
 
     @Test

--- a/library/src/test/java/mobi/parchment/widget/adapterview/AnimationFrameSchedulingTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/AnimationFrameSchedulingTest.java
@@ -8,6 +8,7 @@ import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.os.Looper;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
@@ -271,14 +272,18 @@ public class AnimationFrameSchedulingTest {
                 final boolean isViewPager,
                 final AdapterViewManager adapterViewManager,
                 final LayoutManager<View> layoutManager,
-                final boolean isVerticalScroll) {
+                final boolean isVerticalScroll,
+                final Drawable divider,
+                final int dividerSize) {
             final AdapterViewInitializer<View> initializer =
                     super.createAdapterViewInitializer(
                             context,
                             isViewPager,
                             adapterViewManager,
                             layoutManager,
-                            isVerticalScroll);
+                            isVerticalScroll,
+                            divider,
+                            dividerSize);
             mGestureListener = initializer.getChildTouchListener();
             return initializer;
         }

--- a/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerGroupTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerGroupTest.java
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import androidx.test.core.app.ApplicationProvider;
+import java.util.ArrayList;
+import java.util.List;
+import mobi.parchment.widget.adapterview.gridpatternview.GridPatternGroupDefinition;
+import mobi.parchment.widget.adapterview.gridpatternview.GridPatternItemDefinition;
+import mobi.parchment.widget.adapterview.gridpatternview.GridPatternLayoutManager;
+import mobi.parchment.widget.adapterview.gridpatternview.GridPatternLayoutManagerAttributes;
+import mobi.parchment.widget.adapterview.gridview.GridLayoutManager;
+import mobi.parchment.widget.adapterview.gridview.GridLayoutManagerAttributes;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class CellDividerGroupTest {
+
+    private static final int VIEW_GROUP_SIZE = 300;
+    private static final int GRID_VIEW_SIZE = 100;
+    private static final int GRID_PATTERN_VIEW_SIZE = 145;
+    private static final int CELL_SPACING = 10;
+    private static final int DIVIDER_SIZE = 4;
+    private static final int VIEWS_PER_CELL = 2;
+    private static final int EIGHT_ITEMS = 8;
+    private static final int THREE_ITEMS = 3;
+    private static final int SIX_DRAWN_VIEWS = 6;
+    private static final int THREE_DRAWN_GROUPS = 3;
+    private static final int TWO_DRAWN_GROUPS = 2;
+    private static final float SQUARE_RATIO = 1f;
+    private static final boolean IS_VERTICAL = true;
+    private static final boolean IS_HORIZONTAL = false;
+    private static final boolean NOT_CIRCULAR = false;
+    private static final boolean NOT_SNAP_TO_POSITION = false;
+    private static final boolean NOT_A_VIEW_PAGER = false;
+    private static final int VIEWPORT_VIEW_PAGER_INTERVAL = 0;
+    private static final boolean NOT_SELECT_ON_SNAP = false;
+    private static final boolean NOT_SELECT_WHILE_SCROLLING = false;
+    private static final boolean GRAVITY_TOP = true;
+    private static final boolean GRAVITY_BOTTOM = false;
+    private static final boolean GRAVITY_LEFT = false;
+    private static final boolean GRAVITY_RIGHT = false;
+
+    private final Canvas mCanvas = new Canvas();
+
+    @Test
+    public void gridDivider_inAVerticalGrid_separatesRowsRatherThanTheItemsWithinARow() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, IS_VERTICAL);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        assertThat(viewGroup.mViews).hasSize(SIX_DRAWN_VIEWS);
+        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(THREE_DRAWN_GROUPS);
+        assertThat(divider.getDrawCount()).isEqualTo(2);
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 103, VIEW_GROUP_SIZE, 107));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(0, 213, VIEW_GROUP_SIZE, 217));
+    }
+
+    @Test
+    public void gridDivider_inAHorizontalGrid_separatesColumnsRatherThanTheItemsWithinAColumn() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, IS_HORIZONTAL);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        assertThat(viewGroup.mViews).hasSize(SIX_DRAWN_VIEWS);
+        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(THREE_DRAWN_GROUPS);
+        assertThat(divider.getDrawCount()).isEqualTo(2);
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(103, 0, 107, VIEW_GROUP_SIZE));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(213, 0, 217, VIEW_GROUP_SIZE));
+    }
+
+    @Test
+    public void gridPatternDivider_inAVerticalView_separatesGroupsNotTheItemsWithinAGroup() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGridPattern(viewGroup, IS_VERTICAL);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        assertThat(viewGroup.mViews).hasSize(THREE_ITEMS);
+        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(TWO_DRAWN_GROUPS);
+        assertThat(divider.getDrawCount()).isEqualTo(1);
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 148, VIEW_GROUP_SIZE, 152));
+    }
+
+    @Test
+    public void gridPatternDivider_inAHorizontalView_separatesGroupsNotTheItemsWithinAGroup() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGridPattern(viewGroup, IS_HORIZONTAL);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        assertThat(viewGroup.mViews).hasSize(THREE_ITEMS);
+        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(TWO_DRAWN_GROUPS);
+        assertThat(divider.getDrawCount()).isEqualTo(1);
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(148, 0, 152, VIEW_GROUP_SIZE));
+    }
+
+    private void draw(
+            final RecordingDrawable divider,
+            final MyViewGroup viewGroup,
+            final LayoutManager<?> layoutManager) {
+        final ScrollDirectionManager scrollDirectionManager =
+                layoutManager.getScrollDirectionManager();
+        final CellDivider cellDivider =
+                new CellDivider(divider, DIVIDER_SIZE, scrollDirectionManager);
+        cellDivider.draw(mCanvas, viewGroup, layoutManager);
+    }
+
+    private static LayoutManager<?> layOutGrid(
+            final MyViewGroup viewGroup, final boolean isVertical) {
+        final AdapterViewManager adapterViewManager = new AdapterViewManager();
+        final GridLayoutManagerAttributes attributes =
+                new GridLayoutManagerAttributes(
+                        VIEWS_PER_CELL,
+                        NOT_CIRCULAR,
+                        NOT_SNAP_TO_POSITION,
+                        NOT_A_VIEW_PAGER,
+                        VIEWPORT_VIEW_PAGER_INTERVAL,
+                        SnapPosition.onScreen,
+                        CELL_SPACING,
+                        NOT_SELECT_ON_SNAP,
+                        NOT_SELECT_WHILE_SCROLLING,
+                        isVertical,
+                        GRAVITY_TOP,
+                        GRAVITY_BOTTOM,
+                        GRAVITY_LEFT,
+                        GRAVITY_RIGHT);
+        final GridLayoutManager layoutManager =
+                new GridLayoutManager(viewGroup, null, adapterViewManager, attributes);
+        final TestAdapter testAdapter = new TestAdapter(GRID_VIEW_SIZE);
+        adapterViewManager.setAdapter(testAdapter);
+        layOut(viewGroup);
+        testAdapter.setAdapterSize(EIGHT_ITEMS);
+        layoutManager.layout(viewGroup, newAnimation(), 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+        return layoutManager;
+    }
+
+    private static LayoutManager<?> layOutGridPattern(
+            final MyViewGroup viewGroup, final boolean isVertical) {
+        final AdapterViewManager adapterViewManager = new AdapterViewManager();
+        final GridPatternLayoutManagerAttributes attributes =
+                new GridPatternLayoutManagerAttributes(
+                        NOT_CIRCULAR,
+                        NOT_SNAP_TO_POSITION,
+                        NOT_A_VIEW_PAGER,
+                        VIEWPORT_VIEW_PAGER_INTERVAL,
+                        SnapPosition.onScreen,
+                        CELL_SPACING,
+                        NOT_SELECT_ON_SNAP,
+                        NOT_SELECT_WHILE_SCROLLING,
+                        isVertical,
+                        SQUARE_RATIO);
+        final GridPatternLayoutManager layoutManager =
+                new GridPatternLayoutManager(viewGroup, null, adapterViewManager, attributes);
+        layoutManager.addGridPatternGroupDefinition(newPairGroupDefinition(isVertical));
+        layoutManager.addGridPatternGroupDefinition(newLongGroupDefinition(isVertical));
+        final TestAdapter testAdapter = new TestAdapter(GRID_PATTERN_VIEW_SIZE);
+        adapterViewManager.setAdapter(testAdapter);
+        layOut(viewGroup);
+        testAdapter.setAdapterSize(THREE_ITEMS);
+        layoutManager.layout(viewGroup, newAnimation(), 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+        return layoutManager;
+    }
+
+    private static GridPatternGroupDefinition newPairGroupDefinition(final boolean isVertical) {
+        final List<GridPatternItemDefinition> itemDefinitions =
+                new ArrayList<GridPatternItemDefinition>();
+        itemDefinitions.add(new GridPatternItemDefinition(0, 0, 1, 1));
+        if (isVertical) {
+            itemDefinitions.add(new GridPatternItemDefinition(0, 1, 1, 1));
+        } else {
+            itemDefinitions.add(new GridPatternItemDefinition(1, 0, 1, 1));
+        }
+        return new GridPatternGroupDefinition(isVertical, itemDefinitions);
+    }
+
+    private static GridPatternGroupDefinition newLongGroupDefinition(final boolean isVertical) {
+        final List<GridPatternItemDefinition> itemDefinitions =
+                new ArrayList<GridPatternItemDefinition>();
+        if (isVertical) {
+            itemDefinitions.add(new GridPatternItemDefinition(0, 0, 1, 2));
+        } else {
+            itemDefinitions.add(new GridPatternItemDefinition(0, 0, 2, 1));
+        }
+        return new GridPatternGroupDefinition(isVertical, itemDefinitions);
+    }
+
+    private static MyViewGroup newViewGroup() {
+        return new MyViewGroup(ApplicationProvider.getApplicationContext());
+    }
+
+    private static Animation newAnimation() {
+        final Animation animation = new Animation();
+        animation.newAnimation();
+        return animation;
+    }
+
+    private static void layOut(final MyViewGroup viewGroup) {
+        final int measureSpec =
+                View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
+        viewGroup.measure(measureSpec, measureSpec);
+        viewGroup.layout(0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+    }
+
+    private static final class MyViewGroup extends LinearLayout implements AdapterViewHandler {
+        private final List<View> mViews = new ArrayList<View>();
+
+        private MyViewGroup(final Context context) {
+            super(context);
+        }
+
+        @Override
+        public boolean addViewInAdapterView(
+                final View view, final int index, final ViewGroup.LayoutParams layoutParams) {
+            mViews.add(index, view);
+            return true;
+        }
+
+        @Override
+        public void removeViewInAdapterView(final View view) {
+            mViews.remove(view);
+        }
+    }
+
+    private static final class TestAdapter extends BaseAdapter {
+        private final int mViewSize;
+        private int mAdapterSize;
+
+        private TestAdapter(final int viewSize) {
+            mViewSize = viewSize;
+        }
+
+        private void setAdapterSize(final int adapterSize) {
+            mAdapterSize = adapterSize;
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public int getCount() {
+            return mAdapterSize;
+        }
+
+        @Override
+        public Object getItem(final int position) {
+            return position;
+        }
+
+        @Override
+        public long getItemId(final int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(final int position, final View convertView, final ViewGroup parent) {
+            final FrameLayout view = new FrameLayout(parent.getContext());
+            view.setLayoutParams(new ViewGroup.LayoutParams(mViewSize, mViewSize));
+            return view;
+        }
+    }
+}

--- a/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerGroupTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerGroupTest.java
@@ -16,6 +16,9 @@ import android.widget.LinearLayout;
 import androidx.test.core.app.ApplicationProvider;
 import java.util.ArrayList;
 import java.util.List;
+import mobi.parchment.widget.adapterview.divideraxis.BreadthDividerAxis;
+import mobi.parchment.widget.adapterview.divideraxis.DividerAxisInterface;
+import mobi.parchment.widget.adapterview.divideraxis.SizeDividerAxis;
 import mobi.parchment.widget.adapterview.gridpatternview.GridPatternGroupDefinition;
 import mobi.parchment.widget.adapterview.gridpatternview.GridPatternItemDefinition;
 import mobi.parchment.widget.adapterview.gridpatternview.GridPatternLayoutManager;
@@ -39,6 +42,7 @@ public class CellDividerGroupTest {
     private static final int THREE_ITEMS = 3;
     private static final int SIX_DRAWN_VIEWS = 6;
     private static final int THREE_DRAWN_GROUPS = 3;
+    private static final int ONE_DRAWN_GROUP = 1;
     private static final int TWO_DRAWN_GROUPS = 2;
     private static final float SQUARE_RATIO = 1f;
     private static final boolean IS_VERTICAL = true;
@@ -51,110 +55,432 @@ public class CellDividerGroupTest {
     private static final boolean NOT_SELECT_WHILE_SCROLLING = false;
     private static final boolean GRAVITY_TOP = true;
     private static final boolean GRAVITY_BOTTOM = false;
-    private static final boolean GRAVITY_LEFT = false;
     private static final boolean GRAVITY_RIGHT = false;
+    private static final boolean GRAVITY_CENTRE = false;
+    private static final int TALL_VIEW_SIZE = 100;
+    private static final int SHORT_VIEW_SIZE = 60;
+    private static final boolean CIRCULAR = true;
+    private static final int NO_CELL_SPACING = 0;
+    private static final int THICK_DIVIDER_SIZE = 20;
+    private static final int TWO_ITEMS = 2;
+    private static final int ONE_ITEM = 1;
+    private static final int NO_ITEMS = 0;
+    private static final int START_BREADTH_PADDING = 20;
+    private static final int START_SIZE_PADDING = 30;
+    private static final int END_BREADTH_PADDING = 40;
+    private static final int END_SIZE_PADDING = 50;
+    private static final int A_FORWARD_SCROLL = -150;
+    private static final int SIX_ITEMS = 6;
+    private static final int FIRST_CELL = 0;
+    private static final int FIRST_VIEW = 0;
 
     private final Canvas mCanvas = new Canvas();
 
     @Test
-    public void gridDivider_inAVerticalGrid_separatesRowsRatherThanTheItemsWithinARow() {
+    public void gridDivider_inAVerticalGrid_separatesTheItemsWithinARowAsWellAsTheRows() {
         final MyViewGroup viewGroup = newViewGroup();
-        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, IS_VERTICAL);
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, IS_VERTICAL, GRAVITY_TOP);
         final RecordingDrawable divider = new RecordingDrawable();
 
         draw(divider, viewGroup, layoutManager);
 
         assertThat(viewGroup.mViews).hasSize(SIX_DRAWN_VIEWS);
         assertThat(layoutManager.getDrawnCellCount()).isEqualTo(THREE_DRAWN_GROUPS);
-        assertThat(divider.getDrawCount()).isEqualTo(2);
-        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 103, VIEW_GROUP_SIZE, 107));
-        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(0, 213, VIEW_GROUP_SIZE, 217));
+        assertThat(divider.getDrawCount()).isEqualTo(7);
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 103, 145, 107));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(148, 0, 152, 100));
+        assertThat(divider.getDrawnBounds(2)).isEqualTo(new Rect(155, 103, 300, 107));
+        assertThat(divider.getDrawnBounds(3)).isEqualTo(new Rect(0, 213, 145, 217));
+        assertThat(divider.getDrawnBounds(4)).isEqualTo(new Rect(148, 110, 152, 210));
+        assertThat(divider.getDrawnBounds(5)).isEqualTo(new Rect(155, 213, 300, 217));
+        assertThat(divider.getDrawnBounds(6)).isEqualTo(new Rect(148, 220, 152, 320));
     }
 
     @Test
-    public void gridDivider_inAHorizontalGrid_separatesColumnsRatherThanTheItemsWithinAColumn() {
+    public void gridDivider_inAHorizontalGrid_separatesTheItemsWithinAColumnAsWellAsTheColumns() {
         final MyViewGroup viewGroup = newViewGroup();
-        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, IS_HORIZONTAL);
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, IS_HORIZONTAL, GRAVITY_TOP);
         final RecordingDrawable divider = new RecordingDrawable();
 
         draw(divider, viewGroup, layoutManager);
 
         assertThat(viewGroup.mViews).hasSize(SIX_DRAWN_VIEWS);
         assertThat(layoutManager.getDrawnCellCount()).isEqualTo(THREE_DRAWN_GROUPS);
-        assertThat(divider.getDrawCount()).isEqualTo(2);
-        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(103, 0, 107, VIEW_GROUP_SIZE));
-        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(213, 0, 217, VIEW_GROUP_SIZE));
+        assertThat(divider.getDrawCount()).isEqualTo(7);
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(103, 0, 107, 145));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(0, 148, 100, 152));
+        assertThat(divider.getDrawnBounds(2)).isEqualTo(new Rect(103, 155, 107, 300));
+        assertThat(divider.getDrawnBounds(3)).isEqualTo(new Rect(213, 0, 217, 145));
+        assertThat(divider.getDrawnBounds(4)).isEqualTo(new Rect(110, 148, 210, 152));
+        assertThat(divider.getDrawnBounds(5)).isEqualTo(new Rect(213, 155, 217, 300));
+        assertThat(divider.getDrawnBounds(6)).isEqualTo(new Rect(220, 148, 320, 152));
     }
 
     @Test
-    public void gridPatternDivider_inAVerticalView_separatesGroupsNotTheItemsWithinAGroup() {
+    public void gridDivider_atTheOuterBoundaryOfAVerticalGrid_isNotDrawn() {
         final MyViewGroup viewGroup = newViewGroup();
-        final LayoutManager<?> layoutManager = layOutGridPattern(viewGroup, IS_VERTICAL);
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, IS_VERTICAL, GRAVITY_TOP);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        final ScrollDirectionManager scrollDirectionManager =
+                layoutManager.getScrollDirectionManager();
+        final DividerAxisInterface sizeAxis = new SizeDividerAxis(scrollDirectionManager);
+        final DividerAxisInterface breadthAxis = new BreadthDividerAxis(scrollDirectionManager);
+        final int contentStart = contentStart(viewGroup, sizeAxis);
+        final int contentEnd = contentEnd(viewGroup, sizeAxis);
+        final int contentBreadthStart = contentStart(viewGroup, breadthAxis);
+        final int contentBreadthEnd = contentEnd(viewGroup, breadthAxis);
+        for (int index = 0; index < divider.getDrawCount(); index++) {
+            final Rect bounds = divider.getDrawnBounds(index);
+            final boolean isASizeDivider = bounds.height() == DIVIDER_SIZE;
+            if (isASizeDivider) {
+                assertThat(bounds.top).isGreaterThan(contentStart);
+                assertThat(bounds.bottom).isLessThan(contentEnd);
+            } else {
+                assertThat(bounds.left).isGreaterThan(contentBreadthStart);
+                assertThat(bounds.right).isLessThan(contentBreadthEnd);
+            }
+        }
+    }
+
+    @Test
+    public void gridDivider_onAnEdgeSharedByTwoItems_isDrawnOnlyOnce() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, IS_VERTICAL, GRAVITY_TOP);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        final List<Rect> drawn = new ArrayList<Rect>();
+        for (int index = 0; index < divider.getDrawCount(); index++) {
+            drawn.add(divider.getDrawnBounds(index));
+        }
+        assertThat(drawn).doesNotHaveDuplicates();
+    }
+
+    private static int contentStart(final MyViewGroup viewGroup, final DividerAxisInterface axis) {
+        int start = Integer.MAX_VALUE;
+        for (final View view : viewGroup.mViews) {
+            final int viewStart = axis.getStart(view);
+            if (viewStart < start) start = viewStart;
+        }
+        return start;
+    }
+
+    private static int contentEnd(final MyViewGroup viewGroup, final DividerAxisInterface axis) {
+        int end = Integer.MIN_VALUE;
+        for (final View view : viewGroup.mViews) {
+            final int viewEnd = axis.getEnd(view);
+            if (viewEnd > end) end = viewEnd;
+        }
+        return end;
+    }
+
+    @Test
+    public void gridPatternDivider_inAVerticalViewWithATeeJunction_dividesEveryInternalEdgeOnce() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGridPatternTee(viewGroup, IS_VERTICAL);
         final RecordingDrawable divider = new RecordingDrawable();
 
         draw(divider, viewGroup, layoutManager);
 
         assertThat(viewGroup.mViews).hasSize(THREE_ITEMS);
-        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(TWO_DRAWN_GROUPS);
-        assertThat(divider.getDrawCount()).isEqualTo(1);
-        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 148, VIEW_GROUP_SIZE, 152));
+        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(ONE_DRAWN_GROUP);
+        assertThat(divider.getDrawCount()).isEqualTo(3);
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(148, 0, 152, 145));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(148, 155, 152, 300));
+        assertThat(divider.getDrawnBounds(2)).isEqualTo(new Rect(155, 148, 300, 152));
     }
 
     @Test
-    public void gridPatternDivider_inAHorizontalView_separatesGroupsNotTheItemsWithinAGroup() {
+    public void
+            gridPatternDivider_inAHorizontalViewWithATeeJunction_dividesEveryInternalEdgeOnce() {
         final MyViewGroup viewGroup = newViewGroup();
-        final LayoutManager<?> layoutManager = layOutGridPattern(viewGroup, IS_HORIZONTAL);
+        final LayoutManager<?> layoutManager = layOutGridPatternTee(viewGroup, IS_HORIZONTAL);
         final RecordingDrawable divider = new RecordingDrawable();
 
         draw(divider, viewGroup, layoutManager);
 
         assertThat(viewGroup.mViews).hasSize(THREE_ITEMS);
-        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(TWO_DRAWN_GROUPS);
+        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(ONE_DRAWN_GROUP);
+        assertThat(divider.getDrawCount()).isEqualTo(3);
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 148, 145, 152));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(155, 148, 300, 152));
+        assertThat(divider.getDrawnBounds(2)).isEqualTo(new Rect(148, 155, 152, 300));
+    }
+
+    @Test
+    public void gridDivider_withAShortViewPlacedByGravity_followsTheViewRatherThanTheCell() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutUnevenGrid(viewGroup);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 103, 145, 107));
+        assertThat(divider.getDrawnBounds(2)).isEqualTo(new Rect(155, 83, 300, 87));
+    }
+
+    @Test
+    public void gridDivider_withNoCellSpacing_straddlesTheSharedEdgeOnBothAxes() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, NO_CELL_SPACING, EIGHT_ITEMS);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 98, 150, 102));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(148, 0, 152, 100));
+    }
+
+    @Test
+    public void gridDivider_thickerThanTheGap_overlapsTheItemsOnBothAxes() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, IS_VERTICAL, GRAVITY_TOP);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, layoutManager, THICK_DIVIDER_SIZE);
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 95, 145, 115));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(140, 0, 160, 100));
+    }
+
+    @Test
+    public void gridDivider_withASingleRow_dividesTheRowButNothingElse() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, CELL_SPACING, TWO_ITEMS);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(ONE_DRAWN_GROUP);
         assertThat(divider.getDrawCount()).isEqualTo(1);
-        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(148, 0, 152, VIEW_GROUP_SIZE));
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(148, 100, 152, 200));
+    }
+
+    @Test
+    public void gridDivider_withASingleItem_drawsNothing() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, CELL_SPACING, ONE_ITEM);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(ONE_DRAWN_GROUP);
+        assertThat(divider.getDrawCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void gridDivider_withAnEmptyAdapter_drawsNothing() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, CELL_SPACING, NO_ITEMS);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(NO_ITEMS);
+        assertThat(divider.getDrawCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void gridDivider_withCircularScroll_dividesEveryGapBetweenDrawnRows() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutCircularGrid(viewGroup);
+        scroll(viewGroup, layoutManager, A_FORWARD_SCROLL);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        final int drawnCellCount = layoutManager.getDrawnCellCount();
+        final int gapsBetweenDrawnRows = drawnCellCount - ONE_DRAWN_GROUP;
+        final int lastCellIndex = drawnCellCount - ONE_DRAWN_GROUP;
+        final View firstDrawnView = layoutManager.getDrawnCellView(FIRST_CELL, FIRST_VIEW);
+        final View lastDrawnView = layoutManager.getDrawnCellView(lastCellIndex, FIRST_VIEW);
+        assertThat(layoutManager.getPosition(lastDrawnView))
+                .isLessThan(layoutManager.getPosition(firstDrawnView));
+        assertThat(countSizeDividers(divider)).isEqualTo(gapsBetweenDrawnRows * VIEWS_PER_CELL);
+    }
+
+    @Test
+    public void gridDivider_withPaddingSet_followsTheItemsInsideThePadding() {
+        final MyViewGroup viewGroup = newViewGroup();
+        viewGroup.setPadding(
+                START_BREADTH_PADDING, START_SIZE_PADDING, END_BREADTH_PADDING, END_SIZE_PADDING);
+        final LayoutManager<?> layoutManager = layOutCentredGrid(viewGroup);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(30, 133, 145, 137));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(148, 30, 152, 130));
+    }
+
+    @Test
+    public void gridPatternDivider_whereAWideItemMeetsTwoNarrowOnes_dividesEachOverlapSeparately() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGridPatternPair(viewGroup);
+        final RecordingDrawable divider = new RecordingDrawable();
+
+        draw(divider, viewGroup, layoutManager);
+
+        assertThat(layoutManager.getDrawnCellCount()).isEqualTo(TWO_DRAWN_GROUPS);
+        assertThat(divider.getDrawCount()).isEqualTo(3);
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 148, 145, 152));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(148, 0, 152, 145));
+        assertThat(divider.getDrawnBounds(2)).isEqualTo(new Rect(155, 148, 300, 152));
+    }
+
+    @Test
+    public void everyGridDividerOfEveryFrame_isMeasuredIntoTheSameBoundsRect() {
+        final MyViewGroup viewGroup = newViewGroup();
+        final LayoutManager<?> layoutManager = layOutGrid(viewGroup, IS_VERTICAL, GRAVITY_TOP);
+        final RecordingDrawable divider = new RecordingDrawable();
+        final CellDivider cellDivider =
+                new CellDivider(divider, DIVIDER_SIZE, layoutManager.getScrollDirectionManager());
+
+        cellDivider.draw(mCanvas, layoutManager);
+        cellDivider.draw(mCanvas, layoutManager);
+
+        final List<Rect> boundsInstances = divider.getBoundsInstances();
+        assertThat(boundsInstances).hasSize(14);
+        for (final Rect bounds : boundsInstances) {
+            assertThat(bounds).isSameAs(boundsInstances.get(0));
+        }
     }
 
     private void draw(
             final RecordingDrawable divider,
             final MyViewGroup viewGroup,
             final LayoutManager<?> layoutManager) {
+        draw(divider, layoutManager, DIVIDER_SIZE);
+    }
+
+    private void draw(
+            final RecordingDrawable divider,
+            final LayoutManager<?> layoutManager,
+            final int dividerSize) {
         final ScrollDirectionManager scrollDirectionManager =
                 layoutManager.getScrollDirectionManager();
         final CellDivider cellDivider =
-                new CellDivider(divider, DIVIDER_SIZE, scrollDirectionManager);
-        cellDivider.draw(mCanvas, viewGroup, layoutManager);
+                new CellDivider(divider, dividerSize, scrollDirectionManager);
+        cellDivider.draw(mCanvas, layoutManager);
     }
 
     private static LayoutManager<?> layOutGrid(
-            final MyViewGroup viewGroup, final boolean isVertical) {
+            final MyViewGroup viewGroup, final boolean isVertical, final boolean isTop) {
+        return newGridLayoutManager(
+                viewGroup,
+                isVertical,
+                isTop,
+                new TestAdapter(isVertical),
+                CELL_SPACING,
+                NOT_CIRCULAR,
+                EIGHT_ITEMS);
+    }
+
+    private static LayoutManager<?> layOutGrid(
+            final MyViewGroup viewGroup, final int cellSpacing, final int adapterSize) {
+        return newGridLayoutManager(
+                viewGroup,
+                IS_VERTICAL,
+                GRAVITY_TOP,
+                new TestAdapter(IS_VERTICAL),
+                cellSpacing,
+                NOT_CIRCULAR,
+                adapterSize);
+    }
+
+    private static LayoutManager<?> layOutCentredGrid(final MyViewGroup viewGroup) {
+        return newGridLayoutManager(
+                viewGroup,
+                IS_VERTICAL,
+                GRAVITY_CENTRE,
+                new TestAdapter(IS_VERTICAL),
+                CELL_SPACING,
+                NOT_CIRCULAR,
+                EIGHT_ITEMS);
+    }
+
+    private static LayoutManager<?> layOutCircularGrid(final MyViewGroup viewGroup) {
+        return newGridLayoutManager(
+                viewGroup,
+                IS_VERTICAL,
+                GRAVITY_TOP,
+                new TestAdapter(IS_VERTICAL),
+                CELL_SPACING,
+                CIRCULAR,
+                SIX_ITEMS);
+    }
+
+    private static LayoutManager<?> layOutUnevenGrid(final MyViewGroup viewGroup) {
+        return newGridLayoutManager(
+                viewGroup,
+                IS_VERTICAL,
+                GRAVITY_TOP,
+                new UnevenAdapter(IS_VERTICAL),
+                CELL_SPACING,
+                NOT_CIRCULAR,
+                EIGHT_ITEMS);
+    }
+
+    private static GridLayoutManager newGridLayoutManager(
+            final MyViewGroup viewGroup,
+            final boolean isVertical,
+            final boolean isTop,
+            final TestAdapter testAdapter,
+            final int cellSpacing,
+            final boolean isCircular,
+            final int adapterSize) {
         final AdapterViewManager adapterViewManager = new AdapterViewManager();
         final GridLayoutManagerAttributes attributes =
                 new GridLayoutManagerAttributes(
                         VIEWS_PER_CELL,
-                        NOT_CIRCULAR,
+                        isCircular,
                         NOT_SNAP_TO_POSITION,
                         NOT_A_VIEW_PAGER,
                         VIEWPORT_VIEW_PAGER_INTERVAL,
                         SnapPosition.onScreen,
-                        CELL_SPACING,
+                        cellSpacing,
                         NOT_SELECT_ON_SNAP,
                         NOT_SELECT_WHILE_SCROLLING,
                         isVertical,
-                        GRAVITY_TOP,
+                        isTop,
                         GRAVITY_BOTTOM,
-                        GRAVITY_LEFT,
+                        isTop,
                         GRAVITY_RIGHT);
         final GridLayoutManager layoutManager =
                 new GridLayoutManager(viewGroup, null, adapterViewManager, attributes);
-        final TestAdapter testAdapter = new TestAdapter(GRID_VIEW_SIZE);
         adapterViewManager.setAdapter(testAdapter);
         layOut(viewGroup);
-        testAdapter.setAdapterSize(EIGHT_ITEMS);
+        layoutManager.measure(viewGroup, measureSpec(), measureSpec());
+        testAdapter.setAdapterSize(adapterSize);
         layoutManager.layout(viewGroup, newAnimation(), 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
         return layoutManager;
     }
 
-    private static LayoutManager<?> layOutGridPattern(
+    private static void scroll(
+            final MyViewGroup viewGroup,
+            final LayoutManager<?> layoutManager,
+            final int displacement) {
+        final Animation animation = new Animation();
+        animation.newAnimation();
+        animation.setDisplacement(displacement);
+        layoutManager.layout(viewGroup, animation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+    }
+
+    private static int countSizeDividers(final RecordingDrawable divider) {
+        int count = 0;
+        for (int index = 0; index < divider.getDrawCount(); index++) {
+            final Rect bounds = divider.getDrawnBounds(index);
+            final boolean isASizeDivider = bounds.height() == DIVIDER_SIZE;
+            if (isASizeDivider) count++;
+        }
+        return count;
+    }
+
+    private static LayoutManager<?> layOutGridPatternTee(
             final MyViewGroup viewGroup, final boolean isVertical) {
         final AdapterViewManager adapterViewManager = new AdapterViewManager();
         final GridPatternLayoutManagerAttributes attributes =
@@ -171,35 +497,69 @@ public class CellDividerGroupTest {
                         SQUARE_RATIO);
         final GridPatternLayoutManager layoutManager =
                 new GridPatternLayoutManager(viewGroup, null, adapterViewManager, attributes);
-        layoutManager.addGridPatternGroupDefinition(newPairGroupDefinition(isVertical));
-        layoutManager.addGridPatternGroupDefinition(newLongGroupDefinition(isVertical));
-        final TestAdapter testAdapter = new TestAdapter(GRID_PATTERN_VIEW_SIZE);
+        layoutManager.addGridPatternGroupDefinition(newTeeGroupDefinition(isVertical));
+        final TestAdapter testAdapter = new TestAdapter(GRID_PATTERN_VIEW_SIZE, isVertical);
         adapterViewManager.setAdapter(testAdapter);
         layOut(viewGroup);
+        layoutManager.measure(viewGroup, measureSpec(), measureSpec());
         testAdapter.setAdapterSize(THREE_ITEMS);
         layoutManager.layout(viewGroup, newAnimation(), 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
         return layoutManager;
     }
 
-    private static GridPatternGroupDefinition newPairGroupDefinition(final boolean isVertical) {
+    private static LayoutManager<?> layOutGridPatternPair(final MyViewGroup viewGroup) {
+        final AdapterViewManager adapterViewManager = new AdapterViewManager();
+        final GridPatternLayoutManagerAttributes attributes =
+                new GridPatternLayoutManagerAttributes(
+                        NOT_CIRCULAR,
+                        NOT_SNAP_TO_POSITION,
+                        NOT_A_VIEW_PAGER,
+                        VIEWPORT_VIEW_PAGER_INTERVAL,
+                        SnapPosition.onScreen,
+                        CELL_SPACING,
+                        NOT_SELECT_ON_SNAP,
+                        NOT_SELECT_WHILE_SCROLLING,
+                        IS_VERTICAL,
+                        SQUARE_RATIO);
+        final GridPatternLayoutManager layoutManager =
+                new GridPatternLayoutManager(viewGroup, null, adapterViewManager, attributes);
+        layoutManager.addGridPatternGroupDefinition(newSideBySideGroupDefinition());
+        layoutManager.addGridPatternGroupDefinition(newWideGroupDefinition());
+        final TestAdapter testAdapter = new TestAdapter(GRID_PATTERN_VIEW_SIZE, IS_VERTICAL);
+        adapterViewManager.setAdapter(testAdapter);
+        layOut(viewGroup);
+        layoutManager.measure(viewGroup, measureSpec(), measureSpec());
+        testAdapter.setAdapterSize(THREE_ITEMS);
+        layoutManager.layout(viewGroup, newAnimation(), 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+        return layoutManager;
+    }
+
+    private static GridPatternGroupDefinition newSideBySideGroupDefinition() {
         final List<GridPatternItemDefinition> itemDefinitions =
                 new ArrayList<GridPatternItemDefinition>();
         itemDefinitions.add(new GridPatternItemDefinition(0, 0, 1, 1));
-        if (isVertical) {
-            itemDefinitions.add(new GridPatternItemDefinition(0, 1, 1, 1));
-        } else {
-            itemDefinitions.add(new GridPatternItemDefinition(1, 0, 1, 1));
-        }
-        return new GridPatternGroupDefinition(isVertical, itemDefinitions);
+        itemDefinitions.add(new GridPatternItemDefinition(0, 1, 1, 1));
+        return new GridPatternGroupDefinition(IS_VERTICAL, itemDefinitions);
     }
 
-    private static GridPatternGroupDefinition newLongGroupDefinition(final boolean isVertical) {
+    private static GridPatternGroupDefinition newWideGroupDefinition() {
+        final List<GridPatternItemDefinition> itemDefinitions =
+                new ArrayList<GridPatternItemDefinition>();
+        itemDefinitions.add(new GridPatternItemDefinition(0, 0, 1, 2));
+        return new GridPatternGroupDefinition(IS_VERTICAL, itemDefinitions);
+    }
+
+    private static GridPatternGroupDefinition newTeeGroupDefinition(final boolean isVertical) {
         final List<GridPatternItemDefinition> itemDefinitions =
                 new ArrayList<GridPatternItemDefinition>();
         if (isVertical) {
-            itemDefinitions.add(new GridPatternItemDefinition(0, 0, 1, 2));
-        } else {
             itemDefinitions.add(new GridPatternItemDefinition(0, 0, 2, 1));
+            itemDefinitions.add(new GridPatternItemDefinition(0, 1, 1, 1));
+            itemDefinitions.add(new GridPatternItemDefinition(1, 1, 1, 1));
+        } else {
+            itemDefinitions.add(new GridPatternItemDefinition(0, 0, 1, 2));
+            itemDefinitions.add(new GridPatternItemDefinition(1, 0, 1, 1));
+            itemDefinitions.add(new GridPatternItemDefinition(1, 1, 1, 1));
         }
         return new GridPatternGroupDefinition(isVertical, itemDefinitions);
     }
@@ -214,10 +574,12 @@ public class CellDividerGroupTest {
         return animation;
     }
 
+    private static int measureSpec() {
+        return View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
+    }
+
     private static void layOut(final MyViewGroup viewGroup) {
-        final int measureSpec =
-                View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
-        viewGroup.measure(measureSpec, measureSpec);
+        viewGroup.measure(measureSpec(), measureSpec());
         viewGroup.layout(0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
     }
 
@@ -241,17 +603,27 @@ public class CellDividerGroupTest {
         }
     }
 
-    private static final class TestAdapter extends BaseAdapter {
+    private static class TestAdapter extends BaseAdapter {
         private final int mViewSize;
+        private final boolean mIsVertical;
         private int mAdapterSize;
 
-        private TestAdapter(final int viewSize) {
+        private TestAdapter(final boolean isVertical) {
+            this(GRID_VIEW_SIZE, isVertical);
+        }
+
+        private TestAdapter(final int viewSize, final boolean isVertical) {
             mViewSize = viewSize;
+            mIsVertical = isVertical;
         }
 
         private void setAdapterSize(final int adapterSize) {
             mAdapterSize = adapterSize;
             notifyDataSetChanged();
+        }
+
+        protected int getViewSize(final int position) {
+            return mViewSize;
         }
 
         @Override
@@ -272,8 +644,27 @@ public class CellDividerGroupTest {
         @Override
         public View getView(final int position, final View convertView, final ViewGroup parent) {
             final FrameLayout view = new FrameLayout(parent.getContext());
-            view.setLayoutParams(new ViewGroup.LayoutParams(mViewSize, mViewSize));
+            final int fill = ViewGroup.LayoutParams.MATCH_PARENT;
+            final int size = getViewSize(position);
+            if (mIsVertical) {
+                view.setLayoutParams(new ViewGroup.LayoutParams(fill, size));
+            } else {
+                view.setLayoutParams(new ViewGroup.LayoutParams(size, fill));
+            }
             return view;
+        }
+    }
+
+    private static final class UnevenAdapter extends TestAdapter {
+        private UnevenAdapter(final boolean isVertical) {
+            super(TALL_VIEW_SIZE, isVertical);
+        }
+
+        @Override
+        protected int getViewSize(final int position) {
+            final boolean isOdd = position % 2 == 1;
+            if (isOdd) return SHORT_VIEW_SIZE;
+            return TALL_VIEW_SIZE;
         }
     }
 }

--- a/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerPaintTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerPaintTest.java
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import androidx.test.core.app.ApplicationProvider;
+import java.util.ArrayList;
+import java.util.List;
+import mobi.parchment.test.R;
+import mobi.parchment.widget.adapterview.gridpatternview.GridPatternItemDefinition;
+import mobi.parchment.widget.adapterview.gridpatternview.GridPatternView;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.GraphicsMode;
+
+@RunWith(RobolectricTestRunner.class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+public class CellDividerPaintTest {
+
+    private static final int LIST_SIZE = 300;
+    private static final int CELL_SIZE = 100;
+    private static final int LIST_ADAPTER_SIZE = 6;
+    private static final int GRID_PATTERN_ADAPTER_SIZE = 3;
+    private static final int CELL_COLOUR = 0xFF0000FF;
+    private static final int DIVIDER_COLOUR = 0xFF00FF00;
+    private static final int NOTHING_PAINTED = 0;
+    private static final int DIVIDER_SIZE = 6;
+    private static final int NO_INTRINSIC_SIZE = -1;
+    private static final int OUTSIDE_EVERY_CELL = 5;
+    private static final int INSIDE_A_LIST_CELL = 150;
+    private static final int INSIDE_A_GRID_CELL = 100;
+    private static final int FIRST_GAP_CENTRE = 105;
+    private static final int INSIDE_THE_FIRST_CELL = 50;
+    private static final int INSIDE_THE_FIRST_CELL_UNDER_A_THICK_DIVIDER = 97;
+    private static final int PADDED_FIRST_GAP_CENTRE = 165;
+    private static final int PADDED_SECOND_GAP_CENTRE = 275;
+    private static final int OUTSIDE_THE_START_BREADTH_PADDING = 10;
+    private static final int OUTSIDE_THE_END_BREADTH_PADDING = 290;
+
+    @Test
+    public void dividerInXml_isPaintedAcrossTheGapBetweenTheCells() {
+        final Bitmap bitmap = paintList(R.id.divider_list_view);
+
+        assertThat(bitmap.getPixel(INSIDE_A_LIST_CELL, FIRST_GAP_CENTRE)).isEqualTo(DIVIDER_COLOUR);
+        assertThat(bitmap.getPixel(OUTSIDE_THE_START_BREADTH_PADDING, FIRST_GAP_CENTRE))
+                .isEqualTo(DIVIDER_COLOUR);
+        assertThat(bitmap.getPixel(INSIDE_A_LIST_CELL, INSIDE_THE_FIRST_CELL))
+                .isEqualTo(CELL_COLOUR);
+        assertThat(countRowsOfColour(bitmap, OUTSIDE_EVERY_CELL)).isEqualTo(2 * DIVIDER_SIZE);
+    }
+
+    @Test
+    public void noDividerInXml_paintsNothingBetweenTheCells() {
+        final Bitmap bitmap = paintList(R.id.no_divider_list_view);
+
+        assertThat(bitmap.getPixel(INSIDE_A_LIST_CELL, FIRST_GAP_CENTRE))
+                .isEqualTo(NOTHING_PAINTED);
+        assertThat(bitmap.getPixel(INSIDE_A_LIST_CELL, INSIDE_THE_FIRST_CELL))
+                .isEqualTo(CELL_COLOUR);
+    }
+
+    @Test
+    public void aColourDividerWithNoDividerSize_paintsNothing() {
+        final ColorDrawable colour = new ColorDrawable(Color.GREEN);
+        assertThat(colour.getIntrinsicHeight()).isEqualTo(NO_INTRINSIC_SIZE);
+        assertThat(colour.getIntrinsicWidth()).isEqualTo(NO_INTRINSIC_SIZE);
+
+        final Bitmap bitmap = paintList(R.id.sizeless_colour_divider_list_view);
+
+        assertThat(bitmap.getPixel(INSIDE_A_LIST_CELL, FIRST_GAP_CENTRE))
+                .isEqualTo(NOTHING_PAINTED);
+        assertThat(countRowsOfColour(bitmap, OUTSIDE_EVERY_CELL)).isEqualTo(0);
+    }
+
+    @Test
+    public void dividerThickerThanTheCellSpacing_isPaintedOverTheCells() {
+        final Bitmap bitmap = paintList(R.id.thick_divider_list_view);
+
+        assertThat(bitmap.getPixel(INSIDE_A_LIST_CELL, INSIDE_THE_FIRST_CELL_UNDER_A_THICK_DIVIDER))
+                .isEqualTo(DIVIDER_COLOUR);
+    }
+
+    @Test
+    public void dividerWithClipToPaddingOn_isPaintedIntoThePaddingItWouldClipACellOutOf() {
+        final Bitmap bitmap = paintList(R.id.padded_clipped_divider_list_view);
+
+        assertThat(bitmap.getPixel(INSIDE_A_LIST_CELL, PADDED_FIRST_GAP_CENTRE))
+                .isEqualTo(DIVIDER_COLOUR);
+        assertThat(bitmap.getPixel(INSIDE_A_LIST_CELL, PADDED_SECOND_GAP_CENTRE))
+                .isEqualTo(DIVIDER_COLOUR);
+        assertThat(bitmap.getPixel(OUTSIDE_THE_START_BREADTH_PADDING, PADDED_FIRST_GAP_CENTRE))
+                .isEqualTo(NOTHING_PAINTED);
+        assertThat(bitmap.getPixel(OUTSIDE_THE_END_BREADTH_PADDING, PADDED_FIRST_GAP_CENTRE))
+                .isEqualTo(NOTHING_PAINTED);
+    }
+
+    @Test
+    public void dividerWithClipToPaddingOff_paintsTheSameSurfaceAsWithClipToPaddingOn() {
+        final Bitmap clipped = paintList(R.id.padded_clipped_divider_list_view);
+        final Bitmap unclipped = paintList(R.id.padded_unclipped_divider_list_view);
+
+        assertThat(countRowsOfColour(unclipped, INSIDE_A_LIST_CELL)).isEqualTo(2 * DIVIDER_SIZE);
+        assertThat(sameDividerRows(clipped, unclipped)).isTrue();
+    }
+
+    @Test
+    public void dividerInXmlOnAGridView_isPaintedBetweenRowsRatherThanBetweenItems() {
+        final Bitmap bitmap = paintList(R.id.divider_grid_view);
+
+        assertThat(bitmap.getPixel(INSIDE_A_GRID_CELL, FIRST_GAP_CENTRE)).isEqualTo(DIVIDER_COLOUR);
+        assertThat(bitmap.getPixel(INSIDE_A_GRID_CELL, INSIDE_THE_FIRST_CELL))
+                .isEqualTo(CELL_COLOUR);
+        assertThat(countRowsOfColour(bitmap, OUTSIDE_EVERY_CELL)).isEqualTo(2 * DIVIDER_SIZE);
+    }
+
+    @Test
+    public void dividerInXmlOnAGridPatternView_isPaintedBetweenTheTwoPatternGroups() {
+        final Bitmap bitmap = paintGridPattern();
+
+        assertThat(countRowsOfColour(bitmap, OUTSIDE_EVERY_CELL)).isEqualTo(DIVIDER_SIZE);
+    }
+
+    private static int countRowsOfColour(final Bitmap bitmap, final int column) {
+        int rows = 0;
+        for (int row = 0; row < LIST_SIZE; row++) {
+            if (bitmap.getPixel(column, row) == DIVIDER_COLOUR) rows++;
+        }
+        return rows;
+    }
+
+    private static boolean sameDividerRows(final Bitmap first, final Bitmap second) {
+        for (int row = 0; row < LIST_SIZE; row++) {
+            for (int column = 0; column < LIST_SIZE; column++) {
+                final boolean firstIsDivider = first.getPixel(column, row) == DIVIDER_COLOUR;
+                final boolean secondIsDivider = second.getPixel(column, row) == DIVIDER_COLOUR;
+                if (firstIsDivider != secondIsDivider) return false;
+            }
+        }
+        return true;
+    }
+
+    private static Bitmap paintList(final int viewId) {
+        final View root = inflate();
+        final AbstractAdapterView<BaseAdapter, ?> adapterView = root.findViewById(viewId);
+        adapterView.setAdapter(new ColouredAdapter(CELL_SIZE, LIST_ADAPTER_SIZE));
+        return paint(adapterView);
+    }
+
+    private static Bitmap paintGridPattern() {
+        final View root = inflate();
+        final GridPatternView<BaseAdapter> gridPatternView =
+                root.findViewById(R.id.divider_grid_pattern_view);
+        final List<GridPatternItemDefinition> pairGroup =
+                new ArrayList<GridPatternItemDefinition>();
+        pairGroup.add(new GridPatternItemDefinition(0, 0, 1, 1));
+        pairGroup.add(new GridPatternItemDefinition(0, 1, 1, 1));
+        gridPatternView.addGridPatternGroupDefinition(pairGroup);
+        final List<GridPatternItemDefinition> tallGroup =
+                new ArrayList<GridPatternItemDefinition>();
+        tallGroup.add(new GridPatternItemDefinition(0, 0, 1, 2));
+        gridPatternView.addGridPatternGroupDefinition(tallGroup);
+        gridPatternView.setAdapter(new ColouredAdapter(CELL_SIZE, GRID_PATTERN_ADAPTER_SIZE));
+        return paint(gridPatternView);
+    }
+
+    private static Bitmap paint(final View adapterView) {
+        final int measureSpec =
+                View.MeasureSpec.makeMeasureSpec(LIST_SIZE, View.MeasureSpec.EXACTLY);
+        adapterView.measure(measureSpec, measureSpec);
+        adapterView.layout(0, 0, LIST_SIZE, LIST_SIZE);
+
+        final Bitmap bitmap = Bitmap.createBitmap(LIST_SIZE, LIST_SIZE, Bitmap.Config.ARGB_8888);
+        final Canvas canvas = new Canvas(bitmap);
+        adapterView.draw(canvas);
+        return bitmap;
+    }
+
+    private static View inflate() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        return View.inflate(context, R.layout.divider_paint, null);
+    }
+
+    private static final class ColouredAdapter extends BaseAdapter {
+        private final int mCellSize;
+        private final int mAdapterSize;
+
+        private ColouredAdapter(final int cellSize, final int adapterSize) {
+            mCellSize = cellSize;
+            mAdapterSize = adapterSize;
+        }
+
+        @Override
+        public int getCount() {
+            return mAdapterSize;
+        }
+
+        @Override
+        public Object getItem(final int position) {
+            return position;
+        }
+
+        @Override
+        public long getItemId(final int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(final int position, final View convertView, final ViewGroup parent) {
+            final View view = new View(parent.getContext());
+            view.setBackgroundColor(CELL_COLOUR);
+            view.setLayoutParams(new ViewGroup.LayoutParams(mCellSize, mCellSize));
+            return view;
+        }
+    }
+}

--- a/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerPaintTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerPaintTest.java
@@ -37,7 +37,12 @@ public class CellDividerPaintTest {
     private static final int NOTHING_PAINTED = 0;
     private static final int DIVIDER_SIZE = 6;
     private static final int NO_INTRINSIC_SIZE = -1;
-    private static final int OUTSIDE_EVERY_CELL = 5;
+    private static final int FILLS_THE_BREADTH = ViewGroup.LayoutParams.MATCH_PARENT;
+    private static final int NEAR_THE_START_OF_EVERY_CELL = 5;
+    private static final int BETWEEN_THE_GRID_COLUMNS = 150;
+    private static final int THE_START_BREADTH_EDGE = 0;
+    private static final int THE_END_BREADTH_EDGE = LIST_SIZE - 1;
+    private static final int PATTERN_GROUP_GAP_CENTRE = 150;
     private static final int INSIDE_A_LIST_CELL = 150;
     private static final int INSIDE_A_GRID_CELL = 100;
     private static final int FIRST_GAP_CENTRE = 105;
@@ -57,7 +62,8 @@ public class CellDividerPaintTest {
                 .isEqualTo(DIVIDER_COLOUR);
         assertThat(bitmap.getPixel(INSIDE_A_LIST_CELL, INSIDE_THE_FIRST_CELL))
                 .isEqualTo(CELL_COLOUR);
-        assertThat(countRowsOfColour(bitmap, OUTSIDE_EVERY_CELL)).isEqualTo(2 * DIVIDER_SIZE);
+        assertThat(countRowsOfColour(bitmap, NEAR_THE_START_OF_EVERY_CELL))
+                .isEqualTo(2 * DIVIDER_SIZE);
     }
 
     @Test
@@ -80,7 +86,7 @@ public class CellDividerPaintTest {
 
         assertThat(bitmap.getPixel(INSIDE_A_LIST_CELL, FIRST_GAP_CENTRE))
                 .isEqualTo(NOTHING_PAINTED);
-        assertThat(countRowsOfColour(bitmap, OUTSIDE_EVERY_CELL)).isEqualTo(0);
+        assertThat(countRowsOfColour(bitmap, NEAR_THE_START_OF_EVERY_CELL)).isEqualTo(0);
     }
 
     @Test
@@ -115,20 +121,56 @@ public class CellDividerPaintTest {
     }
 
     @Test
-    public void dividerInXmlOnAGridView_isPaintedBetweenRowsRatherThanBetweenItems() {
+    public void dividerInXmlOnAGridView_isPaintedBetweenTheItemsOfARowAsWellAsBetweenTheRows() {
         final Bitmap bitmap = paintList(R.id.divider_grid_view);
 
         assertThat(bitmap.getPixel(INSIDE_A_GRID_CELL, FIRST_GAP_CENTRE)).isEqualTo(DIVIDER_COLOUR);
+        assertThat(bitmap.getPixel(BETWEEN_THE_GRID_COLUMNS, INSIDE_THE_FIRST_CELL))
+                .isEqualTo(DIVIDER_COLOUR);
         assertThat(bitmap.getPixel(INSIDE_A_GRID_CELL, INSIDE_THE_FIRST_CELL))
                 .isEqualTo(CELL_COLOUR);
-        assertThat(countRowsOfColour(bitmap, OUTSIDE_EVERY_CELL)).isEqualTo(2 * DIVIDER_SIZE);
+        assertThat(countRowsOfColour(bitmap, NEAR_THE_START_OF_EVERY_CELL))
+                .isEqualTo(2 * DIVIDER_SIZE);
+        assertThat(countColumnsOfColour(bitmap, INSIDE_THE_FIRST_CELL)).isEqualTo(DIVIDER_SIZE);
     }
 
     @Test
-    public void dividerInXmlOnAGridPatternView_isPaintedBetweenTheTwoPatternGroups() {
+    public void dividerInXmlOnAGridView_isNotPaintedAtTheOuterBreadthEdges() {
+        final Bitmap bitmap = paintList(R.id.divider_grid_view);
+
+        assertThat(bitmap.getPixel(THE_START_BREADTH_EDGE, INSIDE_THE_FIRST_CELL))
+                .isEqualTo(CELL_COLOUR);
+        assertThat(bitmap.getPixel(THE_END_BREADTH_EDGE, INSIDE_THE_FIRST_CELL))
+                .isEqualTo(CELL_COLOUR);
+    }
+
+    @Test
+    public void dividerInXmlOnAGridView_whereTwoGapsCross_paintsNothing() {
+        final Bitmap bitmap = paintList(R.id.divider_grid_view);
+
+        assertThat(bitmap.getPixel(BETWEEN_THE_GRID_COLUMNS, FIRST_GAP_CENTRE))
+                .isEqualTo(NOTHING_PAINTED);
+    }
+
+    @Test
+    public void dividerInXmlOnAGridPatternView_isPaintedInsideAGroupAsWellAsBetweenGroups() {
         final Bitmap bitmap = paintGridPattern();
 
-        assertThat(countRowsOfColour(bitmap, OUTSIDE_EVERY_CELL)).isEqualTo(DIVIDER_SIZE);
+        assertThat(bitmap.getPixel(BETWEEN_THE_GRID_COLUMNS, INSIDE_THE_FIRST_CELL))
+                .isEqualTo(DIVIDER_COLOUR);
+        assertThat(bitmap.getPixel(INSIDE_A_GRID_CELL, PATTERN_GROUP_GAP_CENTRE))
+                .isEqualTo(DIVIDER_COLOUR);
+        assertThat(countRowsOfColour(bitmap, NEAR_THE_START_OF_EVERY_CELL)).isEqualTo(DIVIDER_SIZE);
+    }
+
+    @Test
+    public void dividerInXmlOnAGridPatternView_isNotPaintedAtTheOuterBreadthEdges() {
+        final Bitmap bitmap = paintGridPattern();
+
+        assertThat(bitmap.getPixel(THE_START_BREADTH_EDGE, INSIDE_THE_FIRST_CELL))
+                .isEqualTo(CELL_COLOUR);
+        assertThat(bitmap.getPixel(THE_END_BREADTH_EDGE, INSIDE_THE_FIRST_CELL))
+                .isEqualTo(CELL_COLOUR);
     }
 
     private static int countRowsOfColour(final Bitmap bitmap, final int column) {
@@ -137,6 +179,14 @@ public class CellDividerPaintTest {
             if (bitmap.getPixel(column, row) == DIVIDER_COLOUR) rows++;
         }
         return rows;
+    }
+
+    private static int countColumnsOfColour(final Bitmap bitmap, final int row) {
+        int columns = 0;
+        for (int column = 0; column < LIST_SIZE; column++) {
+            if (bitmap.getPixel(column, row) == DIVIDER_COLOUR) columns++;
+        }
+        return columns;
     }
 
     private static boolean sameDividerRows(final Bitmap first, final Bitmap second) {
@@ -153,7 +203,8 @@ public class CellDividerPaintTest {
     private static Bitmap paintList(final int viewId) {
         final View root = inflate();
         final AbstractAdapterView<BaseAdapter, ?> adapterView = root.findViewById(viewId);
-        adapterView.setAdapter(new ColouredAdapter(CELL_SIZE, LIST_ADAPTER_SIZE));
+        adapterView.setAdapter(
+                new ColouredAdapter(FILLS_THE_BREADTH, CELL_SIZE, LIST_ADAPTER_SIZE));
         return paint(adapterView);
     }
 
@@ -170,7 +221,9 @@ public class CellDividerPaintTest {
                 new ArrayList<GridPatternItemDefinition>();
         tallGroup.add(new GridPatternItemDefinition(0, 0, 1, 2));
         gridPatternView.addGridPatternGroupDefinition(tallGroup);
-        gridPatternView.setAdapter(new ColouredAdapter(CELL_SIZE, GRID_PATTERN_ADAPTER_SIZE));
+        gridPatternView.setAdapter(
+                new ColouredAdapter(
+                        FILLS_THE_BREADTH, FILLS_THE_BREADTH, GRID_PATTERN_ADAPTER_SIZE));
         return paint(gridPatternView);
     }
 
@@ -192,11 +245,13 @@ public class CellDividerPaintTest {
     }
 
     private static final class ColouredAdapter extends BaseAdapter {
-        private final int mCellSize;
+        private final int mCellWidth;
+        private final int mCellHeight;
         private final int mAdapterSize;
 
-        private ColouredAdapter(final int cellSize, final int adapterSize) {
-            mCellSize = cellSize;
+        private ColouredAdapter(final int cellWidth, final int cellHeight, final int adapterSize) {
+            mCellWidth = cellWidth;
+            mCellHeight = cellHeight;
             mAdapterSize = adapterSize;
         }
 
@@ -219,7 +274,7 @@ public class CellDividerPaintTest {
         public View getView(final int position, final View convertView, final ViewGroup parent) {
             final View view = new View(parent.getContext());
             view.setBackgroundColor(CELL_COLOUR);
-            view.setLayoutParams(new ViewGroup.LayoutParams(mCellSize, mCellSize));
+            view.setLayoutParams(new ViewGroup.LayoutParams(mCellWidth, mCellHeight));
             return view;
         }
     }

--- a/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerTest.java
@@ -38,6 +38,10 @@ public class CellDividerTest {
     private static final int START_SIZE_PADDING = 30;
     private static final int END_SIZE_PADDING = 50;
     private static final int BREADTH_END = VIEW_GROUP_SIZE - END_BREADTH_PADDING;
+    private static final int PADDED_ROW_BREADTH =
+            VIEW_GROUP_SIZE - START_BREADTH_PADDING - END_BREADTH_PADDING;
+    private static final int PADDED_ROW_START = (VIEW_GROUP_SIZE - PADDED_ROW_BREADTH) / 2;
+    private static final int PADDED_ROW_END = PADDED_ROW_START + PADDED_ROW_BREADTH;
     private static final boolean IS_VERTICAL = true;
     private static final boolean IS_HORIZONTAL = false;
     private static final boolean CIRCULAR = true;
@@ -179,7 +183,7 @@ public class CellDividerTest {
     }
 
     @Test
-    public void divider_inAVerticalListWithPadding_staysInsideTheBreadthPadding() {
+    public void divider_inAVerticalListWithPadding_spansTheRowRatherThanThePaddingBox() {
         final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
         harness.setPadding();
         harness.layout(SIX_CELLS);
@@ -189,13 +193,13 @@ public class CellDividerTest {
         harness.draw();
 
         assertThat(divider.getDrawnBounds(0))
-                .isEqualTo(new Rect(START_BREADTH_PADDING, 133, BREADTH_END, 137));
+                .isEqualTo(new Rect(PADDED_ROW_START, 133, PADDED_ROW_END, 137));
         assertThat(divider.getDrawnBounds(1))
-                .isEqualTo(new Rect(START_BREADTH_PADDING, 243, BREADTH_END, 247));
+                .isEqualTo(new Rect(PADDED_ROW_START, 243, PADDED_ROW_END, 247));
     }
 
     @Test
-    public void divider_inAHorizontalListWithPadding_staysInsideTheBreadthPadding() {
+    public void divider_inAHorizontalListWithPadding_spansTheRowRatherThanThePaddingBox() {
         final Harness harness = new Harness(IS_HORIZONTAL, CELL_SPACING, NOT_CIRCULAR);
         harness.setPadding();
         harness.layout(SIX_CELLS);
@@ -205,9 +209,9 @@ public class CellDividerTest {
         harness.draw();
 
         assertThat(divider.getDrawnBounds(0))
-                .isEqualTo(new Rect(133, START_BREADTH_PADDING, 137, BREADTH_END));
+                .isEqualTo(new Rect(133, PADDED_ROW_START, 137, PADDED_ROW_END));
         assertThat(divider.getDrawnBounds(1))
-                .isEqualTo(new Rect(243, START_BREADTH_PADDING, 247, BREADTH_END));
+                .isEqualTo(new Rect(243, PADDED_ROW_START, 247, PADDED_ROW_END));
     }
 
     @Test
@@ -409,7 +413,7 @@ public class CellDividerTest {
         private final MyViewGroup mViewGroup =
                 new MyViewGroup(ApplicationProvider.getApplicationContext());
         private final AdapterViewManager mAdapterViewManager = new AdapterViewManager();
-        private final TestAdapter mTestAdapter = new TestAdapter(VIEW_SIZE);
+        private final TestAdapter mTestAdapter;
         private final LayoutManager<View> mLayoutManager;
         private final Animation mAnimation = new Animation();
         private CellDivider mCellDivider;
@@ -417,6 +421,7 @@ public class CellDividerTest {
         private Harness(
                 final boolean isVertical, final int cellSpacing, final boolean isCircularScroll) {
             mIsVertical = isVertical;
+            mTestAdapter = new TestAdapter(VIEW_SIZE, isVertical);
             final LayoutManagerAttributes attributes =
                     new LayoutManagerAttributes(
                             isCircularScroll,
@@ -462,6 +467,7 @@ public class CellDividerTest {
                     View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
             mViewGroup.measure(measureSpec, measureSpec);
             mViewGroup.layout(0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+            mLayoutManager.measure(mViewGroup, measureSpec, measureSpec);
             mTestAdapter.setAdapterSize(adapterSize);
             mAnimation.newAnimation();
             mLayoutManager.layout(mViewGroup, mAnimation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
@@ -480,7 +486,7 @@ public class CellDividerTest {
         }
 
         private void draw() {
-            mCellDivider.draw(mCanvas, mViewGroup, mLayoutManager);
+            mCellDivider.draw(mCanvas, mLayoutManager);
         }
 
         private int getDrawnCellCount() {
@@ -521,10 +527,12 @@ public class CellDividerTest {
 
     private static final class TestAdapter extends BaseAdapter {
         private final int mViewSize;
+        private final boolean mIsVertical;
         private int mAdapterSize;
 
-        private TestAdapter(final int viewSize) {
+        private TestAdapter(final int viewSize, final boolean isVertical) {
             mViewSize = viewSize;
+            mIsVertical = isVertical;
         }
 
         private void setAdapterSize(final int adapterSize) {
@@ -550,7 +558,12 @@ public class CellDividerTest {
         @Override
         public View getView(final int position, final View convertView, final ViewGroup parent) {
             final FrameLayout view = new FrameLayout(parent.getContext());
-            view.setLayoutParams(new ViewGroup.LayoutParams(mViewSize, mViewSize));
+            final int fillsTheBreadth = ViewGroup.LayoutParams.MATCH_PARENT;
+            if (mIsVertical) {
+                view.setLayoutParams(new ViewGroup.LayoutParams(fillsTheBreadth, mViewSize));
+            } else {
+                view.setLayoutParams(new ViewGroup.LayoutParams(mViewSize, fillsTheBreadth));
+            }
             return view;
         }
     }

--- a/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/CellDividerTest.java
@@ -1,0 +1,557 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import androidx.test.core.app.ApplicationProvider;
+import java.util.ArrayList;
+import java.util.List;
+import mobi.parchment.widget.adapterview.listview.ListLayoutManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class CellDividerTest {
+
+    private static final int VIEW_GROUP_SIZE = 300;
+    private static final int VIEW_SIZE = 100;
+    private static final int CELL_SPACING = 10;
+    private static final int NO_CELL_SPACING = 0;
+    private static final int DIVIDER_SIZE = 4;
+    private static final int THICK_DIVIDER_SIZE = 20;
+    private static final int INTRINSIC_BREADTH = 7;
+    private static final int INTRINSIC_THICKNESS = 3;
+    private static final int START_BREADTH_PADDING = 20;
+    private static final int END_BREADTH_PADDING = 40;
+    private static final int START_SIZE_PADDING = 30;
+    private static final int END_SIZE_PADDING = 50;
+    private static final int BREADTH_END = VIEW_GROUP_SIZE - END_BREADTH_PADDING;
+    private static final boolean IS_VERTICAL = true;
+    private static final boolean IS_HORIZONTAL = false;
+    private static final boolean CIRCULAR = true;
+    private static final boolean NOT_CIRCULAR = false;
+    private static final int SIX_CELLS = 6;
+    private static final int THREE_CELLS = 3;
+    private static final int ONE_CELL = 1;
+    private static final int NO_CELLS = 0;
+    private static final int FORWARD_SCROLL = -150;
+    private static final int SCROLL_PAST_THE_FIRST_CELL = -105;
+    private static final int SCROLL_CLEAR_OF_THE_FIRST_CELL = -110;
+    private static final int FOUR_CELLS = 4;
+    private static final int NO_DIVIDER_SIZE = 0;
+    private static final int NEGATIVE_DIVIDER_SIZE = -4;
+    private static final int LAST_DRAWN_CELL_INDEX = 2;
+    private static final int FIRST_ADAPTER_POSITION = 0;
+    private static final boolean NOT_SNAP_TO_POSITION = false;
+    private static final boolean NOT_A_VIEW_PAGER = false;
+    private static final int VIEWPORT_VIEW_PAGER_INTERVAL = 0;
+    private static final boolean NOT_SELECT_ON_SNAP = false;
+    private static final boolean NOT_SELECT_WHILE_SCROLLING = false;
+    private static final int GAP_START = 100;
+    private static final int GAP_END = 110;
+    private static final int GAP_START_ACROSS_THE_ORIGIN = -5;
+    private static final int GAP_END_ACROSS_THE_ORIGIN = 4;
+    private static final int ODD_DIVIDER_SIZE = 3;
+    private static final int OVERLAPPING_GAP_START = 110;
+    private static final int OVERLAPPING_GAP_END = 100;
+    private static final int NEGATIVE_CELL_SPACING = -10;
+    private static final int FEWER_CELLS = 2;
+
+    @Test
+    public void dividerStart_inAGapAwayFromTheOrigin_centresTheDividerInTheGap() {
+        final int dividerStart = CellDivider.getDividerStart(GAP_START, GAP_END, DIVIDER_SIZE);
+
+        assertThat(dividerStart).isEqualTo(103);
+    }
+
+    @Test
+    public void dividerStart_inAGapThatStartsBeforeTheOrigin_centresTheDividerInTheGap() {
+        final int dividerStart =
+                CellDivider.getDividerStart(
+                        GAP_START_ACROSS_THE_ORIGIN, GAP_END_ACROSS_THE_ORIGIN, DIVIDER_SIZE);
+
+        assertThat(dividerStart).isEqualTo(-3);
+    }
+
+    @Test
+    public void dividerStart_withADividerWiderThanTheGap_overlapsBothCellsEvenly() {
+        final int dividerStart =
+                CellDivider.getDividerStart(GAP_START, GAP_END, THICK_DIVIDER_SIZE);
+
+        assertThat(dividerStart).isEqualTo(95);
+    }
+
+    @Test
+    public void dividerStart_withAnOddDividerSize_roundsTheBandTowardTheGapEnd() {
+        final int dividerStart = CellDivider.getDividerStart(GAP_START, GAP_END, ODD_DIVIDER_SIZE);
+
+        assertThat(dividerStart).isEqualTo(104);
+    }
+
+    @Test
+    public void dividerStart_inAGapThatRunsBackwards_staysBetweenTheTwoCells() {
+        final int dividerStart =
+                CellDivider.getDividerStart(
+                        OVERLAPPING_GAP_START, OVERLAPPING_GAP_END, DIVIDER_SIZE);
+
+        assertThat(dividerStart).isEqualTo(103);
+    }
+
+    @Test
+    public void divider_withANegativeCellSpacing_isDrawnWhereTheCellsOverlap() {
+        final Harness harness = new Harness(IS_VERTICAL, NEGATIVE_CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 93, VIEW_GROUP_SIZE, 97));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(0, 183, VIEW_GROUP_SIZE, 187));
+    }
+
+    @Test
+    public void divider_afterTheAdapterShrinks_isDrawnOnceFewerThanTheRemainingCells() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+        harness.draw();
+        assertThat(divider.getDrawCount()).isEqualTo(2);
+
+        harness.layout(FEWER_CELLS);
+        harness.draw();
+
+        assertThat(harness.getDrawnCellCount()).isEqualTo(FEWER_CELLS);
+        assertThat(divider.getDrawCount()).isEqualTo(3);
+        assertThat(divider.getDrawnBounds(2)).isEqualTo(new Rect(0, 148, VIEW_GROUP_SIZE, 152));
+    }
+
+    @Test
+    public void divider_betweenThreeDrawnCells_isDrawnOnceFewerThanTheCells() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(harness.getDrawnCellCount()).isEqualTo(THREE_CELLS);
+        assertThat(divider.getDrawCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void divider_inAVerticalList_isCentredInTheGapAndSpansTheBreadth() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 103, VIEW_GROUP_SIZE, 107));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(0, 213, VIEW_GROUP_SIZE, 217));
+    }
+
+    @Test
+    public void divider_inAHorizontalList_isCentredInTheGapAndSpansTheBreadth() {
+        final Harness harness = new Harness(IS_HORIZONTAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(103, 0, 107, VIEW_GROUP_SIZE));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(213, 0, 217, VIEW_GROUP_SIZE));
+    }
+
+    @Test
+    public void divider_inAVerticalListWithPadding_staysInsideTheBreadthPadding() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.setPadding();
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawnBounds(0))
+                .isEqualTo(new Rect(START_BREADTH_PADDING, 133, BREADTH_END, 137));
+        assertThat(divider.getDrawnBounds(1))
+                .isEqualTo(new Rect(START_BREADTH_PADDING, 243, BREADTH_END, 247));
+    }
+
+    @Test
+    public void divider_inAHorizontalListWithPadding_staysInsideTheBreadthPadding() {
+        final Harness harness = new Harness(IS_HORIZONTAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.setPadding();
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawnBounds(0))
+                .isEqualTo(new Rect(133, START_BREADTH_PADDING, 137, BREADTH_END));
+        assertThat(divider.getDrawnBounds(1))
+                .isEqualTo(new Rect(243, START_BREADTH_PADDING, 247, BREADTH_END));
+    }
+
+    @Test
+    public void dividerSizeOfZero_drawsNothing() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider =
+                new RecordingDrawable(INTRINSIC_BREADTH, INTRINSIC_THICKNESS);
+        harness.setDivider(divider, NO_DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void aNegativeDividerSize_drawsNothing() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider =
+                new RecordingDrawable(INTRINSIC_BREADTH, INTRINSIC_THICKNESS);
+        harness.setDivider(divider, NEGATIVE_DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void divider_whenACellScrollsOffTheStart_isStillDrawnWhileItsGapIsOnScreen() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        harness.scroll(SCROLL_PAST_THE_FIRST_CELL);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(harness.getDrawnCellCount()).isEqualTo(FOUR_CELLS);
+        assertThat(divider.getDrawCount()).isEqualTo(3);
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, -2, VIEW_GROUP_SIZE, 2));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(0, 108, VIEW_GROUP_SIZE, 112));
+        assertThat(divider.getDrawnBounds(2)).isEqualTo(new Rect(0, 218, VIEW_GROUP_SIZE, 222));
+    }
+
+    @Test
+    public void divider_whenACellScrollsClearOfTheStart_isNotDrawnAboveTheFirstDrawnCell() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        harness.scroll(SCROLL_CLEAR_OF_THE_FIRST_CELL);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(harness.getDrawnCellCount()).isEqualTo(THREE_CELLS);
+        assertThat(divider.getDrawCount()).isEqualTo(2);
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 103, VIEW_GROUP_SIZE, 107));
+    }
+
+    @Test
+    public void dividerSizeAbsent_inAVerticalList_takesTheIntrinsicHeight() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider =
+                new RecordingDrawable(INTRINSIC_BREADTH, INTRINSIC_THICKNESS);
+        harness.setDivider(divider, CellDivider.INTRINSIC_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 104, VIEW_GROUP_SIZE, 107));
+    }
+
+    @Test
+    public void dividerSizeAbsent_inAHorizontalList_takesTheIntrinsicWidth() {
+        final Harness harness = new Harness(IS_HORIZONTAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider =
+                new RecordingDrawable(INTRINSIC_BREADTH, INTRINSIC_THICKNESS);
+        harness.setDivider(divider, CellDivider.INTRINSIC_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(102, 0, 109, VIEW_GROUP_SIZE));
+    }
+
+    @Test
+    public void dividerSizeAbsent_withADrawableThatHasNoIntrinsicSize_drawsNothing() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, CellDivider.INTRINSIC_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void dividerSizeSet_overridesTheDrawablesIntrinsicSize() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider =
+                new RecordingDrawable(INTRINSIC_BREADTH, INTRINSIC_THICKNESS);
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 103, VIEW_GROUP_SIZE, 107));
+    }
+
+    @Test
+    public void dividerThickerThanTheCellSpacing_overlapsBothCellsEvenly() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, THICK_DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 95, VIEW_GROUP_SIZE, 115));
+    }
+
+    @Test
+    public void dividerWithNoCellSpacing_isCentredOnTheBoundaryBetweenTheCells() {
+        final Harness harness = new Harness(IS_VERTICAL, NO_CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(divider.getDrawnBounds(0)).isEqualTo(new Rect(0, 98, VIEW_GROUP_SIZE, 102));
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(0, 198, VIEW_GROUP_SIZE, 202));
+    }
+
+    @Test
+    public void divider_withCircularScroll_isDrawnBetweenTheLastAndTheFirstCell() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, CIRCULAR);
+        harness.layout(THREE_CELLS);
+        harness.scroll(FORWARD_SCROLL);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(harness.getAdapterPositionOfDrawnCell(LAST_DRAWN_CELL_INDEX))
+                .isEqualTo(FIRST_ADAPTER_POSITION);
+        assertThat(divider.getDrawCount()).isEqualTo(2);
+        assertThat(divider.getDrawnBounds(1)).isEqualTo(new Rect(0, 173, VIEW_GROUP_SIZE, 177));
+    }
+
+    @Test
+    public void divider_withASingleCell_drawsNothing() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(ONE_CELL);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(harness.getDrawnCellCount()).isEqualTo(ONE_CELL);
+        assertThat(divider.getDrawCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void divider_withAnEmptyAdapter_drawsNothing() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(NO_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+
+        assertThat(harness.getDrawnCellCount()).isEqualTo(NO_CELLS);
+        assertThat(divider.getDrawCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void everyDividerOfEveryFrame_isMeasuredIntoTheSameBoundsRect() {
+        final Harness harness = new Harness(IS_VERTICAL, CELL_SPACING, NOT_CIRCULAR);
+        harness.layout(SIX_CELLS);
+        final RecordingDrawable divider = new RecordingDrawable();
+        harness.setDivider(divider, DIVIDER_SIZE);
+
+        harness.draw();
+        harness.draw();
+
+        final List<Rect> boundsInstances = divider.getBoundsInstances();
+        assertThat(boundsInstances).hasSize(4);
+        for (final Rect bounds : boundsInstances) {
+            assertThat(bounds).isSameAs(boundsInstances.get(0));
+        }
+    }
+
+    private static final class Harness {
+        private final boolean mIsVertical;
+        private final Canvas mCanvas = new Canvas();
+        private final MyViewGroup mViewGroup =
+                new MyViewGroup(ApplicationProvider.getApplicationContext());
+        private final AdapterViewManager mAdapterViewManager = new AdapterViewManager();
+        private final TestAdapter mTestAdapter = new TestAdapter(VIEW_SIZE);
+        private final LayoutManager<View> mLayoutManager;
+        private final Animation mAnimation = new Animation();
+        private CellDivider mCellDivider;
+
+        private Harness(
+                final boolean isVertical, final int cellSpacing, final boolean isCircularScroll) {
+            mIsVertical = isVertical;
+            final LayoutManagerAttributes attributes =
+                    new LayoutManagerAttributes(
+                            isCircularScroll,
+                            NOT_SNAP_TO_POSITION,
+                            NOT_A_VIEW_PAGER,
+                            VIEWPORT_VIEW_PAGER_INTERVAL,
+                            SnapPosition.onScreen,
+                            cellSpacing,
+                            NOT_SELECT_ON_SNAP,
+                            NOT_SELECT_WHILE_SCROLLING,
+                            isVertical);
+            mLayoutManager =
+                    new ListLayoutManager(mViewGroup, null, mAdapterViewManager, attributes);
+            mAdapterViewManager.setAdapter(mTestAdapter);
+        }
+
+        private void setPadding() {
+            if (mIsVertical) {
+                setVerticalPadding();
+            } else {
+                setHorizontalPadding();
+            }
+        }
+
+        private void setVerticalPadding() {
+            mViewGroup.setPadding(
+                    START_BREADTH_PADDING,
+                    START_SIZE_PADDING,
+                    END_BREADTH_PADDING,
+                    END_SIZE_PADDING);
+        }
+
+        private void setHorizontalPadding() {
+            mViewGroup.setPadding(
+                    START_SIZE_PADDING,
+                    START_BREADTH_PADDING,
+                    END_SIZE_PADDING,
+                    END_BREADTH_PADDING);
+        }
+
+        private void layout(final int adapterSize) {
+            final int measureSpec =
+                    View.MeasureSpec.makeMeasureSpec(VIEW_GROUP_SIZE, View.MeasureSpec.EXACTLY);
+            mViewGroup.measure(measureSpec, measureSpec);
+            mViewGroup.layout(0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+            mTestAdapter.setAdapterSize(adapterSize);
+            mAnimation.newAnimation();
+            mLayoutManager.layout(mViewGroup, mAnimation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+        }
+
+        private void scroll(final int displacement) {
+            mAnimation.newAnimation();
+            mAnimation.setDisplacement(displacement);
+            mLayoutManager.layout(mViewGroup, mAnimation, 0, 0, VIEW_GROUP_SIZE, VIEW_GROUP_SIZE);
+        }
+
+        private void setDivider(final Drawable divider, final int dividerSize) {
+            final ScrollDirectionManager scrollDirectionManager =
+                    mLayoutManager.getScrollDirectionManager();
+            mCellDivider = new CellDivider(divider, dividerSize, scrollDirectionManager);
+        }
+
+        private void draw() {
+            mCellDivider.draw(mCanvas, mViewGroup, mLayoutManager);
+        }
+
+        private int getDrawnCellCount() {
+            return mLayoutManager.getDrawnCellCount();
+        }
+
+        private int getAdapterPositionOfDrawnCell(final int cellIndex) {
+            final ScrollDirectionManager scrollDirectionManager =
+                    mLayoutManager.getScrollDirectionManager();
+            final int cellStart = mLayoutManager.getDrawnCellStart(cellIndex);
+            for (final View view : mViewGroup.mViews) {
+                final int viewStart = scrollDirectionManager.getViewStart(view);
+                if (viewStart == cellStart) return mLayoutManager.getPosition(view);
+            }
+            return LayoutManager.INVALID_POSITION;
+        }
+    }
+
+    private static final class MyViewGroup extends LinearLayout implements AdapterViewHandler {
+        private final List<View> mViews = new ArrayList<View>();
+
+        private MyViewGroup(final Context context) {
+            super(context);
+        }
+
+        @Override
+        public boolean addViewInAdapterView(
+                final View view, final int index, final ViewGroup.LayoutParams layoutParams) {
+            mViews.add(index, view);
+            return true;
+        }
+
+        @Override
+        public void removeViewInAdapterView(final View view) {
+            mViews.remove(view);
+        }
+    }
+
+    private static final class TestAdapter extends BaseAdapter {
+        private final int mViewSize;
+        private int mAdapterSize;
+
+        private TestAdapter(final int viewSize) {
+            mViewSize = viewSize;
+        }
+
+        private void setAdapterSize(final int adapterSize) {
+            mAdapterSize = adapterSize;
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public int getCount() {
+            return mAdapterSize;
+        }
+
+        @Override
+        public Object getItem(final int position) {
+            return position;
+        }
+
+        @Override
+        public long getItemId(final int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(final int position, final View convertView, final ViewGroup parent) {
+            final FrameLayout view = new FrameLayout(parent.getContext());
+            view.setLayoutParams(new ViewGroup.LayoutParams(mViewSize, mViewSize));
+            return view;
+        }
+    }
+}

--- a/library/src/test/java/mobi/parchment/widget/adapterview/CellEdgesTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/CellEdgesTest.java
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class CellEdgesTest {
+
+    private static final int ITEM_START = 0;
+    private static final int ITEM_END = 100;
+    private static final int AFTER_A_GAP_START = 110;
+    private static final int AFTER_A_GAP_END = 210;
+    private static final int TOUCHING_START = 100;
+    private static final int TOUCHING_END = 200;
+    private static final int OVERLAPPING_START = 90;
+    private static final int OVERLAPPING_END = 190;
+    private static final int NESTED_START = 20;
+    private static final int NESTED_END = 80;
+    private static final int BEFORE_START = -110;
+    private static final int BEFORE_END = -10;
+    private static final int FURTHER_START = 220;
+    private static final int FURTHER_END = 320;
+    private static final int BAND_START = 0;
+    private static final int BAND_END = 145;
+
+    @Test
+    public void isAcrossTheEndEdge_forANeighbourSeparatedByAGap_isTrue() {
+        final boolean isAcross =
+                CellEdges.isAcrossTheEndEdge(
+                        ITEM_START, ITEM_END, AFTER_A_GAP_START, AFTER_A_GAP_END);
+
+        assertThat(isAcross).isTrue();
+    }
+
+    @Test
+    public void isAcrossTheEndEdge_forANeighbourTouchingTheEndEdge_isTrue() {
+        final boolean isAcross =
+                CellEdges.isAcrossTheEndEdge(ITEM_START, ITEM_END, TOUCHING_START, TOUCHING_END);
+
+        assertThat(isAcross).isTrue();
+    }
+
+    @Test
+    public void isAcrossTheEndEdge_forANeighbourOverlappingButReachingFurther_isTrue() {
+        final boolean isAcross =
+                CellEdges.isAcrossTheEndEdge(
+                        ITEM_START, ITEM_END, OVERLAPPING_START, OVERLAPPING_END);
+
+        assertThat(isAcross).isTrue();
+    }
+
+    @Test
+    public void isAcrossTheEndEdge_forTheItemItself_isFalse() {
+        final boolean isAcross =
+                CellEdges.isAcrossTheEndEdge(ITEM_START, ITEM_END, ITEM_START, ITEM_END);
+
+        assertThat(isAcross).isFalse();
+    }
+
+    @Test
+    public void isAcrossTheEndEdge_forANeighbourBeforeTheItem_isFalse() {
+        final boolean isAcross =
+                CellEdges.isAcrossTheEndEdge(ITEM_START, ITEM_END, BEFORE_START, BEFORE_END);
+
+        assertThat(isAcross).isFalse();
+    }
+
+    @Test
+    public void isAcrossTheEndEdge_forANeighbourNestedInsideTheItem_isFalse() {
+        final boolean isAcross =
+                CellEdges.isAcrossTheEndEdge(ITEM_START, ITEM_END, NESTED_START, NESTED_END);
+
+        assertThat(isAcross).isFalse();
+    }
+
+    @Test
+    public void isAcrossTheEndEdge_forAPairOfItems_holdsInOneDirectionOnly() {
+        final boolean forwards =
+                CellEdges.isAcrossTheEndEdge(
+                        ITEM_START, ITEM_END, AFTER_A_GAP_START, AFTER_A_GAP_END);
+        final boolean backwards =
+                CellEdges.isAcrossTheEndEdge(
+                        AFTER_A_GAP_START, AFTER_A_GAP_END, ITEM_START, ITEM_END);
+
+        assertThat(forwards).isTrue();
+        assertThat(backwards).isFalse();
+    }
+
+    @Test
+    public void overlap_ofTwoPartlyOverlappingSpans_isTheSharedRun() {
+        final int overlapStart = CellEdges.getOverlapStart(ITEM_START, NESTED_START);
+        final int overlapEnd = CellEdges.getOverlapEnd(ITEM_END, AFTER_A_GAP_END);
+
+        assertThat(overlapStart).isEqualTo(NESTED_START);
+        assertThat(overlapEnd).isEqualTo(ITEM_END);
+        assertThat(CellEdges.isAnOverlap(overlapStart, overlapEnd)).isTrue();
+    }
+
+    @Test
+    public void isAnOverlap_forSpansThatOnlyTouch_isFalse() {
+        final int overlapStart = CellEdges.getOverlapStart(ITEM_START, TOUCHING_START);
+        final int overlapEnd = CellEdges.getOverlapEnd(ITEM_END, TOUCHING_END);
+
+        assertThat(overlapStart).isEqualTo(ITEM_END);
+        assertThat(overlapEnd).isEqualTo(ITEM_END);
+        assertThat(CellEdges.isAnOverlap(overlapStart, overlapEnd)).isFalse();
+    }
+
+    @Test
+    public void isAnOverlap_forDisjointSpans_isFalse() {
+        final int overlapStart = CellEdges.getOverlapStart(ITEM_START, AFTER_A_GAP_START);
+        final int overlapEnd = CellEdges.getOverlapEnd(ITEM_END, AFTER_A_GAP_END);
+
+        assertThat(CellEdges.isAnOverlap(overlapStart, overlapEnd)).isFalse();
+    }
+
+    @Test
+    public void isInTheGap_forAnItemBetweenTheTwo_isTrue() {
+        final boolean isInTheGap =
+                CellEdges.isInTheGap(
+                        ITEM_START,
+                        ITEM_END,
+                        FURTHER_START,
+                        FURTHER_END,
+                        AFTER_A_GAP_START,
+                        AFTER_A_GAP_END);
+
+        assertThat(isInTheGap).isTrue();
+    }
+
+    @Test
+    public void isInTheGap_forTheNeighbourItself_isFalse() {
+        final boolean isInTheGap =
+                CellEdges.isInTheGap(
+                        ITEM_START,
+                        ITEM_END,
+                        AFTER_A_GAP_START,
+                        AFTER_A_GAP_END,
+                        AFTER_A_GAP_START,
+                        AFTER_A_GAP_END);
+
+        assertThat(isInTheGap).isFalse();
+    }
+
+    @Test
+    public void isInTheGap_forAnItemBeyondTheNeighbour_isFalse() {
+        final boolean isInTheGap =
+                CellEdges.isInTheGap(
+                        ITEM_START,
+                        ITEM_END,
+                        AFTER_A_GAP_START,
+                        AFTER_A_GAP_END,
+                        FURTHER_START,
+                        FURTHER_END);
+
+        assertThat(isInTheGap).isFalse();
+    }
+
+    @Test
+    public void isInTheGap_forAnItemBeforeTheItem_isFalse() {
+        final boolean isInTheGap =
+                CellEdges.isInTheGap(
+                        ITEM_START,
+                        ITEM_END,
+                        AFTER_A_GAP_START,
+                        AFTER_A_GAP_END,
+                        BEFORE_START,
+                        BEFORE_END);
+
+        assertThat(isInTheGap).isFalse();
+    }
+
+    @Test
+    public void reachesTheBand_forACandidateInsideTheBand_isTrue() {
+        final boolean reaches =
+                CellEdges.reachesTheBand(BAND_START, BAND_END, NESTED_START, NESTED_END);
+
+        assertThat(reaches).isTrue();
+    }
+
+    @Test
+    public void reachesTheBand_forACandidateOnlyTouchingTheBand_isFalse() {
+        final boolean reaches =
+                CellEdges.reachesTheBand(BAND_START, BAND_END, BAND_END, FURTHER_END);
+
+        assertThat(reaches).isFalse();
+    }
+
+    @Test
+    public void reachesTheBand_forACandidateOutsideTheBand_isFalse() {
+        final boolean reaches =
+                CellEdges.reachesTheBand(BAND_START, BAND_END, FURTHER_START, FURTHER_END);
+
+        assertThat(reaches).isFalse();
+    }
+}

--- a/library/src/test/java/mobi/parchment/widget/adapterview/GroupBoundsTest.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/GroupBoundsTest.java
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import android.view.View;
+import androidx.test.core.app.ApplicationProvider;
+import mobi.parchment.widget.adapterview.gridview.Group;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class GroupBoundsTest {
+
+    private static final boolean IS_VERTICAL = true;
+    private static final int NO_PIXEL = 0;
+    private static final int ONLY_VIEW_LEFT = 11;
+    private static final int ONLY_VIEW_TOP = 22;
+    private static final int ONLY_VIEW_RIGHT = 33;
+    private static final int ONLY_VIEW_BOTTOM = 44;
+    private static final int LOWEST_LEFT = 5;
+    private static final int LOWEST_TOP = 7;
+    private static final int HIGHEST_RIGHT = 400;
+    private static final int HIGHEST_BOTTOM = 500;
+    private static final int INNER_LEFT = 100;
+    private static final int INNER_TOP = 110;
+    private static final int INNER_RIGHT = 200;
+    private static final int INNER_BOTTOM = 210;
+    private static final int OTHER_INNER_LEFT = 150;
+    private static final int OTHER_INNER_TOP = 160;
+    private static final int OTHER_INNER_RIGHT = 250;
+    private static final int OTHER_INNER_BOTTOM = 260;
+
+    @Test
+    public void anEmptyGroup_reportsNoPixelForEveryBound() {
+        final Group group = new Group(IS_VERTICAL);
+
+        assertThat(group.getTop()).isEqualTo(NO_PIXEL);
+        assertThat(group.getBottom()).isEqualTo(NO_PIXEL);
+        assertThat(group.getLeft()).isEqualTo(NO_PIXEL);
+        assertThat(group.getRight()).isEqualTo(NO_PIXEL);
+        assertThat(group.getMeasuredWidth()).isEqualTo(NO_PIXEL);
+        assertThat(group.getMeasuredHeight()).isEqualTo(NO_PIXEL);
+    }
+
+    @Test
+    public void aGroupOfOneView_reportsThatViewsBounds() {
+        final Group group = new Group(IS_VERTICAL);
+        group.addView(
+                laidOutView(ONLY_VIEW_LEFT, ONLY_VIEW_TOP, ONLY_VIEW_RIGHT, ONLY_VIEW_BOTTOM));
+
+        assertThat(group.getLeft()).isEqualTo(ONLY_VIEW_LEFT);
+        assertThat(group.getTop()).isEqualTo(ONLY_VIEW_TOP);
+        assertThat(group.getRight()).isEqualTo(ONLY_VIEW_RIGHT);
+        assertThat(group.getBottom()).isEqualTo(ONLY_VIEW_BOTTOM);
+    }
+
+    @Test
+    public void aGroupWhoseFirstViewIsNotTheExtreme_reportsTheExtremeOfEveryView() {
+        final Group group = new Group(IS_VERTICAL);
+        group.addView(laidOutView(INNER_LEFT, INNER_TOP, INNER_RIGHT, INNER_BOTTOM));
+        group.addView(laidOutView(LOWEST_LEFT, LOWEST_TOP, HIGHEST_RIGHT, HIGHEST_BOTTOM));
+        group.addView(
+                laidOutView(
+                        OTHER_INNER_LEFT, OTHER_INNER_TOP, OTHER_INNER_RIGHT, OTHER_INNER_BOTTOM));
+
+        assertThat(group.getLeft()).isEqualTo(LOWEST_LEFT);
+        assertThat(group.getTop()).isEqualTo(LOWEST_TOP);
+        assertThat(group.getRight()).isEqualTo(HIGHEST_RIGHT);
+        assertThat(group.getBottom()).isEqualTo(HIGHEST_BOTTOM);
+    }
+
+    @Test
+    public void aGroupWhoseFirstViewIsTheExtreme_keepsTheFirstViewsBounds() {
+        final Group group = new Group(IS_VERTICAL);
+        group.addView(laidOutView(LOWEST_LEFT, LOWEST_TOP, HIGHEST_RIGHT, HIGHEST_BOTTOM));
+        group.addView(laidOutView(INNER_LEFT, INNER_TOP, INNER_RIGHT, INNER_BOTTOM));
+        group.addView(
+                laidOutView(
+                        OTHER_INNER_LEFT, OTHER_INNER_TOP, OTHER_INNER_RIGHT, OTHER_INNER_BOTTOM));
+
+        assertThat(group.getLeft()).isEqualTo(LOWEST_LEFT);
+        assertThat(group.getTop()).isEqualTo(LOWEST_TOP);
+        assertThat(group.getRight()).isEqualTo(HIGHEST_RIGHT);
+        assertThat(group.getBottom()).isEqualTo(HIGHEST_BOTTOM);
+    }
+
+    private static View laidOutView(
+            final int left, final int top, final int right, final int bottom) {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final View view = new View(context);
+        view.layout(left, top, right, bottom);
+        return view;
+    }
+}

--- a/library/src/test/java/mobi/parchment/widget/adapterview/RecordingDrawable.java
+++ b/library/src/test/java/mobi/parchment/widget/adapterview/RecordingDrawable.java
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2014 Emir Hasanbegovic and Parchment contributors.
+
+package mobi.parchment.widget.adapterview;
+
+import android.graphics.Canvas;
+import android.graphics.ColorFilter;
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class RecordingDrawable extends Drawable {
+
+    public static final int NO_INTRINSIC_SIZE = -1;
+
+    private final List<Rect> mDrawnBounds = new ArrayList<Rect>();
+    private final List<Rect> mBoundsInstances = new ArrayList<Rect>();
+    private final int mIntrinsicWidth;
+    private final int mIntrinsicHeight;
+
+    public RecordingDrawable() {
+        this(NO_INTRINSIC_SIZE, NO_INTRINSIC_SIZE);
+    }
+
+    public RecordingDrawable(final int intrinsicWidth, final int intrinsicHeight) {
+        mIntrinsicWidth = intrinsicWidth;
+        mIntrinsicHeight = intrinsicHeight;
+    }
+
+    @Override
+    public void setBounds(final Rect bounds) {
+        mBoundsInstances.add(bounds);
+        super.setBounds(bounds);
+    }
+
+    @Override
+    public void draw(final Canvas canvas) {
+        final Rect bounds = getBounds();
+        mDrawnBounds.add(new Rect(bounds));
+    }
+
+    @Override
+    public void setAlpha(final int alpha) {}
+
+    @Override
+    public void setColorFilter(final ColorFilter colorFilter) {}
+
+    @Deprecated
+    @Override
+    public int getOpacity() {
+        return PixelFormat.TRANSLUCENT;
+    }
+
+    @Override
+    public int getIntrinsicWidth() {
+        return mIntrinsicWidth;
+    }
+
+    @Override
+    public int getIntrinsicHeight() {
+        return mIntrinsicHeight;
+    }
+
+    public int getDrawCount() {
+        return mDrawnBounds.size();
+    }
+
+    public Rect getDrawnBounds(final int index) {
+        return mDrawnBounds.get(index);
+    }
+
+    public List<Rect> getBoundsInstances() {
+        return mBoundsInstances;
+    }
+}

--- a/library/src/test/res/layout/attribute_parsing_divider_sizes.xml
+++ b/library/src/test/res/layout/attribute_parsing_divider_sizes.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:parchment="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/negative_divider_size_list_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            parchment:parchment_divider="#ff112233"
+            parchment:parchment_dividerSize="-0.4px"/>
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/no_divider_size_list_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            parchment:parchment_divider="#ff112233"/>
+
+</LinearLayout>

--- a/library/src/test/res/layout/attribute_parsing_list_view.xml
+++ b/library/src/test/res/layout/attribute_parsing_list_view.xml
@@ -13,4 +13,6 @@
         parchment:parchment_isViewPager="true"
         parchment:parchment_viewPagerInterval="3"
         parchment:parchment_snapPosition="end"
-        parchment:parchment_selectWhileScrolling="true"/>
+        parchment:parchment_selectWhileScrolling="true"
+        parchment:parchment_divider="#ff112233"
+        parchment:parchment_dividerSize="@dimen/divider_test_size"/>

--- a/library/src/test/res/layout/divider_paint.xml
+++ b/library/src/test/res/layout/divider_paint.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:parchment="http://schemas.android.com/apk/res-auto"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/divider_list_view"
+            android:layout_width="300px"
+            android:layout_height="300px"
+            parchment:parchment_orientation="vertical"
+            parchment:parchment_cellSpacing="10px"
+            parchment:parchment_divider="#ff00ff00"
+            parchment:parchment_dividerSize="6px"/>
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/no_divider_list_view"
+            android:layout_width="300px"
+            android:layout_height="300px"
+            parchment:parchment_orientation="vertical"
+            parchment:parchment_cellSpacing="10px"/>
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/sizeless_colour_divider_list_view"
+            android:layout_width="300px"
+            android:layout_height="300px"
+            parchment:parchment_orientation="vertical"
+            parchment:parchment_cellSpacing="10px"
+            parchment:parchment_divider="#ff00ff00"/>
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/thick_divider_list_view"
+            android:layout_width="300px"
+            android:layout_height="300px"
+            parchment:parchment_orientation="vertical"
+            parchment:parchment_cellSpacing="10px"
+            parchment:parchment_divider="#ff00ff00"
+            parchment:parchment_dividerSize="20px"/>
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/padded_clipped_divider_list_view"
+            android:layout_width="300px"
+            android:layout_height="300px"
+            android:padding="60px"
+            android:clipToPadding="true"
+            parchment:parchment_orientation="vertical"
+            parchment:parchment_cellSpacing="10px"
+            parchment:parchment_divider="#ff00ff00"
+            parchment:parchment_dividerSize="6px"/>
+
+    <mobi.parchment.widget.adapterview.listview.ListView
+            android:id="@+id/padded_unclipped_divider_list_view"
+            android:layout_width="300px"
+            android:layout_height="300px"
+            android:padding="60px"
+            android:clipToPadding="false"
+            parchment:parchment_orientation="vertical"
+            parchment:parchment_cellSpacing="10px"
+            parchment:parchment_divider="#ff00ff00"
+            parchment:parchment_dividerSize="6px"/>
+
+    <mobi.parchment.widget.adapterview.gridview.GridView
+            android:id="@+id/divider_grid_view"
+            android:layout_width="300px"
+            android:layout_height="300px"
+            parchment:parchment_orientation="vertical"
+            parchment:parchment_numberOfViewsPerCell="2"
+            parchment:parchment_cellSpacing="10px"
+            parchment:parchment_divider="#ff00ff00"
+            parchment:parchment_dividerSize="6px"/>
+
+    <mobi.parchment.widget.adapterview.gridpatternview.GridPatternView
+            android:id="@+id/divider_grid_pattern_view"
+            android:layout_width="300px"
+            android:layout_height="300px"
+            parchment:parchment_orientation="vertical"
+            parchment:parchment_ratio="1"
+            parchment:parchment_cellSpacing="10px"
+            parchment:parchment_divider="#ff00ff00"
+            parchment:parchment_dividerSize="6px"/>
+
+</LinearLayout>

--- a/library/src/test/res/values/dimens.xml
+++ b/library/src/test/res/values/dimens.xml
@@ -2,4 +2,5 @@
     <dimen name="horizontal_list_view_test_margin">10px</dimen>
     <dimen name="list_item_test_width">100px</dimen>
     <dimen name="list_item_test_height">100px</dimen>
+    <dimen name="divider_test_size">6px</dimen>
 </resources>

--- a/sample/src/main/res/layout/activity_simple_grid_pattern_view.xml
+++ b/sample/src/main/res/layout/activity_simple_grid_pattern_view.xml
@@ -5,6 +5,8 @@
         parchment:parchment_cellSpacing="@dimen/activity_simple_grid_pattern_view_cell_spacing"
         parchment:parchment_orientation="horizontal"
         parchment:parchment_snapPosition="onScreen"
+        parchment:parchment_divider="@color/cell_divider"
+        parchment:parchment_dividerSize="@dimen/activity_sample_parchment_divider_size"
         parchment:parchment_ratio="@dimen/activity_simple_grid_pattern_ratio"
         android:scrollbars="horizontal"
         android:scrollbarStyle="outsideOverlay"

--- a/sample/src/main/res/layout/activity_simple_gridview.xml
+++ b/sample/src/main/res/layout/activity_simple_gridview.xml
@@ -9,6 +9,8 @@
         parchment:parchment_orientation="vertical"
         parchment:parchment_gravity="top"
         parchment:parchment_snapPosition="onScreen"
+        parchment:parchment_divider="@color/cell_divider"
+        parchment:parchment_dividerSize="@dimen/activity_sample_parchment_divider_size"
         android:paddingStart="@dimen/activity_sample_parchment_padding_small"
         android:paddingEnd="@dimen/activity_sample_parchment_padding_large"
         android:paddingTop="@dimen/activity_sample_parchment_padding_medium"

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -6,4 +6,6 @@
 
     <color name="press_state_colour">#6600498b</color>
     <color name="selected_state_colour">#338b7700</color>
+
+    <color name="cell_divider">#664c4c4c</color>
 </resources>

--- a/sample/src/main/res/values/dimens.xml
+++ b/sample/src/main/res/values/dimens.xml
@@ -3,6 +3,7 @@
     <dimen name="activity_sample_parchment_padding_small">10dp</dimen>
     <dimen name="activity_sample_parchment_padding_medium">20dp</dimen>
     <dimen name="activity_sample_parchment_padding_large">30dp</dimen>
+    <dimen name="activity_sample_parchment_divider_size">2dp</dimen>
     <dimen name="list_item_gridview_picture_height">200dp</dimen>
     <dimen name="list_item_view_pager_height">200dp</dimen>
     <dimen name="list_item_horizontal_height">300dp</dimen>


### PR DESCRIPTION
## Description

Closes #25.

Adds `parchment_divider` (a drawable or a colour) and `parchment_dividerSize` (a
dimension) to all three views, and draws the divider on **every edge that is internal to the
content and on no edge at the content's outer boundary**.

That second half is the rule the owner set after seeing the first version on a device. The
first version walked the drawn cells along the scroll axis and drew one line per gap,
spanning the full breadth. For `ListView` that is complete, because a list has one axis. For
`GridView` and `GridPatternView` a cell is a whole group, so the coarse structure was divided
and the fine structure was not: a single full-breadth line at each group boundary and
nothing between the items stacked inside a group. It read as arbitrary.

### The edge model

Work in edges rather than lines. For each drawn item, for each of its two trailing edges,
draw in the gap only where another item lies across it, and span only the run the two share
on the perpendicular axis. An item with no neighbour on a side is at the content boundary
and gets nothing, so "never at the outer boundary" falls out rather than being a case, and
mixed spans and T-junctions in a `GridPatternView` work without rows or columns having to
exist.

Only trailing edges are considered, so each shared edge is drawn once:
`CellEdges.isAcrossTheEndEdge` requires the neighbour to reach further than the item, which
holds for at most one of an ordered pair.

A pass draws in a gap, so a pair that overlaps along this axis has no gap on this axis and
gets nothing from this pass (`CellEdges.isAGap`). A gap of zero is still a gap, so zero cell
spacing still draws. This is the rule that replaced an earlier guard, "skip the pair when
the other axis will claim it"; every pair that guard skipped overlaps on this axis, so the
gap rule skips it too, and the only pairs it additionally skips are ones physically over
each other in the same band, where drawing into a negative gap was never right.

A third item standing in the gap inside the band blocks the divider, so three items in a
line are divided 1–2 and 2–3 and not 1–3 through the middle one (`isGapOccupied`).

### Where the code lives, and why

- `CellDivider` owns the walk. The two axis passes are one method over
  `divideraxis/DividerAxisInterface`, with `SizeDividerAxis` and `BreadthDividerAxis` built
  once in the constructor and reused every frame. This mirrors `snapposition/` and
  `pageinterval/`: one algorithm per strategy, chosen once. Both strategies reach orientation
  only through `ScrollDirectionManager`, so there is still exactly one place in the engine
  that knows about left and top.
- `CellEdges` holds the scalar geometry as `public static` functions in the
  `ViewGroupUtilities` shape, so each predicate is pinned on its own with no layout manager.
- `LayoutManager` gains indexed access to a drawn cell's item views
  (`getDrawnCellViewCount`, `getDrawnCellView`), because `Group.getViews()` copies its list
  on every call and the divider runs on every frame. `ScrollDirectionManager` gains an item's
  laid-out extent across the breadth, which had no accessor.
- Nothing is allocated in the draw path: one reused `Rect`, strategies built once, indexed
  reads.

### Per-frame cost, stated honestly

The work is linear in the drawn cells and independent of the adapter's size, but the cost
of one cell is cubic in the items of two adjacent cells, not linear: the occupancy scan runs
inside the neighbour scan. A cell of n items with N items in it and the next together costs
up to 2·n·N·(N+1) item reads.

| Case | Bound (item reads per cell) |
|---|---|
| `ListView` | 12 |
| `GridView`, two views per cell | 80 |
| One of the sample's five-item pattern groups | 1,100 |
| A thirty-item pattern group | 219,600 |

Measured rather than bounded: a frame drawing all three of the sample's pattern groups,
eleven items, makes 384 item reads and paints 20 dividers. Each read is an indexed list
lookup and two `View` getters, so the frame spends microseconds here against its 16 ms. A
pattern of dozens of items per group would be different; the fix is a single sweep over the
candidates across an edge instead of a rescan per neighbour, and it is listed as a follow-up
rather than done here.

### Known limitations, documented and pinned

- **A hole in a pattern is divided as though it were spacing**, because nothing in the draw
  pass can tell the two apart, but only while nothing stands anywhere in the gap inside the
  band: `isGapOccupied` answers for the whole edge, so an item beside the hole occludes the
  edge across the hole too. In a pattern without holes that is the right answer.
- **A colour divider with no explicit size paints nothing.** `ColorDrawable` reports an
  intrinsic size of -1 on both axes, so `parchment_dividerSize` is effectively required when
  the divider is a colour. Pinned by a test and called out in the README.
- **A pre-existing centring bug is now visible.** `ListLayoutManager.layoutCell` centres a
  row in the whole breadth rather than inside the padding box, so with asymmetric padding the
  row overhangs one padding edge. The divider follows the row, overhang included, because
  that is where the content is. Fixing the centring is a separate change.
- `GridLayoutManager.getCellStart` / `getCellEnd` read `getTop()` / `getLeft()` directly,
  against the engine rule. Pre-existing, not copied, not fixed here.

## Before and after

Before is the previous head of this pull request, `17affbd`, which was reviewed and green.

- **On the owner's Pixel 8**, the `GridPatternView` screen showed one full-height line at
  the group boundary and nothing between the items stacked inside the group; the
  wrapping-height `GridView` showed one full-width line between rows and nothing between the
  items in a row.
- **In the tests**, `CellDividerGroupTest` asserted that a divider never falls inside a
  group. Those assertions were the defect and now assert the rule. The `ListView` case
  `divider_withANegativeCellSpacing_isDrawnWhereTheCellsOverlap` asserted a divider drawn
  through the overlap of every pair of rows; it now asserts nothing is drawn.
- The old tree cannot compile the new tests, because item access and the axis strategies did
  not exist there, so the before is recorded as those inversions and the device
  observations rather than as quoted red output.

After, on the API 36 phone emulator and the API 35 tablet emulator:

- **Wrapping-height `GridView`, phone**: a vertical divider between the two columns that
  spans each row's items and stops at the row gaps; horizontal dividers between rows spanning
  each item's width; the crossing where a row gap meets the column gap left unpainted; no
  line on the top, left or right boundary.
- **`GridPatternView`, tablet** (the phone is too narrow in portrait to show more than the
  hero item): the hero abuts a column of three items, so one full-height vertical divider at
  that T-junction; horizontal dividers between each stacked pair spanning only their shared
  width; a second vertical divider before the item at the far right; nothing on the top, left
  or bottom boundary.

The Pixel 8 was not attached for the after run, so the after is emulator only.

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## How Has This Been Tested?

- [x] Unit tests — **430**, 0 failures
- [x] Instrumented tests — **194**, 0 failures, a clean 97 on each of two emulators (API 36
      phone, API 35 tablet), `ANDROID_SERIAL` unset, counts parsed from the result XML
- [ ] Manual testing on device/emulator — screenshots described above, no physical device

All of `scripts/ci_local.sh --no-instrumented` is green: spotless, Android Lint with
warnings as errors and no baseline, the unit suite, and `assembleRelease` plus the sample
APK.

**No package-private declarations.** A `javap -p` sweep over the compiled release classes:
60 author-written classes, 857 members, 0 without an explicit `public`, `protected` or
`private` (compiler-generated `$1` classes, `static {}` initialisers and `this$0` fields
excluded).

**Mutation over the predicates the gap rule relies on**, each reverted afterwards, 85 tests
run per mutant, harness aborting on a zero-test run:

| Mutant | Result | Caught by |
|---|---|---|
| `isAGap`: `>=` to `>` | killed, 3 red | `gridDivider_withNoCellSpacing_straddlesTheSharedEdgeOnBothAxes`, `dividerWithNoCellSpacing_isCentredOnTheBoundaryBetweenTheCells`, `isAGap_forANeighbourTouchingTheEndEdge_isTrue` |
| `isAcrossTheEndEdge`: "reaches further" to "reaches as far" | killed, 43 red | `gridDivider_withThreeItemsInALine_isNotDrawnThroughTheMiddleOne` and 42 others |
| `isAnOverlap`: `>` to `>=` | killed, 3 red | `isAnOverlap_forSpansThatOnlyTouch_isFalse`, `reachesTheBand_forACandidateOnlyTouchingTheBand_isFalse`, and the zero-spacing grid case |
| `isAcrossTheEndEdge`: start comparison made strict | **survived 83 tests**, then pinned by `7a0f28d` | `isAcrossTheEndEdge_forANeighbourStartingLevelWithTheItem_isTrue` |

**Independent review** ran on the edge-rule commits; its findings are addressed in
`e3a4cc1` (a draw helper ignoring an argument, a work-bound test that could not tell linear
from quadratic, a fixture that leaned on a rounding detail, and a missing horizontal twin
for the negative-spacing case).

## What could not be verified

- No physical device: the Pixel 8 was not attached after a machine restart.
- Nothing below API 34 is installed, so the `minSdk 21` claim is untested for this feature
  as for the rest of the library.

## Follow-ups this exposed

1. Take the occupancy scan out of the neighbour loop with a single sweep over the
   candidates across an edge, for patterns with dozens of items per group.
2. `ListLayoutManager.layoutCell` centring a row in the whole breadth rather than inside the
   padding box.
3. `GridLayoutManager.getCellStart` / `getCellEnd` reading `getTop()` / `getLeft()` directly.
4. A colour divider with no size silently painting nothing: default to a hairline, or refuse
   loudly at inflation.
5. The sample's pattern is wider than a portrait phone, so that screen demonstrates the
   feature only on a tablet or in landscape.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what
- [x] I have made corresponding changes to documentation — README, CHANGELOG,
      `docs/architecture.md`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
